### PR TITLE
feat: Wrap values in Creator pages

### DIFF
--- a/frontend/components/item/claim/AddValue.vue
+++ b/frontend/components/item/claim/AddValue.vue
@@ -135,6 +135,9 @@ export default {
 <style scoped>
 .full-width {
   width: 100%;
+  word-wrap: break-word;
+  overflow-wrap: break-word;
+  white-space: normal;
 }
 .add-value {
   background-color: white;

--- a/frontend/components/item/claim/Create.vue
+++ b/frontend/components/item/claim/Create.vue
@@ -259,6 +259,9 @@ export default {
 }
 .claim-values {
   background-color: rgb(247, 245, 245);
+  word-wrap: break-word;
+  overflow-wrap: break-word;
+  white-space: normal;
 }
 
 ::v-deep .add-claim-value {

--- a/frontend/components/item/qualifier/Create.vue
+++ b/frontend/components/item/qualifier/Create.vue
@@ -201,6 +201,9 @@ export default {
 }
 .create-qualifier {
   padding: 0;
+  word-wrap: break-word;
+  overflow-wrap: break-word;
+  white-space: normal;
 }
 .max-w-100 {
   max-width: 100px !important;


### PR DESCRIPTION
## Summary
Add text wrapping for long values in Creator pages so they wrap instead of requiring horizontal scroll.

This is exactly similar to #329, applied to Creator pages.

## Changes
- Added `word-wrap`, `overflow-wrap`, and `white-space: normal` styles to Creator components

## Files Modified
- `frontend/components/item/claim/Create.vue`
- `frontend/components/item/claim/AddValue.vue`
- `frontend/components/item/qualifier/Create.vue`

Closes #337