### PR TITLE
feat: Wrap values in display pages

### DIFF
--- a/frontend/components/item/claim/Values.vue
+++ b/frontend/components/item/claim/Values.vue
@@ -164,6 +164,9 @@ export default {
 .table-cell {
   border-bottom: none !important;
   padding-top: 8px !important;
+  word-wrap: break-word;
+  overflow-wrap: break-word;
+  white-space: normal;
 }
 
 .table-cell-btn-edit {

--- a/frontend/components/item/reference/List.vue
+++ b/frontend/components/item/reference/List.vue
@@ -115,6 +115,9 @@ export default {
 .w-100
 .table-cell {
   border: none;
+  word-wrap: break-word;
+  overflow-wrap: break-word;
+  white-space: normal;
 }
 
 .table-cell-value-edit {


### PR DESCRIPTION
## Summary
Add text wrapping for long values in display pages so they wrap instead of requiring horizontal scroll.

## Changes
- Added `word-wrap`, `overflow-wrap`, and `white-space: normal` styles to table cells
- Applied to both claim values and reference values

## Files Modified
- `frontend/components/item/claim/Values.vue`
- `frontend/components/item/reference/List.vue`

## Testing
- Verified app loads without errors
- Long text values like 'Alfonso X, rey de Castilla y León...' now wrap properly

Closes #329