### PR TITLE
#387 Update BIB item label generation logic to include date and reorder fields

### DIFF
--- a/frontend/components/item/Create.vue
+++ b/frontend/components/item/Create.vue
@@ -439,6 +439,21 @@ export default {
         day: 'numeric'
       }).format(date)
     },
+    safeFormatTime (timeString) {
+      if (!timeString || typeof timeString !== 'string' || !timeString.trim()) {
+        return undefined
+      }
+      // Check if it matches expected date pattern (e.g., +YYYY-MM-DD or YYYY-MM-DD)
+      const datePattern = /^[+-]?\d{4}-\d{2}-\d{2}/
+      if (!datePattern.test(timeString)) {
+        return undefined
+      }
+      try {
+        return this.formatTime(timeString)
+      } catch (error) {
+        return undefined
+      }
+    },
     getClaimValue (pbid) {
       const claim = this.initialClaims.find(cl => cl.property?.id === pbid)
       const val = claim?.value?.datavalue?.value
@@ -446,9 +461,15 @@ export default {
       if (!val) {
         return null
       }
-      return typeof val === 'object'
-        ? val.label || val.text || this.formatTime(val.time) || val.id
-        : val
+      if (typeof val === 'object') {
+        // For date values (val.time), use safe formatting
+        if (val.time !== undefined) {
+          const formatted = this.safeFormatTime(val.time)
+          return val.label || val.text || formatted || val.id
+        }
+        return val.label || val.text || val.id
+      }
+      return val
     },
     generateLabelFromClaims () {
       let label = ''

--- a/frontend/components/item/Create.vue
+++ b/frontend/components/item/Create.vue
@@ -470,11 +470,17 @@ export default {
           break
         }
         case 'bibid': {
-          const creator =
-            this.getClaimValue('P1134') || this.getClaimValue('P21')
+          const surname = this.getClaimValue('P247')
+          const author = this.getClaimValue('P21')
+          const creator = this.getClaimValue('P1134')
           const title = this.getClaimValue('P11')
-          if (creator && title) {
-            label = `${creator}. ${title}`
+          const date = this.getClaimValue('P222')
+
+          const name = surname || author || creator
+
+          if (name && title) {
+            const datePart = date ? ` (${date})` : ''
+            label = `${name}${datePart}, ${title}`
           }
           break
         }


### PR DESCRIPTION
Se ha actualizado generateLabelFromClaims() para que funcione con surname, author o creator + el título.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Item labels now prefer surname/author/creator and include date when available for clearer identification.
  * Label format changed to show name (date), title for improved readability.

* **Bug Fixes**
  * Date values are now safely validated and formatted to prevent malformed or empty date displays.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->