### PR TITLE
feat: Display description along with label in edit mode

### DIFF
--- a/frontend/components/item/util/EditSelectField.vue
+++ b/frontend/components/item/util/EditSelectField.vue
@@ -14,6 +14,14 @@
     @change="onchange"
     @update:search-input="$emit('input', $event)"
   >
+    <template #item="data">
+      <v-list-item-content>
+        <v-list-item-title>{{ data.item.label }}</v-list-item-title>
+        <v-list-item-subtitle v-if="data.item.description" class="item-description">
+          {{ data.item.description }}
+        </v-list-item-subtitle>
+      </v-list-item-content>
+    </template>
     <template #append>
       <v-btn
         v-if="isEditable && focussed"
@@ -196,3 +204,12 @@ export default {
   }
 }
 </script>
+
+<style scoped>
+.item-description {
+  font-weight: normal;
+  font-size: 0.8rem;
+  color: #666;
+  margin-top: 2px;
+}
+</style>


### PR DESCRIPTION
## Summary
When selecting entity values in edit mode, displays the description below the label to help users distinguish between items with the same label.

## Problem
Two items might have the same Label, making it impossible to know which is the correct one when adding a value in edit mode.

## Solution
Added a custom item template to the autocomplete dropdown that shows:
- **Label** (title)
- **Description** (subtitle below, styled in gray)

This matches the behavior already implemented for search results in #271 (PR #325).

## Files Modified
- `frontend/components/item/util/EditSelectField.vue`

Closes #272