### PR TITLE
fix: Set correct default values for P131 declaration

### DIFF
--- a/frontend/components/item/Create.vue
+++ b/frontend/components/item/Create.vue
@@ -255,6 +255,16 @@ export default {
           if (entity.id === 'P476') {
             claim = this.buildClaim(entity, [], this.generatePbId(itemNumber), false)
           } else if (entity.id === 'P131') {
+            // Set default bibliography based on database
+            // BETA: Q254471, BITECA: Q256810, BITAGAP: Q256809
+            const bibliographyMap = {
+              BETA: 'Q254471',
+              BITECA: 'Q256810',
+              BITAGAP: 'Q256809'
+            }
+            const bibliographyId = bibliographyMap[this.database] || null
+
+            // P700 (statement refers to) qualifier = Q447226 (PhiloBiblon object)
             const qualifiers = [
               {
                 default: true,
@@ -262,13 +272,13 @@ export default {
                 datatype: 'wikibase-item',
                 datavalue: {
                   value: {
-                    id: 'Q6'
+                    id: 'Q447226'
                   }
                 }
               }
             ]
 
-            claim = this.buildClaim(entity, qualifiers, { id: 'Q4' })
+            claim = this.buildClaim(entity, qualifiers, bibliographyId ? { id: bibliographyId } : null)
           } else if (this.table === 'cnum' && entity.id === 'P590') {
             claim = this.buildClaim(entity, qualifiers, null, false)
           } else if (this.table === 'copid' && entity.id === 'P839') {


### PR DESCRIPTION
## Summary
Fixes the default values for P131 (projects that created) when creating new items.

## Problem
The P131 declaration was using hardcoded values:
- Main value: Q4 (incorrect)
- P700 qualifier: Q6 (incorrect)

## Solution
Now correctly maps the database to the appropriate bibliography:

| Database | Bibliography ID |
|----------|-----------------|
| BETA | Q254471 |
| BITECA | Q256810 |
| BITAGAP | Q256809 |

And sets P700 (statement refers to) qualifier to **Q447226** (PhiloBiblon object).

## Files Modified
- `frontend/components/item/Create.vue`

Closes #326