### PR TITLE
fix: scope image cleanup to philobiblon-ui and fail fast on deploy errors

### DIFF
--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -68,6 +68,7 @@ jobs:
           tags: |
             ${{ env.REGISTRY }}/${{ env.OWNER }}/philobiblon-ui-backend:${{ steps.tag.outputs.version }}
             ${{ env.REGISTRY }}/${{ env.OWNER }}/philobiblon-ui-backend:latest
+          labels: org.opencontainers.image.source=https://github.com/PhiloBiblon/philobiblon-ui
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
@@ -82,6 +83,7 @@ jobs:
           tags: |
             ${{ env.REGISTRY }}/${{ env.OWNER }}/philobiblon-ui-frontend:${{ steps.tag.outputs.version }}
             ${{ env.REGISTRY }}/${{ env.OWNER }}/philobiblon-ui-frontend:latest
+          labels: org.opencontainers.image.source=https://github.com/PhiloBiblon/philobiblon-ui
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
@@ -100,7 +102,8 @@ jobs:
           key: ${{ secrets.SSH_KEY }}
           script_stop: true
           script: |
+            set -e
             cd ${{ vars.DEPLOY_PATH }}
             docker compose -f docker-compose.ui-fact.yml pull
             docker compose -f docker-compose.ui-fact.yml up -d
-            docker image prune -f
+            docker images --filter "dangling=true" --filter "label=org.opencontainers.image.source=https://github.com/PhiloBiblon/philobiblon-ui" -q | xargs -r docker rmi -f

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -58,6 +58,7 @@ jobs:
           tags: |
             ${{ env.REGISTRY }}/${{ env.OWNER }}/philobiblon-ui-backend:main-${{ steps.meta.outputs.short_sha }}
             ${{ env.REGISTRY }}/${{ env.OWNER }}/philobiblon-ui-backend:main-latest
+          labels: org.opencontainers.image.source=https://github.com/PhiloBiblon/philobiblon-ui
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
@@ -72,6 +73,7 @@ jobs:
           tags: |
             ${{ env.REGISTRY }}/${{ env.OWNER }}/philobiblon-ui-frontend:main-${{ steps.meta.outputs.short_sha }}
             ${{ env.REGISTRY }}/${{ env.OWNER }}/philobiblon-ui-frontend:main-latest
+          labels: org.opencontainers.image.source=https://github.com/PhiloBiblon/philobiblon-ui
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
@@ -90,10 +92,11 @@ jobs:
           key: ${{ secrets.SSH_KEY }}
           script_stop: true
           script: |
+            set -e
             cd ${{ vars.DEPLOY_PATH }}
             docker compose -f docker-compose.ui-dev.yml pull
             docker compose -f docker-compose.ui-dev.yml up -d
-            docker image prune -f
+            docker images --filter "dangling=true" --filter "label=org.opencontainers.image.source=https://github.com/PhiloBiblon/philobiblon-ui" -q | xargs -r docker rmi -f
 
   cleanup:
     name: Clean up old staging images


### PR DESCRIPTION
## Summary

- Afegit label `org.opencontainers.image.source` a totes les imatges construïdes per poder filtrar per label
- Substituït `docker image prune -f` per una neteja limitada a imatges de philobiblon-ui (evita eliminar imatges d'altres serveis del servidor)
- Afegit `set -e` als scripts de deploy remot perquè qualsevol error falli el job

## Test plan

- [ ] Verificar que després d'un deploy les imatges antigues de philobiblon-ui s'eliminen
- [ ] Verificar que les imatges d'altres serveis del servidor no es veuen afectades
- [ ] Verificar que un error en `docker compose pull` o `up` fa fallar el job

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced deployment reliability by adding fail-on-error handling to CI/CD workflows
  * Improved Docker image management with source tracking metadata and targeted cleanup processes for production and staging environments

<!-- end of auto-generated comment: release notes by coderabbit.ai -->