### PR TITLE
fix: Display proper qualifier labels in BIB Creator screen

### DIFF
--- a/frontend/components/item/Create.vue
+++ b/frontend/components/item/Create.vue
@@ -215,9 +215,15 @@ export default {
       }
     },
     buildQualifier (claim, qualifier) {
+      // Build property object with label for autocomplete display
+      const label = this.$wikibase.getValueByLang(qualifier.labels, this.$i18n.locale)?.value || qualifier.id
       return {
         default: true,
-        property: qualifier.id,
+        property: {
+          id: qualifier.id,
+          label,
+          datatype: qualifier.datatype
+        },
         datatype: qualifier.datatype,
         datavalue: {
           value: null

--- a/frontend/components/item/claim/Create.vue
+++ b/frontend/components/item/claim/Create.vue
@@ -222,8 +222,10 @@ export default {
     updateQualifiers (data, key) {
       this.claims[key].qualifiers = data.map((qualifier) => {
         if (!this.forCreate) {
+          // Extract property ID - handle both object and string formats
+          const propertyId = qualifier?.property?.id || qualifier?.property
           return {
-            property: qualifier?.property,
+            property: propertyId,
             value: qualifier?.datavalue?.value?.id ?? qualifier.datavalue?.value
           }
         } else {

--- a/frontend/components/item/qualifier/Create.vue
+++ b/frontend/components/item/qualifier/Create.vue
@@ -128,14 +128,16 @@ export default {
   },
   methods: {
     allowCreateQualifier (qualifier) {
-      return this.claim && !this.forCreate && qualifier.property && qualifier.datavalue?.value
+      const propertyId = qualifier.property?.id || qualifier.property
+      return this.claim && !this.forCreate && propertyId && qualifier.datavalue?.value
     },
     onNewValue (event, qualifier) {
       qualifier.datavalue.value = event
     },
     onChangeProperty (event, index) {
       const qualifier = this.qualifiers[index]
-      qualifier.property = event?.id
+      // Keep the full property object for display, but track ID separately
+      qualifier.property = event ? { id: event.id, label: event.label, datatype: event.datatype } : null
       qualifier.datatype = event?.datatype
       qualifier.datavalue = {
         value: null
@@ -169,10 +171,12 @@ export default {
     },
     async createQualifier (index) {
       const qualifier = this.qualifiers[index]
+      // Extract property ID - handle both object and string formats
+      const propertyId = qualifier.property?.id || qualifier.property
       await this.$wikibase.getWbEdit().qualifier.add({
         guid: this.claim.id,
         value: qualifier.datavalue.value.id ?? qualifier.datavalue.value,
-        property: qualifier.property
+        property: propertyId
       }, this.$store.getters['auth/getRequestConfig']).then((res) => {
         if (res.success) {
           this.updateQualifiers(res.claim.qualifiers[qualifier.property])


### PR DESCRIPTION
## Summary
Fixes the '<<<<<<' display issue for qualifier properties in the BIB Creator screen.

## Problem
When creating a new BIB item, the P1137 (Published in) property has a qualifier P1138 (Abbreviation). Instead of showing 'P1138 (Abbreviation)', the UI displayed '<<<<<<' in the property dropdown.

### Screenshots from Issue
**Expected:**
![Expected](https://github.com/user-attachments/assets/bd100515-e66c-400c-9d93-9803098d397e)

**Bug:**
![Bug](https://github.com/user-attachments/assets/7f503fc8-9d5f-496c-86d9-d98f109bad27)

## Root Cause
The `buildQualifier` method was setting `property` to just the ID string (e.g., 'P1138') instead of an object with `{id, label}`. The v-autocomplete uses `item-text="label"` to display the property name, but when given a plain string, it couldn't find the label property.

## Solution
- Modified `buildQualifier` to return property as an object with `{id, label, datatype}`
- Updated `onChangeProperty` to maintain the full property object structure
- Updated `allowCreateQualifier` and `createQualifier` to extract the ID when calling the API
- Updated `updateQualifiers` to handle both object and string formats

## Files Modified
- `frontend/components/item/Create.vue`
- `frontend/components/item/qualifier/Create.vue`
- `frontend/components/item/claim/Create.vue`

Closes #331