### PR TITLE
feat: Change font attributes for Section Headers and References

### DIFF
--- a/frontend/components/item/claim/Base.vue
+++ b/frontend/components/item/claim/Base.vue
@@ -1,7 +1,7 @@
 <template>
   <v-container class="claim">
     <v-row dense>
-      <v-subheader class="claim-header grey--text">
+      <v-subheader class="claim-header section-header">
         <item-util-view-text-lang :value="propertyLabel" :tooltip="claim.property" />
       </v-subheader>
     </v-row>
@@ -62,6 +62,10 @@ export default {
 }
 .claim-header {
   font-size: 16px;
+}
+.section-header {
+  color: #616161 !important;
+  font-weight: bold !important;
 }
 .claim-values {
   padding: 0;

--- a/frontend/components/item/reference/Base.vue
+++ b/frontend/components/item/reference/Base.vue
@@ -2,7 +2,7 @@
   <v-expansion-panels class="ma-2 pa-2 bg-gray none-z-index">
     <v-expansion-panel class="bg-gray">
       <v-expansion-panel-header class="bg-gray header">
-        <p class="text-subtitle-2 mb-0">
+        <p class="text-subtitle-2 mb-0 reference-header">
           {{ header }}
         </p>
       </v-expansion-panel-header>
@@ -80,6 +80,10 @@ export default {
 .header {
   padding: 0;
   align-items: center;
+}
+
+.reference-header {
+  font-weight: normal !important;
 }
 
 ::v-deep .v-expansion-panel-content__wrap {


### PR DESCRIPTION
## Summary
Changes font styling for section headers and reference headers as requested.

## Changes
- **Section headers**: Now use darker gray color (#616161) and bold font weight
- **Reference headers**: Now use normal font weight (not bold)

## Files Modified
- `frontend/components/item/claim/Base.vue` - Updated section header styling
- `frontend/components/item/reference/Base.vue` - Updated reference header styling

Closes #310