### PR TITLE
fix: Correct section headers for related items in insid table

### DIFF
--- a/frontend/components/item/related/Tables.vue
+++ b/frontend/components/item/related/Tables.vue
@@ -342,24 +342,28 @@ export default {
             ]
           },
           {
+            label: 'item.related.insid.related_individuals',
+            refTables: [
+              { refTable: 'bioid', property: 'P703' }
+            ]
+          },
+          {
             label: 'item.related.insid.related_institutions',
             refTables: [
-              { refTable: 'bioid', property: 'P232' },
               { refTable: 'insid', property: 'P232' },
               { refTable: 'libid', property: 'P232' }
             ]
           },
           {
+            label: 'item.related.insid.work_context',
+            refTables: [
+              { refTable: 'texid', property: 'P590' }
+            ]
+          },
+          {
             label: 'item.related.insid.subject_references',
             refTables: [
-              { refTable: 'bibid', property: 'P243' },
-              { refTable: 'bioid', property: 'P243' },
-              { refTable: 'copid', property: 'P243' },
-              { refTable: 'geoid', property: 'P243' },
-              { refTable: 'insid', property: 'P243' },
-              { refTable: 'libid', property: 'P243' },
-              { refTable: 'manid', property: 'P243' },
-              { refTable: 'texid', property: 'P243' }
+              { refTable: 'subid', property: 'P243' }
             ]
           }
         ],

--- a/frontend/lang/ca.js
+++ b/frontend/lang/ca.js
@@ -518,7 +518,9 @@ export default {
         milestones: 'Fites',
         owner: 'Propietat',
         printed_by: 'Imprès per',
+        related_individuals: 'Individus relacionats',
         related_institutions: 'Institucions relacionades',
+        work_context: 'Context de l\'obra',
         subject_references: 'Referències temàtiques'
       },
       libid: {

--- a/frontend/lang/en.js
+++ b/frontend/lang/en.js
@@ -520,7 +520,9 @@ export default {
         milestones: 'Milestones',
         owner: 'Owner',
         printed_by: 'Printed by',
+        related_individuals: 'Related individuals',
         related_institutions: 'Related institutions',
+        work_context: 'Work context',
         subject_references: 'Subject references'
       },
       libid: {

--- a/frontend/lang/es.js
+++ b/frontend/lang/es.js
@@ -518,7 +518,9 @@ export default {
         milestones: 'Hitos',
         owner: 'Propietario',
         printed_by: 'Impreso por',
+        related_individuals: 'Individuos relacionados',
         related_institutions: 'Instituciones relacionadas',
+        work_context: 'Contexto de la obra',
         subject_references: 'Referencias del tema'
       },
       libid: {

--- a/frontend/lang/gl.js
+++ b/frontend/lang/gl.js
@@ -518,7 +518,9 @@ export default {
         milestones: 'Fitos',
         owner: 'Propietario',
         printed_by: 'Impreso por',
+        related_individuals: 'Individuos relacionados',
         related_institutions: 'Institucións relacionadas',
+        work_context: 'Contexto da obra',
         subject_references: 'Referencias temáticas'
       },
       libid: {

--- a/frontend/lang/pt.js
+++ b/frontend/lang/pt.js
@@ -518,7 +518,9 @@ export default {
         milestones: 'Conquistas',
         owner: 'Proprietário',
         printed_by: 'Impresso por',
+        related_individuals: 'Indivíduos relacionados',
         related_institutions: 'Instituições relacionadas',
+        work_context: 'Contexto da obra',
         subject_references: 'Referências de assunto'
       },
       libid: {


### PR DESCRIPTION
## Summary
Fixes incorrect section headers for related items in the institution (insid) table.

## Problem
In the Related Items section for institutions:
- 'Related Institutions' was showing individuals (bioid records)
- 'Subject References' was showing a mix of content types (bibid, texid, etc.) instead of just subjects

### Screenshot from Issue
![Issue](https://github.com/user-attachments/assets/8e27927a-5ac9-4b1b-8876-99febf4c2760)

## Solution
Split and corrected the section configurations:

| Old Label | New Labels | Property |
|-----------|------------|----------|
| Related Institutions (mixed) | **Related Individuals** | P703 (bioid only) |
| | Related Institutions | P232 (insid, libid) |
| Subject References (mixed) | **Work Context** | P590 (texid) |
| | Subject References | P243 (subid only) |

## Files Modified
- `frontend/components/item/related/Tables.vue`
- `frontend/lang/en.js`
- `frontend/lang/es.js`
- `frontend/lang/ca.js`
- `frontend/lang/gl.js`
- `frontend/lang/pt.js`

Closes #308