### PR TITLE
fix: Update labels when paging through related elements

### DIFF
--- a/frontend/components/item/related/Ritem.vue
+++ b/frontend/components/item/related/Ritem.vue
@@ -56,6 +56,18 @@ export default {
     }
   },
 
+  watch: {
+    // Re-fetch entity when value prop changes (e.g., during pagination)
+    'value.item': {
+      immediate: false,
+      async handler (newItem, oldItem) {
+        if (newItem && newItem !== oldItem) {
+          await this.getEntity()
+        }
+      }
+    }
+  },
+
   async mounted () {
     if (this.value.item) {
       await this.getEntity()


### PR DESCRIPTION
## Summary
Fixes issue where the Label doesn't update when paging through related items, while the PBid changes correctly.

## Root Cause
The `Ritem.vue` component was only fetching the entity (including label) in the `mounted()` hook. When pagination changes, Vue may reuse the component with new props, but the label wasn't re-fetched.

## Solution
Added a watcher on `value.item` prop to re-fetch the entity when the prop changes during pagination.

## Files Modified
- `frontend/components/item/related/Ritem.vue`

Closes #276