### PR TITLE
feat: Add Cancel button to Create page

### DIFF
--- a/frontend/components/item/Create.vue
+++ b/frontend/components/item/Create.vue
@@ -43,6 +43,16 @@
         />
         <v-row class="mt-2" dense>
           <v-spacer />
+          <v-btn
+            class="mt-4 mr-2"
+            color="grey"
+            small
+            elevation="2"
+            outlined
+            @click="$router.go(-1)"
+          >
+            {{ $t('common.cancel') }}
+          </v-btn>
           <v-tooltip bottom>
             <template #activator="{ on, attrs }">
               <div v-bind="attrs" v-on="on">


### PR DESCRIPTION
## Summary
Adds a Cancel button to the left of the Create button on item creation pages, allowing users to abort the creation process.

## Changes
- Added a grey outlined Cancel button next to the Create button
- Button navigates back to the previous page when clicked
- Uses existing `common.cancel` translation key (already available in all languages)

Closes #346