### PR TITLE
fix: Prevent duplicate values when adding new claims

### DIFF
--- a/frontend/components/item/Claims.vue
+++ b/frontend/components/item/Claims.vue
@@ -7,6 +7,7 @@
       :item="item"
       :claim="claim"
       @delete-claim="deleteClaim"
+      @create-claim="addValueToClaim"
     />
     <item-claim-create v-if="isUserLogged" :item="item" @update-claims="updateClaims" />
   </div>
@@ -57,9 +58,26 @@ export default {
       const existingClaim = claims.find(claim => claim.property === data.property)
 
       if (existingClaim) {
-        existingClaim.values.push(...data.values)
+        // Filter out duplicates before adding
+        const newValues = data.values.filter(newVal =>
+          !existingClaim.values.some(existingVal => existingVal.id === newVal.id)
+        )
+        if (newValues.length > 0) {
+          existingClaim.values.push(...newValues)
+        }
       } else {
         claims.push(data)
+      }
+    },
+    addValueToClaim (data) {
+      // Handle adding a new value to an existing claim
+      const existingClaim = this.claims.find(claim => claim.property === data.property)
+      if (existingClaim) {
+        // Check if this claim already exists to prevent duplicates
+        const claimExists = existingClaim.values.some(v => v.id === data.claim.id)
+        if (!claimExists) {
+          existingClaim.values.push(data.claim)
+        }
       }
     }
   }


### PR DESCRIPTION
## Summary
Fixes the bug where after saving a new value and refreshing, two instances of the value appear.

**Also fixes #336** - After adding a new value, the +qualifier button now appears immediately without needing to refresh.

## Problem
When adding a new value to an existing claim:
1. The `create-claim` event from `AddValue.vue` was not being handled by `Claims.vue`
2. No duplicate checking was performed when adding values
3. The new value wasn't added to local state, so UI elements like +qualifier weren't visible (#336)

## Solution
- Added `@create-claim="addValueToClaim"` handler to `item-claim-base`
- Added `addValueToClaim` method that checks if a claim with the same ID already exists before adding
- Added duplicate filtering in `updateClaims` method to prevent duplicates when new claims are created

## Files Modified
- `frontend/components/item/Claims.vue`

Closes #343
Closes #336