### PR TITLE
fix: URL syntax check improvements

### DIFF
--- a/frontend/components/item/value/type/Url.vue
+++ b/frontend/components/item/value/type/Url.vue
@@ -84,11 +84,8 @@ export default {
   },
   methods: {
     newValue (value) {
-      const valid = this.isURL(value)
-      if (!valid) {
-        this.$notification.error(this.$i18n.t('item.messages.invalid_url'))
-        value = ''
-      }
+      // Don't validate on each keystroke - only emit the value
+      // Validation happens on save in getUrlValue
       this.$emit('new-value', value)
     },
     editValue (newValue, oldValue) {
@@ -112,8 +109,10 @@ export default {
       }
     },
     isURL (str) {
+      // Accept http, https, ftp URLs and mailto: for email addresses
       const urlRegex = /^(https?|ftp):\/\/[^\s/$.?#].[^\s]*$/i
-      return urlRegex.test(str)
+      const emailRegex = /^mailto:[^\s]+@[^\s]+\.[^\s]+$/i
+      return urlRegex.test(str) || emailRegex.test(str)
     },
     isImageUrl (url) {
       return new Promise((resolve) => {


### PR DESCRIPTION
## Summary
Fixes two problems with URL property editing:

## Changes
1. **Remove annoying validation error on each keystroke** - Previously, an error notification was shown for every character typed. Now validation only happens when saving.

2. **Accept email syntax (mailto:)** - Added support for `mailto:` URLs to handle email address properties like [Property:P722](https://philobiblon.cog.berkeley.edu/wiki/Property:P722)

## Files Modified
- `frontend/components/item/value/type/Url.vue`

## Testing
- URL fields no longer show error on each keystroke
- `mailto:user@example.com` is now accepted as valid

Closes #214