### PR TITLE
feat(frontend): Nuxt 3 migration — mid-level components (Sub-PR #6)

### DIFF
--- a/frontend/components/item/claim/AddValue.vue
+++ b/frontend/components/item/claim/AddValue.vue
@@ -11,31 +11,31 @@
           <item-value-base
             :key="`${claim.value}-${key}`"
             class="full-width"
-            :label="$t('common.value')"
+            :label="t('common.value')"
             :value="claim"
             type="claim"
             mode="creation"
             @on-blur="updateClaimValue($event, key)"
           />
           <div class="d-flex ml-3 mt-1">
-            <v-btn v-if="!forCreate" :disabled="!claim?.datavalue?.value" text icon @click.stop="createClaim(key)">
-              <v-tooltip top>
-                <template #activator="{ on, attrs }">
-                  <v-icon v-bind="attrs" v-on="on">
+            <v-btn v-if="!forCreate" :disabled="!claim?.datavalue?.value" variant="text" icon @click.stop="createClaim(key)">
+              <v-tooltip location="top">
+                <template #activator="{ props: btnProps }">
+                  <v-icon v-bind="btnProps">
                     mdi-check
                   </v-icon>
                 </template>
-                <span>{{ $t("common.save") }}</span>
+                <span>{{ t("common.save") }}</span>
               </v-tooltip>
             </v-btn>
-            <v-btn text icon @click.stop="removeClaim(key)">
-              <v-tooltip top>
-                <template #activator="{ on, attrs }">
-                  <v-icon v-bind="attrs" v-on="on">
+            <v-btn variant="text" icon @click.stop="removeClaim(key)">
+              <v-tooltip location="top">
+                <template #activator="{ props: btnProps }">
+                  <v-icon v-bind="btnProps">
                     mdi-trash-can
                   </v-icon>
                 </template>
-                <span>{{ $t("common.remove") }}</span>
+                <span>{{ t("common.remove") }}</span>
               </v-tooltip>
             </v-btn>
           </div>
@@ -48,90 +48,88 @@
           <v-icon color="primary">
             mdi-plus
           </v-icon>
-          <span>{{ $t("common.add_value") }}</span>
+          <span>{{ t("common.add_value") }}</span>
         </div>
       </a>
     </v-row>
   </v-container>
 </template>
 
-<script>
-export default {
-  props: {
-    item: {
-      type: Object,
-      default: null
-    },
-    value: {
-      type: Object,
-      default: null
-    },
-    forCreate: {
-      type: Boolean,
-      default: false
-    }
-  },
-  data () {
-    return {
-      items: {},
-      claims: {}
-    }
-  },
-  methods: {
-    addClaim () {
-      const newKey = `P${Date.now()}`
-      const { property, datatype } = this.value
-      const newClaim = {
-        property,
-        datatype,
-        datavalue: { value: null, default: false }
-      }
+<script setup>
+import { reactive } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { useAuthStore } from '~/stores/auth'
 
-      this.$set(this.claims, newKey, newClaim)
+const props = defineProps({
+  item: { type: Object, default: null },
+  value: { type: Object, default: null },
+  forCreate: { type: Boolean, default: false }
+})
 
-      if (this.forCreate) {
-        this.$emit('update-claims-values', this.claims)
-      }
-    },
-    removeClaim (key) {
-      this.$delete(this.claims, key)
-      this.$delete(this.items, key)
+const emit = defineEmits(['update-claims-values', 'create-claim'])
 
-      if (this.forCreate) {
-        this.$emit('update-claims-values', this.claims)
-      }
-    },
-    updateClaimValue (value, key) {
-      this.claims[key].datavalue.value = value && typeof value === 'object' ? value.id ?? null : value
+const { $notification, $wikibase } = useNuxtApp()
+const { t } = useI18n()
+const authStore = useAuthStore()
 
-      if (this.forCreate) {
-        this.$emit('update-claims-values', this.claims)
-      }
-    },
-    async createClaim (index) {
-      const value = this.claims[index]?.datavalue?.value
-      if (!value) {
-        return
-      }
-      const res = await this.$wikibase.getWbEdit().claim.add({
-        value,
-        id: this.item.id,
-        property: this.value.property
-      }, this.$store.getters['auth/getRequestConfig'])
-      res.success ? this.$notification.success(this.$i18n.t('messages.success.updated')) : this.$i18n.t('messages.error.modification.failed')
-      this.updateClaims(res)
-      return res
-    },
-    updateClaims (res) {
-      const data = {
-        claim: res.claim,
-        property: this.value.property
-      }
-      this.$emit('create-claim', data)
-    }
+const items = reactive({})
+const claims = reactive({})
+
+function addClaim () {
+  const newKey = `P${Date.now()}`
+  const { property, datatype } = props.value
+  claims[newKey] = {
+    property,
+    datatype,
+    datavalue: { value: null, default: false }
+  }
+
+  if (props.forCreate) {
+    emit('update-claims-values', claims)
   }
 }
+
+function removeClaim (key) {
+  delete claims[key]
+  delete items[key]
+
+  if (props.forCreate) {
+    emit('update-claims-values', claims)
+  }
+}
+
+function updateClaimValue (value, key) {
+  claims[key].datavalue.value = value && typeof value === 'object' ? value.id ?? null : value
+
+  if (props.forCreate) {
+    emit('update-claims-values', claims)
+  }
+}
+
+async function createClaim (index) {
+  const value = claims[index]?.datavalue?.value
+  if (!value) {
+    return
+  }
+  const res = await $wikibase.getWbEdit().claim.add({
+    value,
+    id: props.item.id,
+    property: props.value.property
+  }, authStore.requestConfig)
+  if (res.success) {
+    $notification.success(t('messages.success.updated'))
+  } else {
+    $notification.error(t('messages.error.modification.failed'))
+  }
+  updateClaims(res)
+  return res
+}
+
+function updateClaims (res) {
+  emit('create-claim', { claim: res.claim, property: props.value.property })
+}
 </script>
+
 <style scoped>
 .full-width {
   width: 100%;

--- a/frontend/components/item/claim/Base.vue
+++ b/frontend/components/item/claim/Base.vue
@@ -1,59 +1,49 @@
 <template>
   <v-container class="claim">
     <v-row dense>
-      <v-subheader class="claim-header section-header">
+      <div class="claim-header section-header">
         <item-util-view-text-lang :value="propertyLabel" :tooltip="claim.property" />
-      </v-subheader>
+      </div>
     </v-row>
     <v-container class="claim-values">
-      <item-claim-values :claim="claim" @delete-claim="$emit('delete-claim', $event)" />
+      <item-claim-values :claim="claim" @delete-claim="emit('delete-claim', $event)" />
       <item-claim-add-value
         v-if="isUserLogged && isAllowedAddValue"
         :key="claim.values.length"
         :item="item"
         :value="claim?.values[0]?.mainsnak"
-        @create-claim="$emit('create-claim', $event)"
+        @create-claim="emit('create-claim', $event)"
       />
     </v-container>
   </v-container>
 </template>
 
-<script>
-export default {
-  props: {
-    table: {
-      type: String,
-      required: true
-    },
-    item: {
-      type: Object,
-      default: null
-    },
-    claim: {
-      type: Object,
-      default: null
-    }
-  },
+<script setup>
+import { computed, onMounted, ref } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { useAuthStore } from '~/stores/auth'
+import { WikibaseService } from '~/service/wikibase.service'
 
-  data () {
-    return {
-      propertyLabel: null
-    }
-  },
+const props = defineProps({
+  table: { type: String, required: true },
+  item: { type: Object, default: null },
+  claim: { type: Object, default: null }
+})
 
-  computed: {
-    isUserLogged () {
-      return this.$store.state.auth.isLogged
-    },
-    isAllowedAddValue () {
-      return this.claim.property !== this.$wikibase.constructor.PROPERTY_NOTES
-    }
-  },
+const emit = defineEmits(['delete-claim', 'create-claim'])
 
-  async mounted () {
-    this.propertyLabel = await this.$wikibase.getEntityLabel(this.table, this.claim.property, this.$i18n.locale)
-  }
-}
+const { $wikibase } = useNuxtApp()
+const { locale } = useI18n()
+const authStore = useAuthStore()
+
+const propertyLabel = ref(null)
+
+const isUserLogged = computed(() => authStore.isLogged)
+const isAllowedAddValue = computed(() => props.claim.property !== WikibaseService.PROPERTY_NOTES)
+
+onMounted(async () => {
+  propertyLabel.value = await $wikibase.getEntityLabel(props.table, props.claim.property, locale.value)
+})
 </script>
 
 <style scoped>
@@ -62,6 +52,12 @@ export default {
 }
 .claim-header {
   font-size: 16px;
+  padding: 0 16px;
+  display: flex;
+  align-items: center;
+  min-height: 48px;
+  color: #616161 !important;
+  font-weight: bold !important;
 }
 .section-header {
   color: #616161 !important;

--- a/frontend/components/item/claim/Create.vue
+++ b/frontend/components/item/claim/Create.vue
@@ -8,41 +8,42 @@
       dense
     >
       <v-col class="p-0 pr-3 mt-3">
-        <v-subheader class="claim-header grey--text">
+        <div class="claim-header text-grey">
           <v-autocomplete
             v-model="claim.property"
             required
             :readonly="claim?.default"
             :items="properties[key]"
-            item-text="label"
+            item-title="label"
             return-object
-            :label="$t('common.property')"
+            :label="t('common.property')"
             variant="outlined"
+            density="compact"
             :filter="acceptAll"
-            @change="onChangeProperty($event, claim)"
-            @update:search-input="onInput($event, 'property', key)"
+            @update:model-value="onChangeProperty($event, claim)"
+            @update:search="onInput($event, 'property', key)"
           />
-        </v-subheader>
+        </div>
       </v-col>
       <v-col class="p-0 pr-3 d-flex justify-end max-w-100">
-        <v-btn v-if="!forCreate" :disabled="!canCreate(key)" text icon @click.stop="addClaim(key)">
-          <v-tooltip top>
-            <template #activator="{ on, attrs }">
-              <v-icon v-bind="attrs" v-on="on">
+        <v-btn v-if="!forCreate" :disabled="!canCreate(key)" variant="text" icon @click.stop="addClaim(key)">
+          <v-tooltip location="top">
+            <template #activator="{ props: btnProps }">
+              <v-icon v-bind="btnProps">
                 mdi-check
               </v-icon>
             </template>
-            <span>{{ $t("common.save") }}</span>
+            <span>{{ t("common.save") }}</span>
           </v-tooltip>
         </v-btn>
-        <v-btn v-if="claim?.property?.id !== pbid" text icon @click.stop="removeClaim(key)">
-          <v-tooltip top>
-            <template #activator="{ on, attrs }">
-              <v-icon v-bind="attrs" v-on="on">
+        <v-btn v-if="claim?.property?.id !== pbid" variant="text" icon @click.stop="removeClaim(key)">
+          <v-tooltip location="top">
+            <template #activator="{ props: btnProps }">
+              <v-icon v-bind="btnProps">
                 mdi-trash-can
               </v-icon>
             </template>
-            <span>{{ $t("common.remove") }}</span>
+            <span>{{ t("common.remove") }}</span>
           </v-tooltip>
         </v-btn>
       </v-col>
@@ -81,173 +82,165 @@
           <v-icon color="primary">
             mdi-plus
           </v-icon>
-          <span>{{ $t("common.add_claim") }}</span>
+          <span>{{ t("common.add_claim") }}</span>
         </div>
       </a>
     </v-row>
   </div>
 </template>
 
-<script>
-export default {
-  props: {
-    item: {
-      type: Object,
-      default: null
-    },
-    initialClaims: {
-      type: Array,
-      default: null
-    },
-    forCreate: {
-      type: Boolean,
-      default: false
-    }
-  },
-  data () {
-    return {
-      claims: [],
-      properties: []
-    }
-  },
-  computed: {
-    pbid () {
-      return this.$wikibase.constructor.PROPERTY_PBID
-    }
-  },
-  watch: {
-    claims: {
-      handler (newValue) {
-        if (this.forCreate) {
-          this.$emit('update-claims', newValue)
-        }
-      },
-      deep: true
-    }
-  },
-  created () {
-    if (this.initialClaims) {
-      this.initialClaims.forEach((claim, index) => {
-        this.$set(this.properties, index, [claim.property])
-        this.claims.push(claim)
-      })
-    }
-  },
-  methods: {
-    onChangeProperty (property, claim) {
-      claim.property = property ?? null
-      claim.value.datavalue.value = null
-      claim.value.property = property?.id ?? null
-      claim.mainsnak.property = property?.id ?? null
-      claim.value.datatype = property?.datatype ?? null
-    },
-    onNewValue (event, claim) {
-      claim.value.datavalue.value = event
-    },
-    canCreate (index) {
-      const c = this.claims[index]
-      const v = c?.value?.datavalue?.value
+<script setup>
+import { computed, reactive, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { useAuthStore } from '~/stores/auth'
+import { WikibaseService } from '~/service/wikibase.service'
 
-      return !!(c?.property && v && (typeof v !== 'object' || Object.values(v).every(val => val != null && val !== '')) &&
-        c.qualifiers?.every(q =>
-          q?.property && q?.value &&
-          (typeof q.value === 'string' ? q.value.trim() : Object.values(q.value).every(v => v != null && v !== ''))
-        ))
-    },
-    addNewClaim () {
-      this.claims.push({
-        default: false,
-        value: {
-          property: null,
-          datatype: null,
-          datavalue: {
-            value: null
-          }
-        },
-        claimsValues: [],
-        mainsnak: {
-          property: null
-        },
-        property: null,
-        qualifiers: []
-      })
-    },
-    removeClaim (index) {
-      this.claims.splice(index, 1)
-      this.properties.splice(index, 1)
-    },
-    async onInput (value, type, index) {
-      if (value && typeof value === 'string') {
-        const search = await this.$wikibase.searchEntityByName(value, this.$i18n.locale, this.$i18n.locale, type)
-        if (search && search.length) {
-          this.$set(this.properties, index, search)
-        }
-      }
-    },
-    updateClaimValues (data, key) {
-      this.claims[key].claimsValues = data
-      this.$emit('update-claims', this.claims)
-    },
-    async addClaim (index) {
-      if (this.claims[index]?.value?.datavalue?.value) {
-        return await this.createClaim(index).then((res) => {
-          if (res.success) {
-            this.updateClaims(res)
-            this.removeClaim(index)
-            this.$notification.success(this.$t('messages.success.updated'))
-          } else {
-            this.$notification.error(this.$t('messages.error.something_went_wrong'))
-          }
-        }).catch((error) => {
-          this.$notification.error(error.message)
-        })
-      }
-    },
-    async createClaim (index) {
-      const { property, value, qualifiers: rawQualifiers } = this.claims[index]
+const props = defineProps({
+  item: { type: Object, default: null },
+  initialClaims: { type: Array, default: null },
+  forCreate: { type: Boolean, default: false }
+})
 
-      const formattedQualifiers = Object.fromEntries(
-        (rawQualifiers || [])
-          .filter(q => q.property && q.value)
-          .map(({ property, value }) => [property, { value }])
-      )
+const emit = defineEmits(['update-claims'])
 
-      return await this.$wikibase.getWbEdit().claim.create({
-        id: this.item.id,
-        property: property.id,
-        value: value.datavalue.value.id ?? value.datavalue.value,
-        qualifiers: Object.keys(formattedQualifiers).length ? formattedQualifiers : undefined
-      }, this.$store.getters['auth/getRequestConfig'])
+const { $notification, $wikibase } = useNuxtApp()
+const { t, locale } = useI18n()
+const authStore = useAuthStore()
+
+const claims = reactive([])
+const properties = reactive([])
+
+const pbid = computed(() => WikibaseService.PROPERTY_PBID)
+
+if (props.initialClaims) {
+  props.initialClaims.forEach((claim, index) => {
+    properties[index] = [claim.property]
+    claims.push(claim)
+  })
+}
+
+watch(claims, (newValue) => {
+  if (props.forCreate) {
+    emit('update-claims', newValue)
+  }
+}, { deep: true })
+
+function onChangeProperty (property, claim) {
+  claim.property = property ?? null
+  claim.value.datavalue.value = null
+  claim.value.property = property?.id ?? null
+  claim.mainsnak.property = property?.id ?? null
+  claim.value.datatype = property?.datatype ?? null
+}
+
+function onNewValue (event, claim) {
+  claim.value.datavalue.value = event
+}
+
+function canCreate (index) {
+  const c = claims[index]
+  const v = c?.value?.datavalue?.value
+
+  return !!(c?.property && v && (typeof v !== 'object' || Object.values(v).every(val => val != null && val !== '')) &&
+    c.qualifiers?.every(q =>
+      q?.property && q?.value &&
+      (typeof q.value === 'string' ? q.value.trim() : Object.values(q.value).every(vv => vv != null && vv !== ''))
+    ))
+}
+
+function addNewClaim () {
+  claims.push({
+    default: false,
+    value: {
+      property: null,
+      datatype: null,
+      datavalue: { value: null }
     },
-    updateQualifiers (data, key) {
-      this.claims[key].qualifiers = data.map((qualifier) => {
-        if (!this.forCreate) {
-          // Extract property ID - handle both object and string formats
-          const propertyId = qualifier?.property?.id || qualifier?.property
-          return {
-            property: propertyId,
-            value: qualifier?.datavalue?.value?.id ?? qualifier.datavalue?.value
-          }
-        } else {
-          return qualifier
-        }
-      })
-    },
-    updateClaims (res) {
-      const data = {
-        values: [res.claim],
-        hasQualifiers: res.claim?.qualifiers,
-        property: res.claim.mainsnak.property,
-        datatype: res.claim.mainsnak.datatype,
-        qualifiersOrder: res.claim['qualifiers-order'] ?? false
-      }
-      this.$emit('update-claims', data)
-    },
-    acceptAll (item, queryText, itemText) {
-      // We accept all the items because they are already filtered
-      return true
+    claimsValues: [],
+    mainsnak: { property: null },
+    property: null,
+    qualifiers: []
+  })
+}
+
+function removeClaim (index) {
+  claims.splice(index, 1)
+  properties.splice(index, 1)
+}
+
+async function onInput (value, type, index) {
+  if (value && typeof value === 'string') {
+    const search = await $wikibase.searchEntityByName(value, locale.value, locale.value, type)
+    if (search && search.length) {
+      properties[index] = search
     }
   }
+}
+
+function updateClaimValues (data, key) {
+  claims[key].claimsValues = data
+  emit('update-claims', claims)
+}
+
+async function addClaim (index) {
+  if (claims[index]?.value?.datavalue?.value) {
+    return await createClaim(index).then((res) => {
+      if (res.success) {
+        updateClaims(res)
+        removeClaim(index)
+        $notification.success(t('messages.success.updated'))
+      } else {
+        $notification.error(t('messages.error.something_went_wrong'))
+      }
+    }).catch((error) => {
+      $notification.error(error.message)
+    })
+  }
+}
+
+async function createClaim (index) {
+  const { property, value, qualifiers: rawQualifiers } = claims[index]
+
+  const formattedQualifiers = Object.fromEntries(
+    (rawQualifiers || [])
+      .filter(q => q.property && q.value)
+      .map(({ property: p, value: v }) => [p, { value: v }])
+  )
+
+  return await $wikibase.getWbEdit().claim.create({
+    id: props.item.id,
+    property: property.id,
+    value: value.datavalue.value.id ?? value.datavalue.value,
+    qualifiers: Object.keys(formattedQualifiers).length ? formattedQualifiers : undefined
+  }, authStore.requestConfig)
+}
+
+function updateQualifiers (data, key) {
+  claims[key].qualifiers = data.map((qualifier) => {
+    if (!props.forCreate) {
+      const propertyId = qualifier?.property?.id || qualifier?.property
+      return {
+        property: propertyId,
+        value: qualifier?.datavalue?.value?.id ?? qualifier.datavalue?.value
+      }
+    } else {
+      return qualifier
+    }
+  })
+}
+
+function updateClaims (res) {
+  emit('update-claims', {
+    values: [res.claim],
+    hasQualifiers: res.claim?.qualifiers,
+    property: res.claim.mainsnak.property,
+    datatype: res.claim.mainsnak.datatype,
+    qualifiersOrder: res.claim['qualifiers-order'] ?? false
+  })
+}
+
+function acceptAll () {
+  return true
 }
 </script>
 
@@ -258,6 +251,8 @@ export default {
 }
 .claim-header {
   font-size: 16px;
+  padding: 0 16px;
+  min-height: 48px;
 }
 .claim-values {
   background-color: rgb(247, 245, 245);
@@ -266,7 +261,7 @@ export default {
   white-space: normal;
 }
 
-::v-deep .add-claim-value {
+:deep(.add-claim-value) {
   .add-value {
     margin-top: 0;
   }

--- a/frontend/components/item/claim/Values.vue
+++ b/frontend/components/item/claim/Values.vue
@@ -2,15 +2,16 @@
   <v-data-table
     v-if="claim"
     :headers="formattedHeaders"
-    :hide-default-header="!Object.values(headers).length"
+    :hide-default-header="!headers.length"
     :items="claim.values"
-    :footer-props="footerProps"
+    :items-per-page-options="perPageOptions"
+    :items-per-page-text="`${t('common.properties')} ${t('common.per_page')}`"
     :hide-default-footer="shouldHideFooter"
     class="elevation-1"
   >
     <template #item="{ item, index }">
       <tr class="table-row">
-        <td v-for="(header, key) in formattedHeaders" :key="header.value" class="table-cell">
+        <td v-for="(header, key) in formattedHeaders" :key="header.key" class="table-cell">
           <item-value-base
             v-if="!key"
             :claim="item"
@@ -18,13 +19,13 @@
             type="claim"
             :in-table="true"
             :column-width="header.width"
-            @delete-claim="$emit('delete-claim', $event)"
+            @delete-claim="emit('delete-claim', $event)"
           />
           <item-qualifier-list
-            v-if="item.qualifiers?.[header.value]"
-            :key="item.qualifiers[header.value].length"
+            v-if="item.qualifiers?.[header.key]"
+            :key="item.qualifiers[header.key].length"
             :claim="item"
-            :qualifiers="item.qualifiers[header.value]"
+            :qualifiers="item.qualifiers[header.key]"
             @delete-qualifier="deleteQualifier($event, index)"
           />
         </td>
@@ -46,108 +47,97 @@
   </v-data-table>
 </template>
 
-<script>
-export default {
-  props: {
-    claim: {
-      type: Object,
-      default: () => ({ values: [] })
-    }
-  },
-  data () {
+<script setup>
+import { computed, onMounted, ref } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { useAuthStore } from '~/stores/auth'
+
+const props = defineProps({
+  claim: { type: Object, default: () => ({ values: [] }) }
+})
+
+const emit = defineEmits(['delete-claim'])
+
+const { $wikibase } = useNuxtApp()
+const { t, locale } = useI18n()
+const authStore = useAuthStore()
+
+const headers = ref([])
+
+const perPageOptions = [
+  { title: '20', value: 20 },
+  { title: '40', value: 40 },
+  { title: '60', value: 60 },
+  { title: '80', value: 80 },
+  { title: '100', value: 100 },
+  { title: t('search.form.common.group_all.label'), value: -1 }
+]
+
+const isUserLogged = computed(() => authStore.isLogged)
+
+const formattedHeaders = computed(() => [
+  { title: '', key: '_value', sortable: false },
+  ...headers.value.map(header => ({
+    title: header.label.value,
+    key: header.property,
+    sortable: false
+  }))
+])
+
+const shouldHideFooter = computed(() => props.claim?.values?.length <= perPageOptions[0].value)
+
+onMounted(async () => {
+  await getHeaders()
+})
+
+async function getHeaders () {
+  const qualifierKeys = new Set()
+  props.claim.values.forEach((item) => {
+    Object.keys(item.qualifiers ?? {}).forEach(key => qualifierKeys.add(key))
+  })
+  const qualifiersKeysOrdered = Array.from(qualifierKeys).sort((a, b) => {
+    return props.claim.qualifiersOrder ? props.claim.qualifiersOrder.indexOf(a) - props.claim.qualifiersOrder.indexOf(b) : -1
+  })
+  const headerPromises = qualifiersKeysOrdered.map(async (property) => {
+    const entity = await $wikibase.getEntity(property, locale.value)
     return {
-      headers: [],
-      perPageOptions: [
-        { text: '20', value: 20 },
-        { text: '40', value: 40 },
-        { text: '60', value: 60 },
-        { text: '80', value: 80 },
-        { text: '100', value: 100 },
-        { text: this.$i18n.t('search.form.common.group_all.label'), value: -1 }
-      ]
+      property,
+      label: $wikibase.getValueByLang(entity.labels, locale.value)
     }
-  },
-  computed: {
-    isUserLogged () {
-      return this.$store.state.auth.isLogged
-    },
-    formattedHeaders () {
-      return [
-        { text: '', value: '', sortable: false },
-        ...this.headers.map(header => ({
-          text: header.label.value,
-          value: header.property,
-          sortable: false
-        }))
-      ]
-    },
-    shouldHideFooter () {
-      return this.claim?.values?.length <= this.perPageOptions[0].value
-    },
-    footerProps () {
-      return {
-        showCurrentPage: true,
-        showFirstLastPage: true,
-        itemsPerPageOptions: this.perPageOptions,
-        itemsPerPageText: `${this.$i18n.t('common.properties')} ${this.$i18n.t('common.per_page')}`
-      }
-    }
-  },
-  async mounted () {
-    await this.getHeaders()
-  },
-  methods: {
-    async getHeaders () {
-      const qualifierKeys = new Set()
-      this.claim.values.forEach((item) => {
-        Object.keys(item.qualifiers ?? {}).forEach(key => qualifierKeys.add(key))
-      })
-      const qualifiersKeysOrdered = Array.from(qualifierKeys).sort((a, b) => {
-        return this.claim.qualifiersOrder ? this.claim.qualifiersOrder.indexOf(a) - this.claim.qualifiersOrder.indexOf(b) : -1
-      })
-      const headerPromises = Array.from(qualifiersKeysOrdered).map(async (property) => {
-        const entity = await this.$wikibase.getEntity(property, this.$i18n.locale)
-        return {
-          property,
-          label: this.$wikibase.getValueByLang(entity.labels, this.$i18n.locale)
-        }
-      })
-      this.headers = await Promise.all(headerPromises)
-    },
-    async createQualifier (qualifiers, index) {
-      if (!this.claim.values[index].qualifiers) {
-        // eslint-disable-next-line vue/no-mutating-props
-        this.claim.values[index].qualifiers = []
-      }
-      // eslint-disable-next-line vue/no-mutating-props
-      this.claim.values[index].qualifiers[qualifiers[0].property] = qualifiers
-      await this.getHeaders()
-    },
-    async deleteQualifier (qualifier, index) {
-      const qualifiers = this.claim.values[index].qualifiers[qualifier.property]
-      const findIndex = qualifiers.findIndex(item => item.hash === qualifier.hash)
-      if (findIndex !== -1) {
-        qualifiers.splice(findIndex, 1)
-      }
-      if (!qualifiers.length) {
-        // eslint-disable-next-line vue/no-mutating-props
-        delete this.claim.values[index].qualifiers[qualifier.property]
-      }
-      await this.getHeaders()
-    }
+  })
+  headers.value = await Promise.all(headerPromises)
+}
+
+async function createQualifier (qualifiers, index) {
+  if (!props.claim.values[index].qualifiers) {
+    props.claim.values[index].qualifiers = []
   }
+  props.claim.values[index].qualifiers[qualifiers[0].property] = qualifiers
+  await getHeaders()
+}
+
+async function deleteQualifier (qualifier, index) {
+  const qualifiers = props.claim.values[index].qualifiers[qualifier.property]
+  const findIndex = qualifiers.findIndex(item => item.hash === qualifier.hash)
+  if (findIndex !== -1) {
+    qualifiers.splice(findIndex, 1)
+  }
+  if (!qualifiers.length) {
+    delete props.claim.values[index].qualifiers[qualifier.property]
+  }
+  await getHeaders()
 }
 </script>
 
 <style scoped>
-::v-deep .v-data-table-header th {
+:deep(.v-data-table-header th) {
   background-color: #e0e0e0;
   color: black;
   font-weight: bold;
   border: none;
 }
 
-::v-deep .v-data-table-header th:last-child {
+:deep(.v-data-table-header th:last-child) {
   border-right: none;
 }
 
@@ -187,14 +177,10 @@ export default {
   background-color: rgb(247, 245, 245) !important;
 }
 
-::v-deep .v-data-footer {
+:deep(.v-data-table-footer) {
   background-color: rgb(247, 245, 245);
   border-top: none;
   width: 100%;
   padding: 8px 16px;
-}
-
-::v-deep .v-data-footer__pagination {
-  justify-content: flex-end;
 }
 </style>

--- a/frontend/components/item/qualifier/Create.vue
+++ b/frontend/components/item/qualifier/Create.vue
@@ -11,24 +11,25 @@
       <v-col class="p-0 pr-3">
         <v-autocomplete
           v-model="qualifier.property"
-          :label="$t('common.property')"
+          :label="t('common.property')"
           required
           return-object
           :readonly="qualifier?.default"
           :items="properties[key]"
-          item-text="label"
+          item-title="label"
           item-value="id"
           variant="outlined"
+          density="compact"
           :filter="acceptAll"
-          @change="onChangeProperty($event, key)"
-          @update:search-input="onInput($event, 'property', key)"
+          @update:model-value="onChangeProperty($event, key)"
+          @update:search="onInput($event, 'property', key)"
         />
       </v-col>
       <v-col class="p-0 pr-3 pt-3">
         <div v-if="claim?.mainsnak?.property || qualifier.default">
           <item-value-base
             :key="`${qualifier.property}-${key}`"
-            :label="$t('common.value')"
+            :label="t('common.value')"
             :claim="claim"
             :value="qualifier"
             type="qualifier"
@@ -38,24 +39,24 @@
         </div>
       </v-col>
       <v-col class="p-0 pr-3 d-flex justify-end max-w-100">
-        <v-btn v-if="allowCreateQualifier(qualifier)" text icon @click.stop="createQualifier(key)">
-          <v-tooltip top>
-            <template #activator="{ on, attrs }">
-              <v-icon v-bind="attrs" v-on="on">
+        <v-btn v-if="allowCreateQualifier(qualifier)" variant="text" icon @click.stop="createQualifier(key)">
+          <v-tooltip location="top">
+            <template #activator="{ props: btnProps }">
+              <v-icon v-bind="btnProps">
                 mdi-check
               </v-icon>
             </template>
-            <span>{{ $t("common.save") }}</span>
+            <span>{{ t("common.save") }}</span>
           </v-tooltip>
         </v-btn>
-        <v-btn v-if="claim" text icon @click.stop="removeQualifier(key)">
-          <v-tooltip top>
-            <template #activator="{ on, attrs }">
-              <v-icon v-bind="attrs" v-on="on">
+        <v-btn v-if="claim" variant="text" icon @click.stop="removeQualifier(key)">
+          <v-tooltip location="top">
+            <template #activator="{ props: btnProps }">
+              <v-icon v-bind="btnProps">
                 mdi-trash-can
               </v-icon>
             </template>
-            <span>{{ $t("common.remove") }}</span>
+            <span>{{ t("common.remove") }}</span>
           </v-tooltip>
         </v-btn>
       </v-col>
@@ -70,135 +71,123 @@
           <v-icon color="primary">
             mdi-plus
           </v-icon>
-          <span>{{ $t("common.add_qualifier") }}</span>
+          <span>{{ t("common.add_qualifier") }}</span>
         </div>
       </a>
     </v-row>
   </div>
 </template>
 
-<script>
-export default {
-  props: {
-    claim: {
-      type: Object,
-      default: null
-    },
-    initialQualifiers: {
-      type: Array,
-      default: null
-    },
-    forCreate: {
-      type: Boolean,
-      default: false
-    }
-  },
-  data () {
-    return {
-      properties: [],
-      qualifiers: [],
-      propertyValues: []
-    }
-  },
-  computed: {
-    pbid () {
-      return this.$wikibase.constructor.PROPERTY_PBID
-    },
-    isAllowedAddQualifier () {
-      return this.claim && this.claim.mainsnak.property !== this.$wikibase.constructor.PROPERTY_NOTES
-    }
-  },
-  watch: {
-    qualifiers: {
-      handler (val) {
-        if (!this.claim || this.forCreate) {
-          this.$emit('update-qualifiers', val)
-        }
-      },
-      deep: true
-    }
-  },
-  created () {
-    if (this.initialQualifiers) {
-      this.initialQualifiers.forEach((qualifier, index) => {
-        this.$set(this.properties, index, [qualifier.property])
-        this.qualifiers.push(qualifier)
-      })
-    }
-  },
-  methods: {
-    allowCreateQualifier (qualifier) {
-      const propertyId = qualifier.property?.id || qualifier.property
-      return this.claim && !this.forCreate && propertyId && qualifier.datavalue?.value
-    },
-    onNewValue (event, qualifier) {
-      qualifier.datavalue.value = event
-    },
-    onChangeProperty (event, index) {
-      const qualifier = this.qualifiers[index]
-      // Keep the full property object for display, but track ID separately
-      qualifier.property = event ? { id: event.id, label: event.label, datatype: event.datatype } : null
-      qualifier.datatype = event?.datatype
-      qualifier.datavalue = {
-        value: null
+<script setup>
+import { computed, reactive, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { useAuthStore } from '~/stores/auth'
+import { WikibaseService } from '~/service/wikibase.service'
+
+const props = defineProps({
+  claim: { type: Object, default: null },
+  initialQualifiers: { type: Array, default: null },
+  forCreate: { type: Boolean, default: false }
+})
+
+const emit = defineEmits(['update-qualifiers', 'create-qualifier'])
+
+const { $notification, $wikibase } = useNuxtApp()
+const { t, locale } = useI18n()
+const authStore = useAuthStore()
+
+const properties = reactive([])
+const qualifiers = reactive([])
+const propertyValues = reactive([])
+
+const pbid = computed(() => WikibaseService.PROPERTY_PBID)
+const isAllowedAddQualifier = computed(() => props.claim && props.claim.mainsnak.property !== WikibaseService.PROPERTY_NOTES)
+
+if (props.initialQualifiers) {
+  props.initialQualifiers.forEach((qualifier, index) => {
+    properties[index] = [qualifier.property]
+    qualifiers.push(qualifier)
+  })
+}
+
+watch(qualifiers, (val) => {
+  if (!props.claim || props.forCreate) {
+    emit('update-qualifiers', val)
+  }
+}, { deep: true })
+
+function allowCreateQualifier (qualifier) {
+  const propertyId = qualifier.property?.id || qualifier.property
+  return props.claim && !props.forCreate && propertyId && qualifier.datavalue?.value
+}
+
+function onNewValue (event, qualifier) {
+  qualifier.datavalue.value = event
+}
+
+function onChangeProperty (event, index) {
+  const qualifier = qualifiers[index]
+  qualifier.property = event ? { id: event.id, label: event.label, datatype: event.datatype } : null
+  qualifier.datatype = event?.datatype
+  qualifier.datavalue = { value: null }
+}
+
+function addQualifier () {
+  qualifiers.push({
+    property: null,
+    datatype: null,
+    datavalue: { value: null }
+  })
+}
+
+function removeQualifier (index) {
+  qualifiers.splice(index, 1)
+  properties.splice(index, 1)
+  propertyValues.splice(index, 1)
+}
+
+async function onInput (value, type, index) {
+  if (value && typeof value === 'string') {
+    const search = await $wikibase.searchEntityByName(value, locale.value, locale.value, type)
+    if (search && search.length) {
+      if (type === 'property') {
+        properties[index] = search
+      } else {
+        propertyValues[index] = search
       }
-    },
-    addQualifier () {
-      this.qualifiers.push({
-        property: null,
-        datatype: null,
-        datavalue: {
-          value: null
-        }
-      })
-    },
-    removeQualifier (index) {
-      this.qualifiers.splice(index, 1)
-      this.properties.splice(index, 1)
-      this.propertyValues.splice(index, 1)
-    },
-    async onInput (value, type, index) {
-      if (value && typeof value === 'string') {
-        const search = await this.$wikibase.searchEntityByName(value, this.$i18n.locale, this.$i18n.locale, type)
-        if (search && search.length) {
-          if (type === 'property') {
-            this.$set(this.properties, index, search)
-          } else {
-            this.$set(this.propertyValues, index, search)
-          }
-        }
-      }
-    },
-    async createQualifier (index) {
-      const qualifier = this.qualifiers[index]
-      // Extract property ID - handle both object and string formats
-      const propertyId = qualifier.property?.id || qualifier.property
-      await this.$wikibase.getWbEdit().qualifier.add({
-        guid: this.claim.id,
-        value: qualifier.datavalue.value.id ?? qualifier.datavalue.value,
-        property: propertyId
-      }, this.$store.getters['auth/getRequestConfig']).then((res) => {
-        if (res.success) {
-          this.updateQualifiers(res.claim.qualifiers[qualifier.property])
-          this.removeQualifier(index)
-          this.$notification.success(this.$t('messages.success.updated'))
-        } else {
-          this.$notification.success(this.$t('messages.error.something_went_wrong'))
-        }
-      }).catch((error) => {
-        this.$notification.error(error)
-      })
-    },
-    updateQualifiers (qualifiers) {
-      this.$emit('create-qualifier', qualifiers)
-    },
-    acceptAll (item, queryText, itemText) {
-      // We accept all the items because they are already filtered
-      return true
     }
   }
 }
+
+async function createQualifier (index) {
+  const qualifier = qualifiers[index]
+  const propertyId = qualifier.property?.id || qualifier.property
+  await $wikibase.getWbEdit().qualifier.add({
+    guid: props.claim.id,
+    value: qualifier.datavalue.value.id ?? qualifier.datavalue.value,
+    property: propertyId
+  }, authStore.requestConfig).then((res) => {
+    if (res.success) {
+      updateQualifiers(res.claim.qualifiers[qualifier.property])
+      removeQualifier(index)
+      $notification.success(t('messages.success.updated'))
+    } else {
+      $notification.error(t('messages.error.something_went_wrong'))
+    }
+  }).catch((error) => {
+    $notification.error(error)
+  })
+}
+
+function updateQualifiers (qs) {
+  emit('create-qualifier', qs)
+}
+
+function acceptAll () {
+  return true
+}
 </script>
+
 <style scoped>
 .add-qualifier {
   margin-bottom: 5px;
@@ -212,7 +201,7 @@ export default {
 .max-w-100 {
   max-width: 100px !important;
 }
-::v-deep .v-text-field__details {
+:deep(.v-text-field__details) {
   display: none;
 }
 </style>

--- a/frontend/components/item/qualifier/List.vue
+++ b/frontend/components/item/qualifier/List.vue
@@ -10,36 +10,27 @@
   </div>
 </template>
 
-<script>
-export default {
-  props: {
-    claim: {
-      type: Object,
-      default: null
-    },
-    qualifiers: {
-      type: Array,
-      default: null
-    }
-  },
-  data () {
-    return {
-      values: []
-    }
-  },
-  mounted () {
-    this.values = [...this.qualifiers]
-  },
-  methods: {
-    deleteQualifier (data) {
-      const findIndex = this.values.findIndex(item => item.hash === data.hash)
+<script setup>
+import { onMounted, ref } from 'vue'
 
-      if (findIndex !== -1) {
-        this.values.splice(findIndex, 1)
-      }
+const props = defineProps({
+  claim: { type: Object, default: null },
+  qualifiers: { type: Array, default: null }
+})
 
-      this.$emit('delete-qualifier', data)
-    }
+const emit = defineEmits(['delete-qualifier'])
+
+const values = ref([])
+
+onMounted(() => {
+  values.value = [...props.qualifiers]
+})
+
+function deleteQualifier (data) {
+  const findIndex = values.value.findIndex(item => item.hash === data.hash)
+  if (findIndex !== -1) {
+    values.value.splice(findIndex, 1)
   }
+  emit('delete-qualifier', data)
 }
 </script>

--- a/frontend/components/item/qualifier/Value.vue
+++ b/frontend/components/item/qualifier/Value.vue
@@ -1,23 +1,16 @@
 <template>
   <div class="qualifier-value">
-    <item-value-base :claim="claim" :value="value" type="qualifier" @delete-qualifier="$emit('delete-qualifier', $event)" />
+    <item-value-base :claim="claim" :value="value" type="qualifier" @delete-qualifier="emit('delete-qualifier', $event)" />
   </div>
 </template>
 
-<script>
-export default {
+<script setup>
+defineProps({
+  value: { type: Object, default: null },
+  claim: { type: Object, default: null }
+})
 
-  props: {
-    value: {
-      type: Object,
-      default: null
-    },
-    claim: {
-      type: Object,
-      default: null
-    }
-  }
-}
+const emit = defineEmits(['delete-qualifier'])
 </script>
 
 <style scoped>

--- a/frontend/components/item/reference/Base.vue
+++ b/frontend/components/item/reference/Base.vue
@@ -1,12 +1,12 @@
 <template>
   <v-expansion-panels class="ma-2 pa-2 bg-gray none-z-index">
     <v-expansion-panel class="bg-gray">
-      <v-expansion-panel-header class="bg-gray header">
+      <v-expansion-panel-title class="bg-gray header">
         <p class="text-subtitle-2 mb-0 reference-header">
           {{ header }}
         </p>
-      </v-expansion-panel-header>
-      <v-expansion-panel-content class="bg-gray">
+      </v-expansion-panel-title>
+      <v-expansion-panel-text class="bg-gray">
         <item-reference-list
           v-for="reference in references"
           :key="`${reference.hash}-${references.length}`"
@@ -20,50 +20,39 @@
           :claim="claim"
           @create-reference="createReference($event)"
         />
-      </v-expansion-panel-content>
+      </v-expansion-panel-text>
     </v-expansion-panel>
   </v-expansion-panels>
 </template>
 
-<script>
-export default {
-  props: {
-    claim: {
-      type: Object,
-      required: true
-    }
-  },
-  data () {
-    return {
-      headers: [],
-      references: []
-    }
-  },
-  computed: {
-    isUserLogged () {
-      return this.$store.state.auth.isLogged
-    },
-    header () {
-      return `${this.referenceCount} reference${this.referenceCount === 1 ? '' : 's'}`
-    },
-    referenceCount () {
-      return Object.keys(this.references || {}).length
-    }
-  },
-  mounted () {
-    this.references = this.claim.references ?? []
-  },
-  methods: {
-    createReference (reference) {
-      this.references.push(reference)
-    },
-    deleteReference (data) {
-      const findIndex = this.references.findIndex(item => item.hash === data.hash)
+<script setup>
+import { computed, onMounted, ref } from 'vue'
+import { useAuthStore } from '~/stores/auth'
 
-      if (findIndex !== -1) {
-        this.references.splice(findIndex, 1)
-      }
-    }
+const props = defineProps({
+  claim: { type: Object, required: true }
+})
+
+const authStore = useAuthStore()
+
+const references = ref([])
+
+const isUserLogged = computed(() => authStore.isLogged)
+const referenceCount = computed(() => Object.keys(references.value || {}).length)
+const header = computed(() => `${referenceCount.value} reference${referenceCount.value === 1 ? '' : 's'}`)
+
+onMounted(() => {
+  references.value = props.claim.references ?? []
+})
+
+function createReference (reference) {
+  references.value.push(reference)
+}
+
+function deleteReference (data) {
+  const findIndex = references.value.findIndex(item => item.hash === data.hash)
+  if (findIndex !== -1) {
+    references.value.splice(findIndex, 1)
   }
 }
 </script>
@@ -86,7 +75,7 @@ export default {
   font-weight: normal !important;
 }
 
-::v-deep .v-expansion-panel-content__wrap {
+:deep(.v-expansion-panel-text__wrapper) {
   padding: 0 8px 0 8px;
 }
 </style>

--- a/frontend/components/item/reference/Create.vue
+++ b/frontend/components/item/reference/Create.vue
@@ -11,23 +11,24 @@
       <v-col class="p-0 pr-3">
         <v-autocomplete
           v-model="reference.property"
-          :label="$t('common.property')"
+          :label="t('common.property')"
           required
           return-object
           :items="properties[key]"
-          item-text="label"
+          item-title="label"
           item-value="id"
           variant="outlined"
+          density="compact"
           :filter="acceptAll"
-          @change="onChangeProperty($event, key)"
-          @update:search-input="onInput($event, 'property', key)"
+          @update:model-value="onChangeProperty($event, key)"
+          @update:search="onInput($event, 'property', key)"
         />
       </v-col>
       <v-col class="p-0 pr-3 pt-3">
         <div v-if="reference.property">
           <item-value-base
             :key="`${key}-${reference.property}`"
-            :label="$t('common.value')"
+            :label="t('common.value')"
             :claim="claim"
             :value="reference"
             type="reference"
@@ -38,28 +39,28 @@
       </v-col>
       <v-col class="p-0 pr-3 d-flex justify-end max-w-100">
         <v-btn
-          text
+          variant="text"
           icon
           :disabled="!reference.property || !reference?.datavalue?.value"
           @click.stop="createReference(key)"
         >
-          <v-tooltip top>
-            <template #activator="{ on, attrs }">
-              <v-icon v-bind="attrs" v-on="on">
+          <v-tooltip location="top">
+            <template #activator="{ props: btnProps }">
+              <v-icon v-bind="btnProps">
                 mdi-check
               </v-icon>
             </template>
-            <span>{{ $t("common.save") }}</span>
+            <span>{{ t("common.save") }}</span>
           </v-tooltip>
         </v-btn>
-        <v-btn v-if="claim" text icon @click.stop="removeReference(key)">
-          <v-tooltip top>
-            <template #activator="{ on, attrs }">
-              <v-icon v-bind="attrs" v-on="on">
+        <v-btn v-if="claim" variant="text" icon @click.stop="removeReference(key)">
+          <v-tooltip location="top">
+            <template #activator="{ props: btnProps }">
+              <v-icon v-bind="btnProps">
                 mdi-trash-can
               </v-icon>
             </template>
-            <span>{{ $t("common.remove") }}</span>
+            <span>{{ t("common.remove") }}</span>
           </v-tooltip>
         </v-btn>
       </v-col>
@@ -73,131 +74,128 @@
           <v-icon color="primary">
             mdi-plus
           </v-icon>
-          <span>{{ !value ? $t("common.add_reference") : $t("common.add") }}</span>
+          <span>{{ !value ? t("common.add_reference") : t("common.add") }}</span>
         </div>
       </a>
     </v-row>
   </div>
 </template>
 
-<script>
-export default {
-  props: {
-    claim: {
-      type: Object,
-      required: true
-    },
-    value: {
-      type: Object,
-      default: null
-    }
-  },
-  data () {
-    return {
-      properties: [],
-      references: [],
-      propertyValues: []
-    }
-  },
-  watch: {
-    references: {
-      handler (val) {
-        if (!this.claim) {
-          this.$emit('update-references', val)
-        }
-      },
-      deep: true
-    }
-  },
-  methods: {
-    onNewValue (event, reference) {
-      reference.datavalue.value = event
-    },
-    onChangeProperty (event, index) {
-      const reference = this.references[index]
-      reference.property = event.id
-      reference.datatype = event.datatype
-      reference.datavalue = {
-        value: null
-      }
-    },
-    addReference () {
-      this.references.push({
-        property: null,
-        type: null,
-        datavalue: {
-          value: null
-        }
-      })
-    },
-    removeReference (index) {
-      this.references.splice(index, 1)
-      this.properties.splice(index, 1)
-      this.propertyValues.splice(index, 1)
-    },
-    async onInput (value, type, index) {
-      if (value && typeof value === 'string') {
-        const search = await this.$wikibase.searchEntityByName(value, this.$i18n.locale, this.$i18n.locale, type)
-        if (search && search.length) {
-          if (type === 'property') {
-            this.$set(this.properties, index, search)
-          } else {
-            this.$set(this.propertyValues, index, search)
-          }
-        }
-      }
-    },
-    async createReference (index) {
-      let data
-      const reference = this.references[index]
+<script setup>
+import { reactive, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { useAuthStore } from '~/stores/auth'
 
-      if (!this.value) {
-        data = {
-          guid: this.claim.id,
-          value: reference.datavalue.value.id ?? reference.datavalue.value,
-          property: reference.property
-        }
+const props = defineProps({
+  claim: { type: Object, required: true },
+  value: { type: Object, default: null }
+})
+
+const emit = defineEmits(['update-references', 'create-reference'])
+
+const { $notification, $wikibase } = useNuxtApp()
+const { t, locale } = useI18n()
+const authStore = useAuthStore()
+
+const properties = reactive([])
+const references = reactive([])
+const propertyValues = reactive([])
+
+watch(references, (val) => {
+  if (!props.claim) {
+    emit('update-references', val)
+  }
+}, { deep: true })
+
+function onNewValue (event, reference) {
+  reference.datavalue.value = event
+}
+
+function onChangeProperty (event, index) {
+  const reference = references[index]
+  reference.property = event.id
+  reference.datatype = event.datatype
+  reference.datavalue = { value: null }
+}
+
+function addReference () {
+  references.push({
+    property: null,
+    type: null,
+    datavalue: { value: null }
+  })
+}
+
+function removeReference (index) {
+  references.splice(index, 1)
+  properties.splice(index, 1)
+  propertyValues.splice(index, 1)
+}
+
+async function onInput (value, type, index) {
+  if (value && typeof value === 'string') {
+    const search = await $wikibase.searchEntityByName(value, locale.value, locale.value, type)
+    if (search && search.length) {
+      if (type === 'property') {
+        properties[index] = search
       } else {
-        const values = {
-          ...this.value.snaks,
-          [reference.property]: [...(this.value.snaks[reference.property] || []), reference]
-        }
-
-        const formattedSnaks = Object.entries(values).reduce((acc, [key, values]) => {
-          acc[key] = values.map(v => v.datavalue.value.id ?? v.datavalue.value)
-          return acc
-        }, {})
-        data = {
-          guid: this.claim.id,
-          snaks: formattedSnaks,
-          hash: this.value.hash,
-          property: this.value.property
-        }
+        propertyValues[index] = search
       }
-
-      await this.$wikibase.getWbEdit().reference.add(data, this.$store.getters['auth/getRequestConfig'])
-        .then((res) => {
-          if (res.success) {
-            this.updateReferences(res.reference)
-            this.removeReference(index)
-            this.$notification.success(this.$t('messages.success.updated'))
-          } else {
-            this.$notification.success(this.$t('messages.error.something_went_wrong'))
-          }
-        }).catch((error) => {
-          this.$notification.error(error)
-        })
-    },
-    updateReferences (reference) {
-      this.$emit('create-reference', reference)
-    },
-    acceptAll (item, queryText, itemText) {
-      // We accept all the items because they are already filtered
-      return true
     }
   }
 }
+
+async function createReference (index) {
+  let data
+  const reference = references[index]
+
+  if (!props.value) {
+    data = {
+      guid: props.claim.id,
+      value: reference.datavalue.value.id ?? reference.datavalue.value,
+      property: reference.property
+    }
+  } else {
+    const values = {
+      ...props.value.snaks,
+      [reference.property]: [...(props.value.snaks[reference.property] || []), reference]
+    }
+
+    const formattedSnaks = Object.entries(values).reduce((acc, [key, vs]) => {
+      acc[key] = vs.map(v => v.datavalue.value.id ?? v.datavalue.value)
+      return acc
+    }, {})
+    data = {
+      guid: props.claim.id,
+      snaks: formattedSnaks,
+      hash: props.value.hash,
+      property: props.value.property
+    }
+  }
+
+  await $wikibase.getWbEdit().reference.add(data, authStore.requestConfig)
+    .then((res) => {
+      if (res.success) {
+        updateReferences(res.reference)
+        removeReference(index)
+        $notification.success(t('messages.success.updated'))
+      } else {
+        $notification.error(t('messages.error.something_went_wrong'))
+      }
+    }).catch((error) => {
+      $notification.error(error)
+    })
+}
+
+function updateReferences (reference) {
+  emit('create-reference', reference)
+}
+
+function acceptAll () {
+  return true
+}
 </script>
+
 <style scoped>
 .add-reference {
   margin-bottom: 5px;
@@ -208,7 +206,7 @@ export default {
 .max-w-100 {
   max-width: 100px !important;
 }
-::v-deep .v-text-field__details {
+:deep(.v-text-field__details) {
   display: none;
 }
 </style>

--- a/frontend/components/item/reference/List.vue
+++ b/frontend/components/item/reference/List.vue
@@ -21,12 +21,11 @@
             :values="item.data"
             :reference="valueToView"
             @create-reference="updateReference($event)"
-            @delete-reference="$emit('delete-reference', $event)"
+            @delete-reference="emit('delete-reference', $event)"
           />
         </td>
       </tr>
     </template>
-    <!-- eslint-disable-next-line vue/valid-v-slot -->
     <template v-if="isUserLogged" #body.append>
       <tr>
         <td :colspan="2" class="full-width">
@@ -43,64 +42,63 @@
   </v-data-table>
 </template>
 
-<script>
-export default {
-  props: {
-    claim: {
-      type: Object,
-      required: true
-    },
-    value: {
-      type: Object,
-      required: true
-    }
-  },
-  data () {
-    return {
-      properties: [],
-      valueToView: null
-    }
-  },
-  computed: {
-    isUserLogged () {
-      return this.$store.state.auth.isLogged
-    },
-    snaks () {
-      return Object.entries(this.valueToView.snaks).map(([key, value]) => ({
-        property: key,
-        propertyLabel: this.properties.find(item => item.property === key)?.label || key,
-        data: value.map(item => ({
-          ...item,
-          reference_hash: this.valueToView.hash
-        }))
-      }))
-    }
-  },
-  async mounted () {
-    this.valueToView = this.value
-    await this.getProperties()
-  },
-  methods: {
-    async getProperties () {
-      const referenceKeys = Object.keys(this.valueToView.snaks ?? {})
+<script setup>
+import { computed, onMounted, ref } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { useAuthStore } from '~/stores/auth'
 
-      const referenceKeysOrdered = Array.from(referenceKeys).sort((a, b) => {
-        return this.valueToView['snaks-order'] ? this.valueToView['snaks-order'].indexOf(a) - this.valueToView['snaks-order'].indexOf(b) : -1
-      })
-      const headerPromises = Array.from(referenceKeysOrdered).map(async (property) => {
-        const entity = await this.$wikibase.getEntity(property, this.$i18n.locale)
-        return {
-          property,
-          label: this.$wikibase.getValueByLang(entity.labels, this.$i18n.locale)
-        }
-      })
-      this.properties = await Promise.all(headerPromises)
-    },
-    async updateReference (data) {
-      this.valueToView = data.reference ?? data
-      await this.getProperties()
+const props = defineProps({
+  claim: { type: Object, required: true },
+  value: { type: Object, required: true }
+})
+
+const emit = defineEmits(['delete-reference'])
+
+const { $wikibase } = useNuxtApp()
+const { locale } = useI18n()
+const authStore = useAuthStore()
+
+const properties = ref([])
+const valueToView = ref(null)
+
+const isUserLogged = computed(() => authStore.isLogged)
+
+const snaks = computed(() => {
+  if (!valueToView.value) { return [] }
+  return Object.entries(valueToView.value.snaks).map(([key, value]) => ({
+    property: key,
+    propertyLabel: properties.value.find(item => item.property === key)?.label || key,
+    data: value.map(item => ({
+      ...item,
+      reference_hash: valueToView.value.hash
+    }))
+  }))
+})
+
+onMounted(async () => {
+  valueToView.value = props.value
+  await getProperties()
+})
+
+async function getProperties () {
+  const referenceKeys = Object.keys(valueToView.value.snaks ?? {})
+
+  const referenceKeysOrdered = Array.from(referenceKeys).sort((a, b) => {
+    return valueToView.value['snaks-order'] ? valueToView.value['snaks-order'].indexOf(a) - valueToView.value['snaks-order'].indexOf(b) : -1
+  })
+  const headerPromises = referenceKeysOrdered.map(async (property) => {
+    const entity = await $wikibase.getEntity(property, locale.value)
+    return {
+      property,
+      label: $wikibase.getValueByLang(entity.labels, locale.value)
     }
-  }
+  })
+  properties.value = await Promise.all(headerPromises)
+}
+
+async function updateReference (data) {
+  valueToView.value = data.reference ?? data
+  await getProperties()
 }
 </script>
 
@@ -112,7 +110,6 @@ export default {
 .table-row {
   background-color: rgb(247, 245, 245);
 }
-.w-100
 .table-cell {
   border: none;
   word-wrap: break-word;

--- a/frontend/components/item/reference/Value.vue
+++ b/frontend/components/item/reference/Value.vue
@@ -5,29 +5,20 @@
       :value="value"
       type="reference"
       :reference="reference"
-      @create-reference="$emit('create-reference', $event)"
-      @delete-reference="$emit('delete-reference', $event)"
+      @create-reference="emit('create-reference', $event)"
+      @delete-reference="emit('delete-reference', $event)"
     />
   </div>
 </template>
 
-<script>
-export default {
-  props: {
-    claim: {
-      type: Object,
-      required: true
-    },
-    reference: {
-      type: Object,
-      required: true
-    },
-    value: {
-      type: Object,
-      required: true
-    }
-  }
-}
+<script setup>
+defineProps({
+  claim: { type: Object, required: true },
+  reference: { type: Object, required: true },
+  value: { type: Object, required: true }
+})
+
+const emit = defineEmits(['create-reference', 'delete-reference'])
 </script>
 
 <style scoped>

--- a/frontend/components/item/reference/Values.vue
+++ b/frontend/components/item/reference/Values.vue
@@ -6,27 +6,18 @@
       :claim="claim"
       :value="value"
       :reference="reference"
-      @create-reference="$emit('create-reference', $event)"
-      @delete-reference="$emit('delete-reference', $event)"
+      @create-reference="emit('create-reference', $event)"
+      @delete-reference="emit('delete-reference', $event)"
     />
   </div>
 </template>
 
-<script>
-export default {
-  props: {
-    claim: {
-      type: Object,
-      required: true
-    },
-    reference: {
-      type: Object,
-      required: true
-    },
-    values: {
-      type: Array,
-      required: true
-    }
-  }
-}
+<script setup>
+defineProps({
+  claim: { type: Object, required: true },
+  reference: { type: Object, required: true },
+  values: { type: Array, required: true }
+})
+
+const emit = defineEmits(['create-reference', 'delete-reference'])
 </script>

--- a/frontend/components/item/related/Ritem.vue
+++ b/frontend/components/item/related/Ritem.vue
@@ -1,81 +1,63 @@
 <template>
   <v-expansion-panels class="mb-2">
     <v-expansion-panel class="cnum">
-      <v-expansion-panel-header class="cnum">
+      <v-expansion-panel-title class="cnum">
         <div>
           <span class="mb-0 ml-3">#{{ index + 1 }}</span>
-          <NuxtLink class="ml-1 black--text" :to="url">
+          <NuxtLink class="ml-1 text-black" :to="url">
             <span>{{ pbid }}</span>
           </NuxtLink>
           <span class="ml-1">
             <item-util-view-text-lang :value="label" />
           </span>
         </div>
-      </v-expansion-panel-header>
-      <v-expansion-panel-content>
+      </v-expansion-panel-title>
+      <v-expansion-panel-text>
         <div>
           <item-claims :table="table" :item="item" :claims="claims" />
         </div>
-      </v-expansion-panel-content>
+      </v-expansion-panel-text>
     </v-expansion-panel>
   </v-expansion-panels>
 </template>
 
-<script>
-export default {
-  inheritAttrs: false,
-  props: {
-    table: {
-      type: String,
-      required: true
-    },
-    value: {
-      type: Object,
-      default: null
-    },
-    index: {
-      type: Number,
-      default: null
-    }
-  },
+<script setup>
+import { computed, onMounted, ref } from 'vue'
+import { useI18n } from 'vue-i18n'
 
-  data () {
-    return {
-      label: null,
-      item: null,
-      claims: null
-    }
-  },
+defineOptions({ inheritAttrs: false })
 
-  computed: {
-    pbid () {
-      return this.value.item_pbid
-    },
-    url () {
-      return this.localePath(`/item/${this.value.item}`)
-    }
-  },
+const props = defineProps({
+  table: { type: String, required: true },
+  value: { type: Object, default: null },
+  index: { type: Number, default: null }
+})
 
-  async mounted () {
-    if (this.value.item) {
-      await this.getEntity()
-    }
-  },
+const { $notification, $wikibase } = useNuxtApp()
+const { locale } = useI18n()
+const localePath = useLocalePath()
 
-  methods: {
-    async getEntity () {
-      try {
-        await this.$wikibase
-          .getEntity(this.value.item, this.$i18n.locale)
-          .then(async (entity) => {
-            this.item = entity
-            this.claims = await this.$wikibase.getOrderedClaims(this.table, entity.claims)
-            this.label = this.$wikibase.getValueByLang(this.item.labels, this.$i18n.locale)
-          })
-      } catch (err) {
-        this.$notification.error(err)
-      }
-    }
+const label = ref(null)
+const item = ref(null)
+const claims = ref(null)
+
+const pbid = computed(() => props.value.item_pbid)
+const url = computed(() => localePath(`/item/${props.value.item}`))
+
+onMounted(async () => {
+  if (props.value.item) {
+    await getEntity()
+  }
+})
+
+async function getEntity () {
+  try {
+    const entity = await $wikibase.getEntity(props.value.item, locale.value)
+    item.value = entity
+    claims.value = await $wikibase.getOrderedClaims(props.table, entity.claims)
+    label.value = $wikibase.getValueByLang(entity.labels, locale.value)
+  } catch (err) {
+    $notification.error(err)
   }
 }
 </script>

--- a/frontend/components/item/related/Table.vue
+++ b/frontend/components/item/related/Table.vue
@@ -1,13 +1,13 @@
 <template>
   <v-container v-if="items.length" class="mt-2">
-    <div class="grey--text">
-      {{ $t(references.label) }} : {{ totalResults }} {{ $t('common.items') }}
+    <div class="text-grey">
+      {{ t(references.label) }} : {{ totalResults }} {{ t('common.items') }}
     </div>
     <item-related-ritem
       v-for="(value, index) in items"
       :key="`related-item-${index}-${value.item}`"
       :table="table"
-      :index="index + ((currentPage -1) * resultsPerPage)"
+      :index="index + ((currentPage - 1) * resultsPerPage)"
       :value="value"
       class="mt-2"
     />
@@ -17,52 +17,46 @@
         v-model="currentPage"
         :length="Math.ceil(totalResults / resultsPerPage)"
         :total-visible="5"
-        circle
-        @input="changePage"
+        @update:model-value="changePage"
       />
     </div>
   </v-container>
 </template>
 
-<script>
-export default {
-  props: {
-    itemId: {
-      type: String,
-      default: null
-    },
-    table: {
-      type: String,
-      required: true
-    },
-    references: {
-      type: Object,
-      default: null
-    }
-  },
-  data () {
-    return {
-      items: [],
-      currentPage: 1,
-      totalResults: 0,
-      resultsPerPage: 10
-    }
-  },
-  async mounted () {
-    if (this.itemId) {
-      this.count()
-      this.items = await this.$wikibase.getRelatedItems(this.itemId, this.references.refTables, this.currentPage, this.resultsPerPage)
-      this.$emit('has-related-table', this.items.length > 0)
-    }
-  },
-  methods: {
-    count () {
-      this.$wikibase.runSparqlQuery(this.$wikibase.$query.getRelatedItemsCount(this.itemId, this.references.refTables), true)
-        .then((results) => { this.totalResults = results[0] })
-    },
-    async changePage () {
-      this.items = await this.$wikibase.getRelatedItems(this.itemId, this.references.refTables, this.currentPage, this.resultsPerPage)
-    }
+<script setup>
+import { onMounted, ref } from 'vue'
+import { useI18n } from 'vue-i18n'
+
+const props = defineProps({
+  itemId: { type: String, default: null },
+  table: { type: String, required: true },
+  references: { type: Object, default: null }
+})
+
+const emit = defineEmits(['has-related-table'])
+
+const { $wikibase } = useNuxtApp()
+const { t } = useI18n()
+
+const items = ref([])
+const currentPage = ref(1)
+const totalResults = ref(0)
+const resultsPerPage = 10
+
+onMounted(async () => {
+  if (props.itemId) {
+    count()
+    items.value = await $wikibase.getRelatedItems(props.itemId, props.references.refTables, currentPage.value, resultsPerPage)
+    emit('has-related-table', items.value.length > 0)
   }
+})
+
+function count () {
+  $wikibase.runSparqlQuery($wikibase.$query.getRelatedItemsCount(props.itemId, props.references.refTables), true)
+    .then((results) => { totalResults.value = results[0] })
+}
+
+async function changePage () {
+  items.value = await $wikibase.getRelatedItems(props.itemId, props.references.refTables, currentPage.value, resultsPerPage)
 }
 </script>

--- a/frontend/components/item/related/Tables.vue
+++ b/frontend/components/item/related/Tables.vue
@@ -11,400 +11,393 @@
   </div>
 </template>
 
-<script>
-export default {
-  props: {
-    itemId: {
-      type: String,
-      default: null
+<script setup>
+import { ref } from 'vue'
+
+const props = defineProps({
+  itemId: { type: String, default: null },
+  table: { type: String, required: true }
+})
+
+const emit = defineEmits(['has-related-table'])
+
+const hasRelatedTables = ref(false)
+
+const relatedTables = {
+  manid: [
+    {
+      label: 'item.related.manid.related_ms_ed',
+      refTables: [
+        { refTable: 'bioid', property: 'P750' },
+        { refTable: 'cnum', property: 'P750' },
+        { refTable: 'copid', property: 'P750' },
+        { refTable: 'geoid', property: 'P740' },
+        { refTable: 'insid', property: 'P750' },
+        { refTable: 'manid', property: 'P750' },
+        { refTable: 'texid', property: 'P750' }
+      ]
     },
-    table: {
-      type: String,
-      required: true
+    {
+      label: 'item.related.manid.manuscript_edition',
+      refTables: [
+        { refTable: 'cnum', property: 'P8' }
+      ]
+    },
+    {
+      label: 'item.related.manid.text',
+      refTables: [
+        { refTable: 'copid', property: 'P839' }
+      ]
     }
-  },
-  data () {
-    return {
-      hasRelatedTables: false,
-      relatedTables: {
-        manid: [
-          {
-            label: 'item.related.manid.related_ms_ed',
-            refTables: [
-              { refTable: 'bioid', property: 'P750' },
-              { refTable: 'cnum', property: 'P750' },
-              { refTable: 'copid', property: 'P750' },
-              { refTable: 'geoid', property: 'P740' },
-              { refTable: 'insid', property: 'P750' },
-              { refTable: 'manid', property: 'P750' },
-              { refTable: 'texid', property: 'P750' }
-            ]
-          },
-          {
-            label: 'item.related.manid.manuscript_edition',
-            refTables: [
-              { refTable: 'cnum', property: 'P8' }
-            ]
-          },
-          {
-            label: 'item.related.manid.text',
-            refTables: [
-              { refTable: 'copid', property: 'P839' }
-            ]
-          }
-        ],
-        texid: [
-          {
-            label: 'item.related.texid.uniform_title',
-            refTables: [
-              { refTable: 'cnum', property: 'P590' }
-            ]
-          },
-          {
-            label: 'item.related.texid.related_uniform_titles',
-            refTables: [
-              { refTable: 'manid', property: 'P9' },
-              { refTable: 'texid', property: 'P740' },
-              { refTable: 'cnum', property: 'P740' }
-            ]
-          }
-        ],
-        bibid: [
-          {
-            label: 'item.related.bibid.related_bibliography',
-            refTables: [
-              { refTable: 'bibid', property: 'P12' },
-              { refTable: 'bioid', property: 'P12' },
-              { refTable: 'cnum', property: 'P12' },
-              { refTable: 'copid', property: 'P12' },
-              { refTable: 'geoid', property: 'P12' },
-              { refTable: 'insid', property: 'P12' },
-              { refTable: 'libid', property: 'P12' },
-              { refTable: 'manid', property: 'P12' },
-              { refTable: 'subid', property: 'P12' },
-              { refTable: 'texid', property: 'P12' }
-            ]
-          }
-        ],
-        bioid: [
-          {
-            label: 'item.related.bioid.subject_references',
-            refTables: [
-              { refTable: 'bibid', property: 'P243' },
-              { refTable: 'bioid', property: 'P243' },
-              { refTable: 'copid', property: 'P243' },
-              { refTable: 'copid', property: 'P243' },
-              { refTable: 'geoid', property: 'P243' },
-              { refTable: 'geoid', property: 'P243' },
-              { refTable: 'insid', property: 'P243' },
-              { refTable: 'libid', property: 'P243' },
-              { refTable: 'manid', property: 'P243' },
-              { refTable: 'texid', property: 'P243' }
-            ]
-          },
-          {
-            label: 'item.related.bioid.authors',
-            refTables: [
-              { refTable: 'texid', property: 'P21' }
-            ]
-          },
-          {
-            label: 'item.related.bioid.commentary',
-            refTables: [
-              { refTable: 'cnum', property: 'P11', qualifier: 'P21' }
-            ]
-          },
-          {
-            label: 'item.related.bioid.financed_by',
-            refTables: [
-              { refTable: 'manid', property: 'P67' }
-            ]
-          },
-          {
-            label: 'item.related.bioid.former_owners',
-            refTables: [
-              { refTable: 'copid', property: 'P229' },
-              { refTable: 'copid', property: 'P229', qualifier: 'P703' }
-            ]
-          },
-          {
-            label: 'item.related.bioid.handwritten_by',
-            refTables: [
-              { refTable: 'manid', property: 'P25' }
-            ]
-          },
-          {
-            label: 'item.related.bioid.milestones',
-            refTables: [
-              { refTable: 'manid', property: 'P536', qualifier: 'P25' },
-              { refTable: 'manid', property: 'P222', qualifier: 'P207' }
-            ]
-          },
-          {
-            label: 'item.related.bioid.owner',
-            refTables: [
-              { refTable: 'manid', property: 'P229' }
-            ]
-          },
-          {
-            label: 'item.related.bioid.printed_by',
-            refTables: [
-              { refTable: 'manid', property: 'P207' }
-            ]
-          },
-          {
-            label: 'item.related.bioid.related_individuals',
-            refTables: [
-              { refTable: 'bioid', property: 'P703' },
-              { refTable: 'cnum', property: 'P703' },
-              { refTable: 'copid', property: 'P703' },
-              { refTable: 'manid', property: 'P703' },
-              { refTable: 'texid', property: 'P703' },
-              { refTable: 'texid', property: 'P33' }
-            ]
-          },
-          {
-            label: 'item.related.bioid.translator',
-            refTables: [
-              { refTable: 'texid', property: 'P24' }
-            ]
-          }
-        ],
-        copid: [
-          {
-            label: 'item.related.copid.related_copies',
-            refTables: [
-              { refTable: 'copid', property: 'P750' }
-            ]
-          }
-        ],
-        geoid: [
-          {
-            label: 'item.related.geoid.career_statement',
-            refTables: [
-              { refTable: 'bioid', property: 'P165', qualifier: 'P47' }
-            ]
-          },
-          {
-            label: 'item.related.geoid.first_known_date',
-            refTables: [
-              { refTable: 'bioid', property: 'P291', qualifier: 'P47' }
-            ]
-          },
-          {
-            label: 'item.related.geoid.former_owners',
-            refTables: [
-              { refTable: 'copid', property: 'P229', qualifier: 'P47' }
-            ]
-          },
-          {
-            label: 'item.related.geoid.from_place',
-            refTables: [
-              { refTable: 'bioid', property: 'P295', qualifier: 'P47' }
-            ]
-          },
-          {
-            label: 'item.related.geoid.history',
-            refTables: [
-              { refTable: 'copid', property: 'P137', qualifier: 'P47' },
-              { refTable: 'manid', property: 'P137', qualifier: 'P47' },
-              { refTable: 'texid', property: 'P137', qualifier: 'P47' }
-            ]
-          },
-          {
-            label: 'item.related.geoid.itinerary',
-            refTables: [
-              { refTable: 'bioid', property: 'P296', qualifier: 'P47' }
-            ]
-          },
-          {
-            label: 'item.related.geoid.last_known_date',
-            refTables: [
-              { refTable: 'bioid', property: 'P292', qualifier: 'P47' }
-            ]
-          },
-          {
-            label: 'item.related.geoid.location',
-            refTables: [
-              { refTable: 'manid', property: 'P47' }
-            ]
-          },
-          {
-            label: 'item.related.geoid.milestones',
-            refTables: [
-              { refTable: 'bioid', property: 'P137', qualifier: 'P47' },
-              { refTable: 'insid', property: 'P137', qualifier: 'P47' },
-              { refTable: 'manid', property: 'P536', qualifier: 'P47' },
-              { refTable: 'manid', property: 'P222', qualifier: 'P47' }
-            ]
-          },
-          {
-            label: 'item.related.geoid.owner',
-            refTables: [
-              { refTable: 'manid', property: 'P229', qualifier: 'P47' }
-            ]
-          },
-          {
-            label: 'item.related.geoid.place_of_birth',
-            refTables: [
-              { refTable: 'bioid', property: 'P82', qualifier: 'P47' }
-            ]
-          },
-          {
-            label: 'item.related.geoid.place_of_death',
-            refTables: [
-              { refTable: 'bioid', property: 'P168', qualifier: 'P47' }
-            ]
-          },
-          {
-            label: 'item.related.geoid.place_of_publication',
-            refTables: [
-              { refTable: 'manid', property: 'P47' }
-            ]
-          },
-          {
-            label: 'item.related.geoid.related_places',
-            refTables: [
-              { refTable: 'geoid', property: 'P297' },
-              { refTable: 'geoid', property: 'P493' },
-              { refTable: 'insid', property: 'P297', qualifier: 'P47' },
-              { refTable: 'libid', property: 'P47' }
-            ]
-          },
-          {
-            label: 'item.related.geoid.religious_background',
-            refTables: [
-              { refTable: 'bioid', property: 'P172', qualifier: 'P47' }
-            ]
-          },
-          {
-            label: 'item.related.geoid.religious_order',
-            refTables: [
-              { refTable: 'bioid', property: 'P746', qualifier: 'P47' }
-            ]
-          },
-          {
-            label: 'item.related.geoid.subject_references',
-            refTables: [
-              { refTable: 'bibid', property: 'P243' },
-              { refTable: 'bioid', property: 'P243' },
-              { refTable: 'copid', property: 'P243' },
-              { refTable: 'geoid', property: 'P243' },
-              { refTable: 'insid', property: 'P243' },
-              { refTable: 'libid', property: 'P243' },
-              { refTable: 'manid', property: 'P243' },
-              { refTable: 'texid', property: 'P243' }
-            ]
-          }
-        ],
-        insid: [
-          {
-            label: 'item.related.insid.authors',
-            refTables: [
-              { refTable: 'texid', property: 'P232' }
-            ]
-          },
-          {
-            label: 'item.related.insid.financed_by',
-            refTables: [
-              { refTable: 'manid', property: 'P67' }
-            ]
-          },
-          {
-            label: 'item.related.insid.former_owners',
-            refTables: [
-              { refTable: 'copid', property: 'P229', qualifier: 'P232' }
-            ]
-          },
-          {
-            label: 'item.related.insid.handwritten_by',
-            refTables: [
-              { refTable: 'manid', property: 'P25' }
-            ]
-          },
-          {
-            label: 'item.related.insid.milestones',
-            refTables: [
-              { refTable: 'manid', property: 'P536', qualifier: 'P25' },
-              { refTable: 'manid', property: 'P222', qualifier: 'P207' }
-            ]
-          },
-          {
-            label: 'item.related.insid.owner',
-            refTables: [
-              { refTable: 'manid', property: 'P229' }
-            ]
-          },
-          {
-            label: 'item.related.insid.printed_by',
-            refTables: [
-              { refTable: 'manid', property: 'P207' }
-            ]
-          },
-          {
-            label: 'item.related.insid.related_individuals',
-            refTables: [
-              { refTable: 'bioid', property: 'P703' }
-            ]
-          },
-          {
-            label: 'item.related.insid.related_institutions',
-            refTables: [
-              { refTable: 'insid', property: 'P232' },
-              { refTable: 'libid', property: 'P232' }
-            ]
-          },
-          {
-            label: 'item.related.insid.work_context',
-            refTables: [
-              { refTable: 'texid', property: 'P590' }
-            ]
-          },
-          {
-            label: 'item.related.insid.subject_references',
-            refTables: [
-              { refTable: 'subid', property: 'P243' }
-            ]
-          }
-        ],
-        libid: [
-          {
-            label: 'item.related.libid.related_libraries',
-            refTables: [
-              { refTable: 'bibid', property: 'P329' }
-            ]
-          },
-          {
-            label: 'item.related.libid.present_holding',
-            refTables: [
-              { refTable: 'manid', property: 'P329' }
-            ]
-          }
-        ],
-        subid: [
-          {
-            label: 'item.related.subid.subject_references',
-            refTables: [
-              { refTable: 'bibid', property: 'P243' },
-              { refTable: 'bioid', property: 'P243' },
-              { refTable: 'cnum', property: 'P243' },
-              { refTable: 'insid', property: 'P243' },
-              { refTable: 'libid', property: 'P243' },
-              { refTable: 'manid', property: 'P243' },
-              { refTable: 'texid', property: 'P243' }
-            ]
-          }
-        ]
-      }
+  ],
+  texid: [
+    {
+      label: 'item.related.texid.uniform_title',
+      refTables: [
+        { refTable: 'cnum', property: 'P590' }
+      ]
+    },
+    {
+      label: 'item.related.texid.related_uniform_titles',
+      refTables: [
+        { refTable: 'manid', property: 'P9' },
+        { refTable: 'texid', property: 'P740' },
+        { refTable: 'cnum', property: 'P740' }
+      ]
     }
-  },
-  methods: {
-    emitHasRelatedTable (hasRelatedTable) {
-      if (!this.hasRelatedTables && hasRelatedTable) {
-        this.hasRelatedTables = true
-      }
-      this.$emit('has-related-table', this.hasRelatedTables)
+  ],
+  bibid: [
+    {
+      label: 'item.related.bibid.related_bibliography',
+      refTables: [
+        { refTable: 'bibid', property: 'P12' },
+        { refTable: 'bioid', property: 'P12' },
+        { refTable: 'cnum', property: 'P12' },
+        { refTable: 'copid', property: 'P12' },
+        { refTable: 'geoid', property: 'P12' },
+        { refTable: 'insid', property: 'P12' },
+        { refTable: 'libid', property: 'P12' },
+        { refTable: 'manid', property: 'P12' },
+        { refTable: 'subid', property: 'P12' },
+        { refTable: 'texid', property: 'P12' }
+      ]
     }
+  ],
+  bioid: [
+    {
+      label: 'item.related.bioid.subject_references',
+      refTables: [
+        { refTable: 'bibid', property: 'P243' },
+        { refTable: 'bioid', property: 'P243' },
+        { refTable: 'copid', property: 'P243' },
+        { refTable: 'copid', property: 'P243' },
+        { refTable: 'geoid', property: 'P243' },
+        { refTable: 'geoid', property: 'P243' },
+        { refTable: 'insid', property: 'P243' },
+        { refTable: 'libid', property: 'P243' },
+        { refTable: 'manid', property: 'P243' },
+        { refTable: 'texid', property: 'P243' }
+      ]
+    },
+    {
+      label: 'item.related.bioid.authors',
+      refTables: [
+        { refTable: 'texid', property: 'P21' }
+      ]
+    },
+    {
+      label: 'item.related.bioid.commentary',
+      refTables: [
+        { refTable: 'cnum', property: 'P11', qualifier: 'P21' }
+      ]
+    },
+    {
+      label: 'item.related.bioid.financed_by',
+      refTables: [
+        { refTable: 'manid', property: 'P67' }
+      ]
+    },
+    {
+      label: 'item.related.bioid.former_owners',
+      refTables: [
+        { refTable: 'copid', property: 'P229' },
+        { refTable: 'copid', property: 'P229', qualifier: 'P703' }
+      ]
+    },
+    {
+      label: 'item.related.bioid.handwritten_by',
+      refTables: [
+        { refTable: 'manid', property: 'P25' }
+      ]
+    },
+    {
+      label: 'item.related.bioid.milestones',
+      refTables: [
+        { refTable: 'manid', property: 'P536', qualifier: 'P25' },
+        { refTable: 'manid', property: 'P222', qualifier: 'P207' }
+      ]
+    },
+    {
+      label: 'item.related.bioid.owner',
+      refTables: [
+        { refTable: 'manid', property: 'P229' }
+      ]
+    },
+    {
+      label: 'item.related.bioid.printed_by',
+      refTables: [
+        { refTable: 'manid', property: 'P207' }
+      ]
+    },
+    {
+      label: 'item.related.bioid.related_individuals',
+      refTables: [
+        { refTable: 'bioid', property: 'P703' },
+        { refTable: 'cnum', property: 'P703' },
+        { refTable: 'copid', property: 'P703' },
+        { refTable: 'manid', property: 'P703' },
+        { refTable: 'texid', property: 'P703' },
+        { refTable: 'texid', property: 'P33' }
+      ]
+    },
+    {
+      label: 'item.related.bioid.translator',
+      refTables: [
+        { refTable: 'texid', property: 'P24' }
+      ]
+    }
+  ],
+  copid: [
+    {
+      label: 'item.related.copid.related_copies',
+      refTables: [
+        { refTable: 'copid', property: 'P750' }
+      ]
+    }
+  ],
+  geoid: [
+    {
+      label: 'item.related.geoid.career_statement',
+      refTables: [
+        { refTable: 'bioid', property: 'P165', qualifier: 'P47' }
+      ]
+    },
+    {
+      label: 'item.related.geoid.first_known_date',
+      refTables: [
+        { refTable: 'bioid', property: 'P291', qualifier: 'P47' }
+      ]
+    },
+    {
+      label: 'item.related.geoid.former_owners',
+      refTables: [
+        { refTable: 'copid', property: 'P229', qualifier: 'P47' }
+      ]
+    },
+    {
+      label: 'item.related.geoid.from_place',
+      refTables: [
+        { refTable: 'bioid', property: 'P295', qualifier: 'P47' }
+      ]
+    },
+    {
+      label: 'item.related.geoid.history',
+      refTables: [
+        { refTable: 'copid', property: 'P137', qualifier: 'P47' },
+        { refTable: 'manid', property: 'P137', qualifier: 'P47' },
+        { refTable: 'texid', property: 'P137', qualifier: 'P47' }
+      ]
+    },
+    {
+      label: 'item.related.geoid.itinerary',
+      refTables: [
+        { refTable: 'bioid', property: 'P296', qualifier: 'P47' }
+      ]
+    },
+    {
+      label: 'item.related.geoid.last_known_date',
+      refTables: [
+        { refTable: 'bioid', property: 'P292', qualifier: 'P47' }
+      ]
+    },
+    {
+      label: 'item.related.geoid.location',
+      refTables: [
+        { refTable: 'manid', property: 'P47' }
+      ]
+    },
+    {
+      label: 'item.related.geoid.milestones',
+      refTables: [
+        { refTable: 'bioid', property: 'P137', qualifier: 'P47' },
+        { refTable: 'insid', property: 'P137', qualifier: 'P47' },
+        { refTable: 'manid', property: 'P536', qualifier: 'P47' },
+        { refTable: 'manid', property: 'P222', qualifier: 'P47' }
+      ]
+    },
+    {
+      label: 'item.related.geoid.owner',
+      refTables: [
+        { refTable: 'manid', property: 'P229', qualifier: 'P47' }
+      ]
+    },
+    {
+      label: 'item.related.geoid.place_of_birth',
+      refTables: [
+        { refTable: 'bioid', property: 'P82', qualifier: 'P47' }
+      ]
+    },
+    {
+      label: 'item.related.geoid.place_of_death',
+      refTables: [
+        { refTable: 'bioid', property: 'P168', qualifier: 'P47' }
+      ]
+    },
+    {
+      label: 'item.related.geoid.place_of_publication',
+      refTables: [
+        { refTable: 'manid', property: 'P47' }
+      ]
+    },
+    {
+      label: 'item.related.geoid.related_places',
+      refTables: [
+        { refTable: 'geoid', property: 'P297' },
+        { refTable: 'geoid', property: 'P493' },
+        { refTable: 'insid', property: 'P297', qualifier: 'P47' },
+        { refTable: 'libid', property: 'P47' }
+      ]
+    },
+    {
+      label: 'item.related.geoid.religious_background',
+      refTables: [
+        { refTable: 'bioid', property: 'P172', qualifier: 'P47' }
+      ]
+    },
+    {
+      label: 'item.related.geoid.religious_order',
+      refTables: [
+        { refTable: 'bioid', property: 'P746', qualifier: 'P47' }
+      ]
+    },
+    {
+      label: 'item.related.geoid.subject_references',
+      refTables: [
+        { refTable: 'bibid', property: 'P243' },
+        { refTable: 'bioid', property: 'P243' },
+        { refTable: 'copid', property: 'P243' },
+        { refTable: 'geoid', property: 'P243' },
+        { refTable: 'insid', property: 'P243' },
+        { refTable: 'libid', property: 'P243' },
+        { refTable: 'manid', property: 'P243' },
+        { refTable: 'texid', property: 'P243' }
+      ]
+    }
+  ],
+  insid: [
+    {
+      label: 'item.related.insid.authors',
+      refTables: [
+        { refTable: 'texid', property: 'P232' }
+      ]
+    },
+    {
+      label: 'item.related.insid.financed_by',
+      refTables: [
+        { refTable: 'manid', property: 'P67' }
+      ]
+    },
+    {
+      label: 'item.related.insid.former_owners',
+      refTables: [
+        { refTable: 'copid', property: 'P229', qualifier: 'P232' }
+      ]
+    },
+    {
+      label: 'item.related.insid.handwritten_by',
+      refTables: [
+        { refTable: 'manid', property: 'P25' }
+      ]
+    },
+    {
+      label: 'item.related.insid.milestones',
+      refTables: [
+        { refTable: 'manid', property: 'P536', qualifier: 'P25' },
+        { refTable: 'manid', property: 'P222', qualifier: 'P207' }
+      ]
+    },
+    {
+      label: 'item.related.insid.owner',
+      refTables: [
+        { refTable: 'manid', property: 'P229' }
+      ]
+    },
+    {
+      label: 'item.related.insid.printed_by',
+      refTables: [
+        { refTable: 'manid', property: 'P207' }
+      ]
+    },
+    {
+      label: 'item.related.insid.related_individuals',
+      refTables: [
+        { refTable: 'bioid', property: 'P703' }
+      ]
+    },
+    {
+      label: 'item.related.insid.related_institutions',
+      refTables: [
+        { refTable: 'insid', property: 'P232' },
+        { refTable: 'libid', property: 'P232' }
+      ]
+    },
+    {
+      label: 'item.related.insid.work_context',
+      refTables: [
+        { refTable: 'texid', property: 'P590' }
+      ]
+    },
+    {
+      label: 'item.related.insid.subject_references',
+      refTables: [
+        { refTable: 'subid', property: 'P243' }
+      ]
+    }
+  ],
+  libid: [
+    {
+      label: 'item.related.libid.related_libraries',
+      refTables: [
+        { refTable: 'bibid', property: 'P329' }
+      ]
+    },
+    {
+      label: 'item.related.libid.present_holding',
+      refTables: [
+        { refTable: 'manid', property: 'P329' }
+      ]
+    }
+  ],
+  subid: [
+    {
+      label: 'item.related.subid.subject_references',
+      refTables: [
+        { refTable: 'bibid', property: 'P243' },
+        { refTable: 'bioid', property: 'P243' },
+        { refTable: 'cnum', property: 'P243' },
+        { refTable: 'insid', property: 'P243' },
+        { refTable: 'libid', property: 'P243' },
+        { refTable: 'manid', property: 'P243' },
+        { refTable: 'texid', property: 'P243' }
+      ]
+    }
+  ]
+}
+
+function emitHasRelatedTable (hasRelatedTable) {
+  if (!hasRelatedTables.value && hasRelatedTable) {
+    hasRelatedTables.value = true
   }
+  emit('has-related-table', hasRelatedTables.value)
 }
 </script>


### PR DESCRIPTION
## Summary

Sub-PR #6 of the Nuxt 3 migration. Stacked on Sub-PR #5 (`feat/nuxt3-components-leaves`).

Converts **14 mid-level components** (those that depend on the leaves from #5 but are themselves consumed by orchestrators).

### Files touched

- `components/item/claim/*` (4): `AddValue`, `Base`, `Create`, `Values`
- `components/item/qualifier/*` (3): `Create`, `List`, `Value`
- `components/item/reference/*` (5): `Base`, `Create`, `List`, `Value`, `Values`
- `components/item/related/*` (3): `Ritem`, `Table`, `Tables`

### Notable Vuetify 3 rewrites

- **`v-subheader` removed** — replaced with a styled `<div>` (same classes, explicit min-height).
- **`v-expansion-panel-*` renamed** — `-header` → `-title`, `-content` → `-text`.
- **`v-data-table` rewritten** (`claim/Values.vue`, `reference/List.vue`) — headers use `{ title, key }` instead of `{ text, value }`; `items-per-page-options` + `items-per-page-text` props replace the old `footer-props` object.
- **Utility classes** — `black--text` / `grey--text` → `text-black` / `text-grey`.

### Script conversions (common to all)

- `this.\$store.state.auth.isLogged` → `useAuthStore().isLogged`
- `this.\$store.getters['auth/getRequestConfig']` → `useAuthStore().requestConfig`
- `this.\$wikibase.constructor.PROPERTY_*` → `import { WikibaseService }` + `WikibaseService.PROPERTY_*`
- `this.\$set` / `this.\$delete` → direct mutation on `reactive()` objects / native `delete`
- Options-API watchers with `deep: true` → `watch(ref, …, { deep: true })`

## Test plan

- [ ] Item page: claim rows render, expansion panels open, related tables show pagination controls
- [ ] Login and add a new claim value → toast on success, row appears without reload
- [ ] Add a qualifier to a claim → data-table header updates (column for new property)
- [ ] Add a reference to a claim → expansion panel count updates
- [ ] Related tables paginate (page 2 triggers fresh fetch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)