### PR TITLE
ci: add GitHub Actions workflows for staging and production

### DIFF
--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -5,6 +5,10 @@ on:
     tags:
       - 'v*'
   workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version tag (e.g. v1.2.3)'
+        required: true
 
 env:
   REGISTRY: ghcr.io
@@ -35,7 +39,15 @@ jobs:
 
       - name: Extract version tag
         id: tag
-        run: echo "version=${GITHUB_REF#refs/tags/}" >> "$GITHUB_OUTPUT"
+        run: |
+          if [ -n "${{ inputs.version }}" ]; then
+            echo "version=${{ inputs.version }}" >> "$GITHUB_OUTPUT"
+          elif [[ "$GITHUB_REF" == refs/tags/* ]]; then
+            echo "version=${GITHUB_REF#refs/tags/}" >> "$GITHUB_OUTPUT"
+          else
+            echo "ERROR: no version tag available (not a tag push and no version input)" >&2
+            exit 1
+          fi
 
       - name: Build & push backend
         uses: docker/build-push-action@v7.1.0

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -1,0 +1,82 @@
+name: Production — build, push & deploy
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  OWNER: ${{ github.repository_owner }}
+
+jobs:
+  build-and-push:
+    name: Build & push images
+    runs-on: ubuntu-latest
+    environment: production
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6.0.2
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v4.1.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4.0.0
+
+      - name: Extract version tag
+        id: tag
+        run: echo "version=${GITHUB_REF#refs/tags/}" >> "$GITHUB_OUTPUT"
+
+      - name: Build & push backend
+        uses: docker/build-push-action@v7.1.0
+        with:
+          context: backend
+          push: true
+          tags: |
+            ${{ env.REGISTRY }}/${{ env.OWNER }}/philobiblon-ui-backend:${{ steps.tag.outputs.version }}
+            ${{ env.REGISTRY }}/${{ env.OWNER }}/philobiblon-ui-backend:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Build & push frontend
+        uses: docker/build-push-action@v7.1.0
+        with:
+          context: frontend
+          push: true
+          build-args: |
+            BASE_URL=${{ vars.BASE_URL }}
+            API_BASE_URL=${{ vars.API_BASE_URL }}
+          tags: |
+            ${{ env.REGISTRY }}/${{ env.OWNER }}/philobiblon-ui-frontend:${{ steps.tag.outputs.version }}
+            ${{ env.REGISTRY }}/${{ env.OWNER }}/philobiblon-ui-frontend:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  deploy:
+    name: Deploy to production
+    needs: build-and-push
+    runs-on: ubuntu-latest
+    environment: production
+
+    steps:
+      - name: Deploy via SSH
+        uses: appleboy/ssh-action@v1.2.5
+        with:
+          host: ${{ secrets.SSH_HOST }}
+          username: ${{ secrets.SSH_USER }}
+          key: ${{ secrets.SSH_KEY }}
+          script: |
+            cd ${{ vars.DEPLOY_PATH }}
+            docker compose -f docker-compose.ui-fact.yaml pull
+            docker compose -f docker-compose.ui-fact.yaml up -d
+            docker image prune -f

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -1,0 +1,105 @@
+name: Staging — build, push & deploy
+
+on:
+  push:
+    branches: [master]
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  OWNER: ${{ github.repository_owner }}
+
+jobs:
+  build-and-push:
+    name: Build & push images
+    runs-on: ubuntu-latest
+    environment: staging
+    permissions:
+      contents: read
+      packages: write
+
+    outputs:
+      short_sha: ${{ steps.meta.outputs.short_sha }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6.0.2
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v4.1.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4.0.0
+
+      - name: Compute short SHA
+        id: meta
+        run: echo "short_sha=${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
+
+      - name: Build & push backend
+        uses: docker/build-push-action@v7.1.0
+        with:
+          context: backend
+          push: true
+          tags: |
+            ${{ env.REGISTRY }}/${{ env.OWNER }}/philobiblon-ui-backend:main-${{ steps.meta.outputs.short_sha }}
+            ${{ env.REGISTRY }}/${{ env.OWNER }}/philobiblon-ui-backend:main-latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Build & push frontend
+        uses: docker/build-push-action@v7.1.0
+        with:
+          context: frontend
+          push: true
+          build-args: |
+            BASE_URL=${{ vars.BASE_URL }}
+            API_BASE_URL=${{ vars.API_BASE_URL }}
+          tags: |
+            ${{ env.REGISTRY }}/${{ env.OWNER }}/philobiblon-ui-frontend:main-${{ steps.meta.outputs.short_sha }}
+            ${{ env.REGISTRY }}/${{ env.OWNER }}/philobiblon-ui-frontend:main-latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  deploy:
+    name: Deploy to staging
+    needs: build-and-push
+    runs-on: ubuntu-latest
+    environment: staging
+
+    steps:
+      - name: Deploy via SSH
+        uses: appleboy/ssh-action@v1.2.5
+        with:
+          host: ${{ secrets.SSH_HOST }}
+          username: ${{ secrets.SSH_USER }}
+          key: ${{ secrets.SSH_KEY }}
+          script: |
+            cd ${{ vars.DEPLOY_PATH }}
+            docker compose -f docker-compose.ui-dev.yaml pull
+            docker compose -f docker-compose.ui-dev.yaml up -d
+            docker image prune -f
+
+  cleanup:
+    name: Clean up old staging images
+    needs: deploy
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+
+    strategy:
+      matrix:
+        package: [philobiblon-ui-backend, philobiblon-ui-frontend]
+
+    steps:
+      - name: Delete old versions of ${{ matrix.package }}
+        uses: actions/delete-package-versions@v5.0.0
+        with:
+          package-name: ${{ matrix.package }}
+          package-type: container
+          min-versions-to-keep: 5
+          ignore-versions: '^v'
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/docs/README.md
+++ b/docs/README.md
@@ -49,6 +49,9 @@ PhiloBiblon UI is a modern web application for querying and editing items in a W
 - [Security & OAuth](backend/security.md) - Authentication and authorization
 - [Caching](backend/caching.md) - SPARQL query caching
 
+### Operations
+- [CI/CD](cicd.md) - GitHub Actions workflows, GHCR image registry, and deploy secrets
+
 ## Quick Start
 
 ### Running with Docker

--- a/docs/cicd.md
+++ b/docs/cicd.md
@@ -1,0 +1,82 @@
+# CI/CD — GitHub Actions + GHCR
+
+## Workflows
+
+### `staging.yml` — triggers: push to `master`, manual
+
+1. Builds `philobiblon-ui-backend` and `philobiblon-ui-frontend` images (with layer cache via GitHub Actions cache).
+2. Pushes to GHCR with two tags each: `main-{7-char SHA}` and `main-latest`.
+3. Deploys to the staging server via SSH using `docker-compose.ui-dev.yaml`.
+4. Deletes old image versions, keeping the 5 most recent. Tags matching `^v` (production releases) are never deleted.
+
+### `production.yml` — triggers: push of a `v*` tag (e.g. `v1.2.3`), manual
+
+1. Builds both images and pushes with tags `v1.2.3` and `latest`.
+2. Deploys to the production server via SSH using `docker-compose.ui-fact.yaml`.
+
+## Deploy sequence
+
+Both environments follow the same sequence on the server:
+
+```bash
+docker compose -f docker-compose.ui-<env>.yaml pull
+docker compose -f docker-compose.ui-<env>.yaml up -d
+docker image prune -f
+```
+
+| Environment | Compose file |
+|---|---|
+| Staging | `docker-compose.ui-dev.yaml` |
+| Production | `docker-compose.ui-fact.yaml` |
+
+The compose files on the server must reference the GHCR images directly:
+- Staging: `ghcr.io/philobiblon/philobiblon-ui-{backend,frontend}:main-latest`
+- Production: `ghcr.io/philobiblon/philobiblon-ui-{backend,frontend}:latest`
+
+## GitHub Environments
+
+Secrets and variables are managed per environment at **Settings → Environments**.
+Create two environments: `staging` and `production`, each with:
+
+### Variables (`vars.*`) — visible, non-sensitive
+
+| Variable | Description |
+|---|---|
+| `BASE_URL` | Frontend base path (e.g. `/` or `/ui/`) — baked into the image at build time |
+| `API_BASE_URL` | Backend API URL (e.g. `https://example.com/api/`) — baked into the image at build time |
+| `DEPLOY_PATH` | Absolute path to the project on the server |
+
+### Secrets (`secrets.*`) — encrypted
+
+| Secret | Description |
+|---|---|
+| `SSH_HOST` | Hostname or IP of the server |
+| `SSH_USER` | SSH username |
+| `SSH_KEY` | Private SSH key (RSA or Ed25519) |
+
+`GITHUB_TOKEN` is provided automatically by GitHub Actions — no manual setup needed.
+
+## Testing pipelines manually
+
+Both workflows support `workflow_dispatch`, which allows triggering them manually without a push or tag:
+
+1. Go to **Actions** in the GitHub repository
+2. Select the workflow (`Staging` or `Production`)
+3. Click **Run workflow** and select the branch
+
+## Server prerequisites
+
+The deploy path on each server must contain:
+- `docker-compose.ui-dev.yaml` (staging) or `docker-compose.ui-fact.yaml` (production)
+- `.env` with the runtime environment variables
+
+The server user must be in the `docker` group (or have equivalent permission to run `docker compose`).
+
+## GHCR image names
+
+```
+ghcr.io/philobiblon/philobiblon-ui-backend
+ghcr.io/philobiblon/philobiblon-ui-frontend
+```
+
+Images in a public repository on GHCR are free to pull without authentication.


### PR DESCRIPTION
## Summary

- `staging.yml`: build + push a GHCR (`main-latest`), deploy per SSH amb `docker-compose.ui-dev.yaml`, neteja d'imatges antigues (manté 5, mai `v*`)
- `production.yml`: build + push a GHCR (`vX.Y.Z` + `latest`), deploy per SSH amb `docker-compose.ui-fact.yaml`
- Tots dos workflows suporten `workflow_dispatch` per a proves manuals
- Secrets i variables gestionats per entorn (`staging` / `production`) a GitHub Environments
- `docs/cicd.md`: documentació completa dels workflows, entorns i prerequisits del servidor

## Test plan

- [ ] Configurar els environments `staging` i `production` a Settings → Environments amb les variables i secrets corresponents
- [ ] Llançar el workflow `Staging` manualment des d'Actions → Run workflow
- [ ] Verificar que les imatges apareixen a GHCR
- [ ] Verificar que el servidor de staging s'ha actualitzat correctament
- [ ] Crear un tag `v*` i verificar que s'activa el workflow de producció

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added automated build, publish, and deploy pipelines for staging (on main pushes) and production (on version releases), including manual dispatch options.
  * Builds backend and frontend container images, tags versions and latest, pushes to the container registry, deploys to remote hosts, and prunes old images; staging includes an automated cleanup of older package versions.

* **Documentation**
  * Added CI/CD and operations docs describing workflows, deployment prerequisites, and environment setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->