### PR TITLE
feat: Improve date filter with partial dates and manual input

### DIFF
--- a/frontend/components/item/value/type/Time.vue
+++ b/frontend/components/item/value/type/Time.vue
@@ -105,18 +105,58 @@ export default {
       }
     },
     getTimeNewValue (value) {
+      const { time, precision } = this.formatDate(value)
       return {
-        time: this.formatDate(value),
+        time,
+        precision,
         calendar: this.valueToView_.calendar.toLowerCase()
       }
     },
     formatDate (dateString) {
-      const date = new Date(dateString)
-      const isoYear = date.getUTCFullYear()
-      const isoMonth = ('0' + (date.getUTCMonth() + 1)).slice(-2)
-      const isoDay = ('0' + date.getUTCDate()).slice(-2)
+      if (!dateString) {
+        return { time: null, precision: 11 }
+      }
 
-      return `+${isoYear}-${isoMonth}-${isoDay}T00:00:00Z`
+      const trimmed = dateString.trim()
+
+      // Year only: YYYY -> precision 9
+      if (/^\d{4}$/.test(trimmed)) {
+        const year = trimmed.padStart(4, '0')
+        return {
+          time: `+${year}-01-01T00:00:00Z`,
+          precision: 9
+        }
+      }
+
+      // Year-Month: YYYY-MM -> precision 10
+      if (/^\d{4}-\d{2}$/.test(trimmed)) {
+        return {
+          time: `+${trimmed}-01T00:00:00Z`,
+          precision: 10
+        }
+      }
+
+      // Full date: YYYY-MM-DD -> precision 11
+      if (/^\d{4}-\d{2}-\d{2}$/.test(trimmed)) {
+        return {
+          time: `+${trimmed}T00:00:00Z`,
+          precision: 11
+        }
+      }
+
+      // Fallback: try to parse as date
+      const date = new Date(dateString)
+      if (!isNaN(date.getTime())) {
+        const isoYear = String(date.getUTCFullYear()).padStart(4, '0')
+        const isoMonth = ('0' + (date.getUTCMonth() + 1)).slice(-2)
+        const isoDay = ('0' + date.getUTCDate()).slice(-2)
+        return {
+          time: `+${isoYear}-${isoMonth}-${isoDay}T00:00:00Z`,
+          precision: 11
+        }
+      }
+
+      return { time: null, precision: 11 }
     }
   }
 }


### PR DESCRIPTION
## Summary
Improves the date input component to support partial dates and manual text entry.

## Problem
- Date field was read-only, requiring calendar picker
- No support for partial dates (year only, year-month)
- Calendar picker starts at current year, requiring excessive scrolling for historical dates (1200-1700)

## Solution

### Manual Input
- Removed `readonly` from text field - users can now type dates directly
- Added placeholder text: "YYYY, YYYY-MM, or YYYY-MM-DD"
- Added hint text explaining accepted formats
- Enter key validates and normalizes input

### Partial Date Support
| Format | Example | Precision |
|--------|---------|-----------|
| YYYY | 1450 | Year (9) |
| YYYY-MM | 1450-06 | Month (10) |
| YYYY-MM-DD | 1450-06-15 | Day (11) |

### Historical Dates
- Date picker now defaults to viewing year 1400
- Added calendar icon button for quick picker access
- Picker view syncs to existing date value when available

## Files Modified
- `frontend/components/item/util/EditDatePickerField.vue`
- `frontend/components/item/value/type/Time.vue`

Closes #306