### PR TITLE
Falta de ortografía Geografia ca_Search

### DIFF
--- a/frontend/lang/ca.js
+++ b/frontend/lang/ca.js
@@ -52,7 +52,7 @@ export default {
             label: 'MsEd'
           },
           geoid: {
-            label: 'Geogràfia'
+            label: 'Geografia'
           },
           subid: {
             label: 'Assumpte'
@@ -87,7 +87,7 @@ export default {
             label: 'MsEd'
           },
           geoid: {
-            label: 'Geogràfia'
+            label: 'Geografia'
           },
           subid: {
             label: 'Assumpte'

--- a/wikiPages/pages/ca_Search
+++ b/wikiPages/pages/ca_Search
@@ -40,7 +40,7 @@ copista / impressor, editor / mecenes, antic posseïdor,
 
 altra persona relacionada]<nowiki></p></nowiki>
 
-<nowiki><p><a href="ca/search/geoid/query/">Geogràfia</a></nowiki><nowiki></p></nowiki>
+<nowiki><p><a href="ca/search/geoid/query/">Geografia</a></nowiki><nowiki></p></nowiki>
 
 <nowiki><p><a href="ca/search/subid/query/">Matèria</a></nowiki><nowiki></p></nowiki>
 


### PR DESCRIPTION
Se ha modificado ca.js y ca_Search, para corregir la palabra Geografía en catalán. Estaba como "Geográfia" y ahora está como "Geografia".