### PR TITLE
fix: lowercase GHCR owner to fix image tag validation

### DIFF
--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -27,6 +27,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6.0.2
 
+      - name: Lowercase owner
+        run: echo "OWNER=$(echo '${{ github.repository_owner }}' | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
+
       - name: Log in to GHCR
         uses: docker/login-action@v4.1.0
         with:

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -25,6 +25,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6.0.2
 
+      - name: Lowercase owner
+        run: echo "OWNER=$(echo '${{ github.repository_owner }}' | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
+
       - name: Log in to GHCR
         uses: docker/login-action@v4.1.0
         with:


### PR DESCRIPTION
## Summary

- `github.repository_owner` retorna `PhiloBiblon` amb majúscules
- Docker exigeix que els noms de repositori siguin en minúscules
- Afegit un step que converteix `OWNER` a minúscules abans de fer el build

## Test plan

- [ ] Tornar a llançar el workflow de staging manualment i verificar que el build passa

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflows to ensure container image registry paths consistently use lowercase naming conventions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->