### PR TITLE
feat(frontend): Nuxt 3 migration — orchestrator components (Sub-PR #7)

### DIFF
--- a/frontend/components/LanguagesMenu.vue
+++ b/frontend/components/LanguagesMenu.vue
@@ -1,12 +1,12 @@
 <template>
-  <v-menu offset-y>
-    <template #activator="{ on }">
+  <v-menu>
+    <template #activator="{ props: activatorProps }">
       <v-btn
-        text
+        v-bind="activatorProps"
+        variant="text"
         class="d-flex align-center pa-0"
         height="0"
         min-width="0"
-        v-on="on"
       >
         <v-img
           :src="localeFlag"
@@ -21,47 +21,43 @@
       <v-list-item
         v-for="(item, index) in languages"
         :key="index"
-        dense
+        density="compact"
         @click="changeLocale(index)"
       >
-        <v-list-item-avatar>
-          <v-img :src="item.image" alt="flag" />
-        </v-list-item-avatar>
+        <template #prepend>
+          <v-avatar>
+            <v-img :src="item.image" alt="flag" />
+          </v-avatar>
+        </template>
         <v-list-item-title>{{ item.name }}</v-list-item-title>
       </v-list-item>
     </v-list>
   </v-menu>
 </template>
 
-<script>
-export default {
-  data () {
-    return {
-      languages: [
-        { locale: 'ca', name: 'Català', image: 'img/flags/flag_catalonia.gif' },
-        { locale: 'es', name: 'Español', image: 'img/flags/flag_spain.gif' },
-        { locale: 'en', name: 'English', image: 'img/flags/flag_unitedstates.gif' },
-        { locale: 'gl', name: 'Galego', image: 'img/flags/flag_galicia.gif' },
-        { locale: 'pt', name: 'Português', image: 'img/flags/flag_portugal.gif' }
-      ]
-    }
-  },
+<script setup>
+import { computed } from 'vue'
+import { useI18n } from 'vue-i18n'
 
-  computed: {
-    localeFlag () {
-      return this.languages.find(lang => lang.locale === this.$i18n.locale)?.image ?? ''
-    }
-  },
-  methods: {
-    changeLocale (index) {
-      this.$i18n.setLocale(this.languages[index].locale)
-    }
-  }
+const { locale, setLocale } = useI18n()
+
+const languages = [
+  { locale: 'ca', name: 'Català', image: 'img/flags/flag_catalonia.gif' },
+  { locale: 'es', name: 'Español', image: 'img/flags/flag_spain.gif' },
+  { locale: 'en', name: 'English', image: 'img/flags/flag_unitedstates.gif' },
+  { locale: 'gl', name: 'Galego', image: 'img/flags/flag_galicia.gif' },
+  { locale: 'pt', name: 'Português', image: 'img/flags/flag_portugal.gif' }
+]
+
+const localeFlag = computed(() => languages.find(lang => lang.locale === locale.value)?.image ?? '')
+
+function changeLocale (index) {
+  setLocale(languages[index].locale)
 }
 </script>
 
 <style scoped>
-::v-deep .v-image__image--cover {
+:deep(.v-image__image--cover) {
   background-size: unset !important;
 }
 </style>

--- a/frontend/components/PhiloFooter.vue
+++ b/frontend/components/PhiloFooter.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-footer color="white" class="over-menu mt-10" padless>
+  <v-footer color="white" class="over-menu mt-10">
     <v-row dense>
       <v-col cols="12" sm="3" class="text-center" align-self="center">
         <span class="text-black text-h4">Philo</span>
@@ -8,25 +8,21 @@
         </a>
       </v-col>
       <v-col cols="12" sm="3">
-        <v-list dense>
-          <v-list-item-group>
-            <v-list-item v-for="(item, index) in links_col_1" :key="index" link @click="goTo(item.link)">
-              <v-list-item-title class="text-subtitle-2">
-                {{ item.label }}
-              </v-list-item-title>
-            </v-list-item>
-          </v-list-item-group>
+        <v-list density="compact">
+          <v-list-item v-for="(item, index) in links_col_1" :key="index" link @click="goTo(item.link)">
+            <v-list-item-title class="text-subtitle-2">
+              {{ item.label }}
+            </v-list-item-title>
+          </v-list-item>
         </v-list>
       </v-col>
       <v-col cols="12" sm="3">
-        <v-list dense>
-          <v-list-item-group>
-            <v-list-item v-for="(item, index) in links_col_2" :key="index" link @click="goTo(item.link)">
-              <v-list-item-title class="text-subtitle-2">
-                {{ item.label }}
-              </v-list-item-title>
-            </v-list-item>
-          </v-list-item-group>
+        <v-list density="compact">
+          <v-list-item v-for="(item, index) in links_col_2" :key="index" link @click="goTo(item.link)">
+            <v-list-item-title class="text-subtitle-2">
+              {{ item.label }}
+            </v-list-item-title>
+          </v-list-item>
         </v-list>
       </v-col>
       <v-col cols="12" sm="3">
@@ -82,18 +78,18 @@
       <v-col class="text-center text-caption">
         &copy; {{ new Date().getFullYear() }}
         <span class="version">
-          v.{{ $config.version }}
+          v.{{ config.version }}
         </span>
-        <v-tooltip top>
-          <template #activator="{ on, attrs }">
-            <span v-bind="attrs" v-on="on">
+        <v-tooltip location="top">
+          <template #activator="{ props: tooltipProps }">
+            <span v-bind="tooltipProps">
               <a class="version" @click="goTo('/privacy-policy')">
-                {{ $i18n.t('privacyPolicy.label') }}
+                {{ t('privacyPolicy.label') }}
               </a>
             </span>
           </template>
           <p class="tooltip">
-            {{ $i18n.t('privacyPolicy.tooltip') }}
+            {{ t('privacyPolicy.tooltip') }}
           </p>
         </v-tooltip>
       </v-col>
@@ -101,29 +97,29 @@
   </v-footer>
 </template>
 
-<script>
-export default {
-  data () {
-    return {
-      links_col_1: [
-        { label: 'ABOUT PhiloBiblon', link: '/wiki/About' },
-        { label: 'HELP', link: '/wiki/Help' },
-        { label: 'RESOURCES', link: '/wiki/Resources' },
-        { label: 'COLLABORATE', link: '/wiki/Collaborate' }
-      ],
-      links_col_2: [
-        { label: 'BETA', link: '/wiki/Beta' },
-        { label: 'BIPA', link: '/wiki/Bipa' },
-        { label: 'BITAGAP', link: '/wiki/Bitagap' },
-        { label: 'BITECA', link: '/wiki/Biteca' }
-      ]
-    }
-  },
-  methods: {
-    goTo (path) {
-      this.$router.push(this.localePath(path))
-    }
-  }
+<script setup>
+import { useI18n } from 'vue-i18n'
+
+const { t } = useI18n()
+const config = useRuntimeConfig().public
+const router = useRouter()
+const localePath = useLocalePath()
+
+const links_col_1 = [
+  { label: 'ABOUT PhiloBiblon', link: '/wiki/About' },
+  { label: 'HELP', link: '/wiki/Help' },
+  { label: 'RESOURCES', link: '/wiki/Resources' },
+  { label: 'COLLABORATE', link: '/wiki/Collaborate' }
+]
+const links_col_2 = [
+  { label: 'BETA', link: '/wiki/Beta' },
+  { label: 'BIPA', link: '/wiki/Bipa' },
+  { label: 'BITAGAP', link: '/wiki/Bitagap' },
+  { label: 'BITECA', link: '/wiki/Biteca' }
+]
+
+function goTo (path) {
+  router.push(localePath(path))
 }
 </script>
 

--- a/frontend/components/create/Base.vue
+++ b/frontend/components/create/Base.vue
@@ -6,14 +6,14 @@
           <v-col cols="7">
             <v-radio-group
               v-model="database"
-              row
+              inline
             >
               <template #label>
-                {{ $t('search.form.common.group.label') }}
+                {{ t('search.form.common.group.label') }}
               </template>
               <v-radio
                 v-for="group in groups"
-                :key="'g-'+group"
+                :key="'g-' + group"
                 class="group-option"
                 :label="group"
                 :value="group"
@@ -31,53 +31,41 @@
   </div>
 </template>
 
-<script>
-export default {
-  props: {
-    table: {
-      type: String,
-      default: null
-    },
-    breadcrumbItems: {
-      type: Array,
-      default: null
-    }
-  },
-  data () {
-    return {
-      database: 'BETA',
-      showGroups: false,
-      groups: [
-        'BETA',
-        'BITAGAP',
-        'BITECA'
-      ]
-    }
-  },
-  watch: {
-    '$route.query.database': {
-      immediate: true,
-      handler (val) {
-        if (this.groups.includes(val)) {
-          this.database = val
-          this.showGroups = false
-        } else {
-          this.showGroups = true
-        }
-      }
-    }
-  },
-  created () {
-    this.$store.commit('breadcrumb/setItems', this.breadcrumbItems)
-    this.$store.commit('breadcrumb/setClass', 'large-font-breadcrumb')
-    this.$store.commit('breadcrumb/setDatabase', this.database)
-    this.$store.commit('breadcrumb/setTable', this.table)
-  },
+<script setup>
+import { onBeforeUnmount, ref, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { useBreadcrumbStore } from '~/stores/breadcrumb'
 
-  destroyed () {
-    this.$store.commit('breadcrumb/setClass', '')
+const props = defineProps({
+  table: { type: String, default: null },
+  breadcrumbItems: { type: Array, default: null }
+})
+
+const { t } = useI18n()
+const route = useRoute()
+const breadcrumbStore = useBreadcrumbStore()
+
+const database = ref('BETA')
+const showGroups = ref(false)
+const groups = ['BETA', 'BITAGAP', 'BITECA']
+
+watch(() => route.query.database, (val) => {
+  if (groups.includes(val)) {
+    database.value = val
+    showGroups.value = false
+  } else {
+    showGroups.value = true
   }
-}
+}, { immediate: true })
+
+breadcrumbStore.setItems(props.breadcrumbItems)
+breadcrumbStore.setClass('large-font-breadcrumb')
+breadcrumbStore.setDatabase(database.value)
+breadcrumbStore.setTable(props.table)
+
+onBeforeUnmount(() => {
+  breadcrumbStore.setClass('')
+})
 </script>
 
 <style scoped>

--- a/frontend/components/item/Base.vue
+++ b/frontend/components/item/Base.vue
@@ -1,27 +1,22 @@
 <template>
   <div class="all-width">
     <v-container v-if="showItem">
-      <!--
-      <v-row>
-        {{ item }}
-      </v-row>
-      -->
       <v-row class="back">
         <a class="link" @click="goTo(`/search/${table}/query`)">
-          <v-tooltip right>
-            <template #activator="{ on, attrs }">
-              <v-icon color="primary" v-bind="attrs" v-on="on">
+          <v-tooltip location="right">
+            <template #activator="{ props: tooltipProps }">
+              <v-icon color="primary" v-bind="tooltipProps">
                 mdi-reply
               </v-icon>
             </template>
-            <span>{{ $t("item.back") }}</span>
+            <span>{{ t("item.back") }}</span>
           </v-tooltip>
         </a>
       </v-row>
       <v-row>
         <v-col>
           <span v-if="isUserLogged">
-            <item-util-edit-text-field :label="$t('item.title')" :save="editLabel" :value="label.value" class="text-h4">
+            <item-util-edit-text-field :label="t('item.title')" :save="editLabel" :value="label.value" class="text-h4">
               <template #append-outer>
                 &nbsp;
                 <a
@@ -45,7 +40,7 @@
       </v-row>
       <v-row class="pb-5">
         <span v-if="isUserLogged" class="full-width">
-          <item-util-edit-text-field :label="$t('item.description')" :save="editDescription" :value="description.value" class="text-subtitle-1" />
+          <item-util-edit-text-field :label="t('item.description')" :save="editDescription" :value="description.value" class="text-subtitle-1" />
         </span>
         <span v-else class="text-subtitle-1">
           <v-col class="text-subtitle-1">
@@ -55,139 +50,128 @@
       </v-row>
       <item-claims :table="table" :item="item" :claims="claimsOrdered" />
       <div v-if="hasRelatedTable" class="text-h6 mt-6">
-        {{ $t('item.related_items') }}
+        {{ t('item.related_items') }}
       </div>
       <item-related-tables :item-id="item.id" :table="table" @has-related-table="hasRelatedTable = $event" />
       <div v-if="hasNotes || isUserLogged" class="text-h6 mt-6">
-        {{ $t('item.notes') }}
+        {{ t('item.notes') }}
       </div>
       <item-notes :item-id="item.id" @has-notes="hasNotes = $event" />
       <div class="text-h6 mt-6">
-        {{ $t('item.identifiers') }}
+        {{ t('item.identifiers') }}
       </div>
       <item-claims :table="table" :item="item" :claims="externalIdClaims" />
     </v-container>
   </div>
 </template>
 
-<script>
-export default {
-  props: {
-    id: {
-      type: String,
-      default: null
-    },
-    database: {
-      type: String,
-      required: true
-    },
-    table: {
-      type: String,
-      required: true
-    }
-  },
+<script setup>
+import { computed, onMounted, onBeforeUnmount, ref } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { useAuthStore } from '~/stores/auth'
+import { useBreadcrumbStore } from '~/stores/breadcrumb'
 
-  data () {
-    return {
-      cnums: [],
-      copids: [],
-      item: null,
-      label: null,
-      showItem: false,
-      claimsOrdered: [],
-      externalIdClaims: [],
-      hasRelatedTable: false,
-      hasNotes: false
-    }
-  },
+const props = defineProps({
+  id: { type: String, default: null },
+  database: { type: String, required: true },
+  table: { type: String, required: true }
+})
 
-  computed: {
-    isUserLogged () {
-      return this.$store.state.auth.isLogged
-    }
-  },
+const { $notification, $wikibase } = useNuxtApp()
+const { t, locale } = useI18n()
+const router = useRouter()
+const localePath = useLocalePath()
+const authStore = useAuthStore()
+const breadcrumbStore = useBreadcrumbStore()
 
-  async mounted () {
-    if (this.id) {
-      await this.getEntity()
-    }
-  },
+const item = ref(null)
+const label = ref(null)
+const description = ref(null)
+const showItem = ref(false)
+const claimsOrdered = ref([])
+const externalIdClaims = ref([])
+const hasRelatedTable = ref(false)
+const hasNotes = ref(false)
 
-  destroyed () {
-    this.$store.commit('breadcrumb/setClass', '')
-  },
+const isUserLogged = computed(() => authStore.isLogged)
 
-  methods: {
-    goTo (path) {
-      this.$router.push(this.localePath(path))
-    },
-    async getEntity () {
-      try {
-        await this.$wikibase
-          .getEntity(this.id, this.$i18n.locale)
-          .then(async (entity) => {
-            this.item = entity
-            this.label = await this.$wikibase.getValueByLang(this.item.labels, this.$i18n.locale)
-            this.description = await this.$wikibase.getValueByLang(this.item.descriptions, this.$i18n.locale)
-            this.setBreadCrumb(this.database, this.table, entity)
-            this.showItem = true
-            this.handleClaims(entity)
-          })
-      } catch (err) {
-        this.$notification.error(err)
-      }
-    },
-    async handleClaims (entity) {
-      const allClaims = await this.$wikibase.getOrderedClaims(this.table, entity.claims)
-      for (const claim of allClaims) {
-        const entityProperty = await this.$wikibase.getEntity(claim.property, this.$i18n.locale)
-        if (entityProperty.datatype === 'external-id') {
-          this.externalIdClaims.push(claim)
-        } else {
-          this.claimsOrdered.push(claim)
-        }
-      }
-    },
-    setBreadCrumb (database, table, entity) {
-      this.$store.commit('breadcrumb/setItems', this.getBreadcrumbItems(database, table, entity))
-      this.$store.commit('breadcrumb/setClass', 'large-font-breadcrumb')
-      this.$store.commit('breadcrumb/setDatabase', database)
-      this.$store.commit('breadcrumb/setTable', table)
-    },
-    getBreadcrumbItems (database, table, entity) {
-      return [
-        {
-          text: this.$i18n.t('menu.item.search.label'),
-          disabled: true
-        },
-        {
-          text: this.$i18n.t('menu.item.search.item.' + table + '.label'),
-          disabled: false,
-          to: this.localePath('/search/' + table + '/query')
-        },
-        {
-          text: this.$wikibase.getPBID(entity, database, table),
-          disabled: true
-        }
-      ]
-    },
-    editLabel (label) {
-      return this.$wikibase
-        .getWbEdit()
-        .label.set(
-          { id: this.item.id, language: this.$i18n.locale, value: label },
-          this.$store.getters['auth/getRequestConfig']
-        )
-    },
-    editDescription (description) {
-      return this.$wikibase
-        .getWbEdit()
-        .description.set(
-          { id: this.item.id, language: this.$i18n.locale, value: description },
-          this.$store.getters['auth/getRequestConfig']
-        )
+onMounted(async () => {
+  if (props.id) {
+    await getEntity()
+  }
+})
+
+onBeforeUnmount(() => {
+  breadcrumbStore.setClass('')
+})
+
+function goTo (path) {
+  router.push(localePath(path))
+}
+
+async function getEntity () {
+  try {
+    const entity = await $wikibase.getEntity(props.id, locale.value)
+    item.value = entity
+    label.value = await $wikibase.getValueByLang(entity.labels, locale.value)
+    description.value = await $wikibase.getValueByLang(entity.descriptions, locale.value)
+    setBreadCrumb(props.database, props.table, entity)
+    showItem.value = true
+    handleClaims(entity)
+  } catch (err) {
+    $notification.error(err)
+  }
+}
+
+async function handleClaims (entity) {
+  const allClaims = await $wikibase.getOrderedClaims(props.table, entity.claims)
+  for (const claim of allClaims) {
+    const entityProperty = await $wikibase.getEntity(claim.property, locale.value)
+    if (entityProperty.datatype === 'external-id') {
+      externalIdClaims.value.push(claim)
+    } else {
+      claimsOrdered.value.push(claim)
     }
   }
+}
+
+function setBreadCrumb (database, table, entity) {
+  breadcrumbStore.setItems(getBreadcrumbItems(database, table, entity))
+  breadcrumbStore.setClass('large-font-breadcrumb')
+  breadcrumbStore.setDatabase(database)
+  breadcrumbStore.setTable(table)
+}
+
+function getBreadcrumbItems (database, table, entity) {
+  return [
+    {
+      text: t('menu.item.search.label'),
+      disabled: true
+    },
+    {
+      text: t('menu.item.search.item.' + table + '.label'),
+      disabled: false,
+      to: localePath('/search/' + table + '/query')
+    },
+    {
+      text: $wikibase.getPBID(entity, database, table),
+      disabled: true
+    }
+  ]
+}
+
+function editLabel (labelValue) {
+  return $wikibase.getWbEdit().label.set(
+    { id: item.value.id, language: locale.value, value: labelValue },
+    authStore.requestConfig
+  )
+}
+
+function editDescription (descriptionValue) {
+  return $wikibase.getWbEdit().description.set(
+    { id: item.value.id, language: locale.value, value: descriptionValue },
+    authStore.requestConfig
+  )
 }
 </script>
 

--- a/frontend/components/item/Claims.vue
+++ b/frontend/components/item/Claims.vue
@@ -13,72 +13,57 @@
   </div>
 </template>
 
-<script>
+<script setup>
+import { computed } from 'vue'
+import { useAuthStore } from '~/stores/auth'
 
-export default {
-  props: {
-    table: {
-      type: String,
-      required: true
-    },
-    item: {
-      type: Object,
-      default: null
-    },
-    claims: {
-      type: Array,
-      default: null
-    }
-  },
+const props = defineProps({
+  table: { type: String, required: true },
+  item: { type: Object, default: null },
+  claims: { type: Array, default: null }
+})
 
-  computed: {
-    isUserLogged () {
-      return this.$store.state.auth.isLogged
-    }
-  },
+const authStore = useAuthStore()
+const isUserLogged = computed(() => authStore.isLogged)
 
-  methods: {
-    deleteClaim (data) {
-      const claims = this.claims
-      claims.forEach((value, key) => {
-        if (value.property === data.mainsnak.property) {
-          if (claims[key].values.length === 1) {
-            claims.splice(key, 1)
-          } else {
-            const index = claims[key].values.findIndex(item => item.id === data.id)
-            if (index !== -1) {
-              claims[key].values.splice(index, 1)
-            }
-          }
-        }
-      })
-    },
-    updateClaims (data) {
-      const claims = this.claims
-      const existingClaim = claims.find(claim => claim.property === data.property)
-
-      if (existingClaim) {
-        // Filter out duplicates before adding
-        const newValues = data.values.filter(newVal =>
-          !existingClaim.values.some(existingVal => existingVal.id === newVal.id)
-        )
-        if (newValues.length > 0) {
-          existingClaim.values.push(...newValues)
-        }
+function deleteClaim (data) {
+  const claims = props.claims
+  claims.forEach((value, key) => {
+    if (value.property === data.mainsnak.property) {
+      if (claims[key].values.length === 1) {
+        claims.splice(key, 1)
       } else {
-        claims.push(data)
-      }
-    },
-    addValueToClaim (data) {
-      // Handle adding a new value to an existing claim
-      const existingClaim = this.claims.find(claim => claim.property === data.property)
-      if (existingClaim) {
-        // Check if this claim already exists to prevent duplicates
-        const claimExists = existingClaim.values.some(v => v.id === data.claim.id)
-        if (!claimExists) {
-          existingClaim.values.push(data.claim)
+        const index = claims[key].values.findIndex(item => item.id === data.id)
+        if (index !== -1) {
+          claims[key].values.splice(index, 1)
         }
       }
+    }
+  })
+}
+
+function updateClaims (data) {
+  const claims = props.claims
+  const existingClaim = claims.find(claim => claim.property === data.property)
+
+  if (existingClaim) {
+    const newValues = data.values.filter(newVal =>
+      !existingClaim.values.some(existingVal => existingVal.id === newVal.id)
+    )
+    if (newValues.length > 0) {
+      existingClaim.values.push(...newValues)
+    }
+  } else {
+    claims.push(data)
+  }
+}
+
+function addValueToClaim (data) {
+  const existingClaim = props.claims.find(claim => claim.property === data.property)
+  if (existingClaim) {
+    const claimExists = existingClaim.values.some(v => v.id === data.claim.id)
+    if (!claimExists) {
+      existingClaim.values.push(data.claim)
     }
   }
 }

--- a/frontend/components/item/Create.vue
+++ b/frontend/components/item/Create.vue
@@ -2,14 +2,14 @@
   <div class="all-width">
     <v-container>
       <v-row class="back">
-        <a class="link" @click="$router.go(-1)">
-          <v-tooltip right>
-            <template #activator="{ on, attrs }">
-              <v-icon color="primary" v-bind="attrs" v-on="on">
+        <a class="link" @click="router.go(-1)">
+          <v-tooltip location="right">
+            <template #activator="{ props: tooltipProps }">
+              <v-icon color="primary" v-bind="tooltipProps">
                 mdi-reply
               </v-icon>
             </template>
-            <span>{{ $t('item.back') }}</span>
+            <span>{{ t('item.back') }}</span>
           </v-tooltip>
         </a>
       </v-row>
@@ -21,19 +21,19 @@
                 v-model="label"
                 type="text"
                 class="text-h4"
-                :label="$t('common.label')"
+                :label="t('common.label')"
               />
               <v-text-field
                 v-model="description"
                 type="text"
                 class="text-subtitle-1"
-                :label="$t('item.description')"
+                :label="t('item.description')"
               />
             </v-form>
           </v-col>
         </v-row>
         <v-alert v-if="!initialClaimsLoaded" type="info">
-          {{ $t('item.create.calculating_new_pbid') }}
+          {{ t('item.create.calculating_new_pbid') }}
         </v-alert>
         <item-claim-create
           v-if="initialClaimsLoaded"
@@ -46,32 +46,30 @@
           <v-btn
             class="mt-4 mr-2"
             color="grey"
-            small
+            size="small"
             elevation="2"
-            outlined
-            @click="$router.go(-1)"
+            variant="outlined"
+            @click="router.go(-1)"
           >
-            {{ $t('common.cancel') }}
+            {{ t('common.cancel') }}
           </v-btn>
-          <v-tooltip bottom>
-            <template #activator="{ on, attrs }">
-              <div v-bind="attrs" v-on="on">
+          <v-tooltip location="bottom">
+            <template #activator="{ props: tooltipProps }">
+              <div v-bind="tooltipProps">
                 <v-btn
                   class="mt-4"
                   color="primary"
-                  small
+                  size="small"
                   elevation="2"
                   :disabled="isCreateDisabled"
                   @click="create"
                 >
-                  {{ $t('common.create') }}
+                  {{ t('common.create') }}
                 </v-btn>
               </div>
             </template>
             <span class="text-no-wrap">
-              {{
-                getCreateDisabledReason() || $t('item.create.button.enabled')
-              }}
+              {{ getCreateDisabledReason() || t('item.create.button.enabled') }}
             </span>
           </v-tooltip>
         </v-row>
@@ -80,490 +78,454 @@
   </div>
 </template>
 
-<script>
-export default {
-  props: {
-    database: {
-      type: String,
-      required: true
-    },
-    table: {
-      type: String,
-      required: true
+<script setup>
+import { computed, nextTick, onMounted, ref } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { useAuthStore } from '~/stores/auth'
+
+const props = defineProps({
+  database: { type: String, required: true },
+  table: { type: String, required: true }
+})
+
+const { $notification, $wikibase } = useNuxtApp()
+const { t, locale } = useI18n()
+const router = useRouter()
+const localePath = useLocalePath()
+const authStore = useAuthStore()
+
+const label = ref('')
+const initialClaimsLoaded = ref(false)
+const initialClaims = ref([])
+const claims = ref([])
+const description = ref('')
+
+const isUserLogged = computed(() => authStore.isLogged)
+const isCreateDisabled = computed(() => !!getCreateDisabledReason())
+const pbid = computed(() => initialClaims.value.find(
+  item => item.property.id === $wikibase.constructor.PROPERTY_PBID
+).value)
+
+onMounted(() => {
+  nextTick(() => {
+    if (!isUserLogged.value || !props.database) {
+      return router.push(localePath('/'))
+    } else {
+      loadInitialClaims()
     }
-  },
-  data () {
-    return {
-      label: '',
-      initialClaimsLoaded: false,
-      initialClaims: [],
-      claims: [],
-      disabled: true,
-      description: ''
-    }
-  },
-  computed: {
-    isUserLogged () {
-      return this.$store.state.auth.isLogged
-    },
-    isCreateDisabled () {
-      return !!this.getCreateDisabledReason()
-    },
-    pbid () {
-      return this.initialClaims.find(
-        item => item.property.id === this.$wikibase.constructor.PROPERTY_PBID
-      ).value
-    }
-  },
-  created () {
-    this.$nextTick(() => {
-      if (!this.isUserLogged || !this.database) {
-        return this.$router.push(this.localePath('/'))
-      } else {
-        this.loadInitialClaims()
-      }
-    })
-  },
-  methods: {
-    getCreateDisabledReason () {
-      if (!this.label) {
-        return this.$t('messages.error.inputs.label')
-      }
+  })
+})
 
-      if (!this.initialClaimsLoaded) {
-        return this.$t('messages.error.inputs.initial_claims')
-      }
+function getCreateDisabledReason () {
+  if (!label.value) {
+    return t('messages.error.inputs.label')
+  }
 
-      const claims = Object.entries(this.claims)
+  if (!initialClaimsLoaded.value) {
+    return t('messages.error.inputs.initial_claims')
+  }
 
-      for (let propIndex = 0; propIndex < claims.length; propIndex++) {
-        const [, claimArray] = claims[propIndex]
-        const initialClaim = this.initialClaims[propIndex]
-        const propertyLabel = initialClaim?.property?.label
+  const claimsEntries = Object.entries(claims.value)
 
-        if (
-          initialClaim?.property?.id === 'P2' ||
-          initialClaim?.property?.id === 'P476' ||
-          (this.table === 'cnum' && initialClaim?.property?.id === 'P590') ||
-          (this.table === 'copid' && initialClaim?.property?.id === 'P839')
-        ) {
-          for (const item of claimArray) {
-            if (item?.value == null || item?.value === '') {
-              return this.$t('messages.error.inputs.claim_value_missing', {
-                propertyLabel
-              })
-            }
+  for (let propIndex = 0; propIndex < claimsEntries.length; propIndex++) {
+    const [, claimArray] = claimsEntries[propIndex]
+    const initialClaim = initialClaims.value[propIndex]
+    const propertyLabel = initialClaim?.property?.label
 
-            const claimLabel =
-              initialClaim?.value?.datavalue?.value?.label || propertyLabel
+    if (
+      initialClaim?.property?.id === 'P2' ||
+      initialClaim?.property?.id === 'P476' ||
+      (props.table === 'cnum' && initialClaim?.property?.id === 'P590') ||
+      (props.table === 'copid' && initialClaim?.property?.id === 'P839')
+    ) {
+      for (const item of claimArray) {
+        if (item?.value == null || item?.value === '') {
+          return t('messages.error.inputs.claim_value_missing', { propertyLabel })
+        }
 
-            for (const [qualifierKey, qualifierVal] of Object.entries(
-              item.qualifiers || {}
-            )) {
-              if (!qualifierKey || qualifierKey === 'null') {
-                return this.$t('messages.error.inputs.qualifier_key_missing', {
-                  claimLabel,
-                  propertyLabel
-                })
-              }
-              if (!qualifierVal || qualifierVal === 'null') {
-                return this.$t(
-                  'messages.error.inputs.qualifier_value_missing',
-                  { claimLabel, propertyLabel }
-                )
-              }
-            }
+        const claimLabel = initialClaim?.value?.datavalue?.value?.label || propertyLabel
+
+        for (const [qualifierKey, qualifierVal] of Object.entries(item.qualifiers || {})) {
+          if (!qualifierKey || qualifierKey === 'null') {
+            return t('messages.error.inputs.qualifier_key_missing', { claimLabel, propertyLabel })
+          }
+          if (!qualifierVal || qualifierVal === 'null') {
+            return t('messages.error.inputs.qualifier_value_missing', { claimLabel, propertyLabel })
           }
         }
       }
-
-      return null
-    },
-    async loadInitialClaims () {
-      try {
-        const res = await this.$wikibase.getTableLastItem(
-          this.database,
-          this.table
-        )
-        if (res?.length && res[0]) {
-          await this.getDefaultClaims(res[0].item_number)
-          this.initialClaimsLoaded = true
-        }
-      } catch (error) {
-        // eslint-disable-next-line no-console
-        console.error(error)
-        this.$notification.error(
-          error?.body?.error?.info || this.$t('messages.error.something_went_wrong')
-        )
-      }
-    },
-    buildClaim (entity, qualifiers = [], value = null, removable = true) {
-      const label =
-        this.$wikibase.getValueByLang(entity.labels, this.$i18n.locale)
-          ?.value || entity.id
-      return {
-        default: true,
-        removable,
-        property: {
-          label,
-          id: entity.id,
-          datatype: entity.datatype
-        },
-        mainsnak: {
-          property: entity.id
-        },
-        claimsValues: [],
-        value: {
-          property: entity.id,
-          datatype: entity.datatype,
-          datavalue: {
-            default: true,
-            value
-          }
-        },
-        qualifiers
-      }
-    },
-    buildQualifier (claim, qualifier) {
-      // Build property object with label for autocomplete display
-      const label = this.$wikibase.getValueByLang(qualifier.labels, this.$i18n.locale)?.value || qualifier.id
-      return {
-        default: true,
-        property: {
-          id: qualifier.id,
-          label,
-          datatype: qualifier.datatype
-        },
-        datatype: qualifier.datatype,
-        datavalue: {
-          value: null
-        }
-      }
-    },
-    async getDefaultClaims (itemNumber) {
-      const def = ['P476', 'P131']
-      const res = await this.$wikibase.getClaimsOrderForNewItem(this.table)
-      const propertyIds = [...new Set([...def, ...Object.keys(res)])]
-      const qualifiersProperties = [...new Set(Object.values(res).flat())]
-      const entities = await this.$wikibase.getEntities(
-        propertyIds,
-        this.$i18n.locale
-      )
-      const qualifiersArr = await this.$wikibase.getEntities(
-        qualifiersProperties,
-        this.$i18n.locale
-      )
-
-      Object.values(entities).forEach((entity) => {
-        if (this.isValidPropertyEntity(entity)) {
-          const qualifiers = []
-
-          res[entity.id]?.forEach((property) => {
-            if (this.isValidPropertyEntity(qualifiersArr[property])) {
-              qualifiers.push(
-                this.buildQualifier(entity, qualifiersArr[property])
-              )
-            }
-          })
-
-          let claim = this.buildClaim(entity, qualifiers, null)
-
-          if (entity.id === 'P476') {
-            claim = this.buildClaim(entity, [], this.generatePbId(itemNumber), false)
-          } else if (entity.id === 'P131') {
-            // Set default bibliography based on database
-            // BETA: Q254471, BITECA: Q256810, BITAGAP: Q256809
-            const bibliographyMap = {
-              BETA: 'Q254471',
-              BITECA: 'Q256810',
-              BITAGAP: 'Q256809'
-            }
-            const bibliographyId = bibliographyMap[this.database] || null
-
-            // P700 (statement refers to) qualifier = Q447226 (PhiloBiblon object)
-            const qualifiers = [
-              {
-                default: true,
-                property: 'P700',
-                datatype: 'wikibase-item',
-                datavalue: {
-                  value: {
-                    id: 'Q447226'
-                  }
-                }
-              }
-            ]
-
-            claim = this.buildClaim(entity, qualifiers, bibliographyId ? { id: bibliographyId } : null)
-          } else if (this.table === 'cnum' && entity.id === 'P590') {
-            claim = this.buildClaim(entity, qualifiers, null, false)
-          } else if (this.table === 'copid' && entity.id === 'P839') {
-            claim = this.buildClaim(entity, qualifiers, null, false)
-          }
-
-          this.initialClaims.push(claim)
-        }
-      })
-    },
-    isValidPropertyEntity (entity) {
-      return entity?.title?.startsWith('Property:') && entity?.labels
-    },
-    generatePbId (lastItemPbId) {
-      return `${this.database} ${this.table} ${parseInt(lastItemPbId) + 1}`
-    },
-    updateClaims (data) {
-      this.initialClaims = data
-      this.claims = this.generateClaimsData(data)
-      this.generateLabelFromClaims()
-    },
-    generateClaimsData (data) {
-      const claims = {}
-      data.forEach((claim) => {
-        if (claim.property) {
-          const claimKey = claim?.property?.id
-
-          claims[claimKey] = claims[claimKey] || []
-          const extractValue = v =>
-            v?.datavalue?.value?.id ?? v?.datavalue?.value
-
-          const createClaim = (val, qualifiers = {}) => ({
-            value: extractValue(val),
-            qualifiers
-          })
-
-          const qualifiers = Object.fromEntries(
-            (claim.qualifiers || []).map(q => [q.property, extractValue(q)])
-          )
-
-          claims[claimKey].push(createClaim(claim.value, qualifiers))
-
-          const values = Object.values(claim.claimsValues || {}) || []
-          values.forEach((v) => {
-            claims[claimKey].push(createClaim(v))
-          })
-        }
-      })
-      return claims
-    },
-    cleanClaims (claims) {
-      const cleanedClaims = {}
-
-      for (const [propertyId, claimArray] of Object.entries(claims)) {
-        const cleanedClaimArray = []
-
-        for (const claim of claimArray) {
-          const value = claim?.value
-          if (value == null || value === '') {
-            continue
-          }
-
-          const cleanedQualifiers = {}
-          for (const [qualKey, qualVal] of Object.entries(
-            claim.qualifiers || {}
-          )) {
-            if (
-              qualKey &&
-              qualKey !== 'null' &&
-              qualVal != null &&
-              qualVal !== 'null' &&
-              qualVal !== ''
-            ) {
-              cleanedQualifiers[qualKey] = qualVal
-            }
-          }
-
-          cleanedClaimArray.push({
-            value,
-            qualifiers: cleanedQualifiers
-          })
-        }
-
-        if (cleanedClaimArray.length) {
-          cleanedClaims[propertyId] = cleanedClaimArray
-        }
-      }
-
-      return cleanedClaims
-    },
-    async create () {
-      const existingPBID = await this.$wikibase.getEntityFromPBID(this.pbid)
-      if (existingPBID === null) {
-        try {
-          const claims = this.cleanClaims(this.claims)
-
-          const data = {
-            labels: {
-              [this.$i18n.locale]: this.label
-            },
-            descriptions: {
-              [this.$i18n.locale]: this.description || ' '
-            },
-            claims: {
-              ...claims
-            }
-          }
-
-          const response = await this.$wikibase
-            .getWbEdit()
-            .entity.create(data, this.$store.getters['auth/getRequestConfig'])
-
-          if (response.success) {
-            await this.$router.push(
-              this.localePath('/item/' + response.entity.id)
-            )
-          } else {
-            this.$notification.error(
-              this.$t('messages.error.something_went_wrong')
-            )
-          }
-        } catch (error) {
-          this.$notification.error(
-            error.body.error.info ??
-              this.$t('messages.error.something_went_wrong')
-          )
-        }
-      } else {
-        this.$notification.error(this.$t('messages.error.creation.pbid_already_exists', {
-          pbid: this.pbid,
-          item: `&nbsp;<a target="_blank" style="color: #ffffff; font-weight: bold;" href="${this.$wikibase.getQItemUrl(existingPBID)}">${existingPBID}</a>`
-        })
-        )
-      }
-    },
-    formatTime (raw) {
-      const cleaned = raw.replace(/^\+/, '')
-      const date = new Date(cleaned)
-      return new Intl.DateTimeFormat('en', {
-        year: 'numeric',
-        month: 'long',
-        day: 'numeric'
-      }).format(date)
-    },
-    safeFormatTime (timeString) {
-      if (!timeString || typeof timeString !== 'string' || !timeString.trim()) {
-        return undefined
-      }
-      // Check if it matches expected date pattern (e.g., +YYYY-MM-DD or YYYY-MM-DD)
-      const datePattern = /^[+-]?\d{4}-\d{2}-\d{2}/
-      if (!datePattern.test(timeString)) {
-        return undefined
-      }
-      try {
-        return this.formatTime(timeString)
-      } catch (error) {
-        return undefined
-      }
-    },
-    getClaimValue (pbid) {
-      const claim = this.initialClaims.find(cl => cl.property?.id === pbid)
-      const val = claim?.value?.datavalue?.value
-
-      if (!val) {
-        return null
-      }
-      if (typeof val === 'object') {
-        // For date values (val.time), use safe formatting
-        if (val.time !== undefined) {
-          const formatted = this.safeFormatTime(val.time)
-          return val.label || val.text || formatted || val.id
-        }
-        return val.label || val.text || val.id
-      }
-      return val
-    },
-    generateLabelFromClaims () {
-      let label = ''
-      switch (this.table) {
-        case 'texid': {
-          const author = this.getClaimValue('P21')
-          const title = this.getClaimValue('P11')
-          if (author && title) {
-            label = `${author}. ${title}`
-          }
-          break
-        }
-        case 'cnum': {
-          const work = this.getClaimValue('P590')
-          const partOf = this.getClaimValue('P8')
-          if (work && partOf) {
-            label = `Witness of ${work}, part of ${partOf}`
-          }
-          break
-        }
-        case 'bibid': {
-          const surname = this.getClaimValue('P247')
-          const author = this.getClaimValue('P21')
-          const creator = this.getClaimValue('P1134')
-          const title = this.getClaimValue('P11')
-          const date = this.getClaimValue('P222')
-
-          const name = surname || author || creator
-
-          if (name && title) {
-            const datePart = date ? ` (${date})` : ''
-            label = `${name}${datePart}, ${title}`
-          }
-          break
-        }
-        case 'bioid': {
-          const fallbackProps = ['P34', 'P77', 'P173', 'P291', 'P165', 'P746']
-          for (const pbid of fallbackProps) {
-            const val = this.getClaimValue(pbid)
-            if (val) {
-              label = val
-              break
-            }
-          }
-          break
-        }
-        case 'manid': {
-          const holding = this.getClaimValue('P329')
-          const position = this.getClaimValue('P10')
-          if (holding && position) {
-            label = `${holding}, ${position}`
-          }
-          break
-        }
-        case 'copid': {
-          const holding = this.getClaimValue('P329')
-          const position = this.getClaimValue('P10')
-          const edition = this.getClaimValue('P839')
-          if (holding && position && edition) {
-            label = `${holding}, ${position} (${edition})`
-          }
-          break
-        }
-        case 'geoid':
-        case 'insid': {
-          const name = this.getClaimValue('P34')
-          const region = this.getClaimValue('P297')
-          if (name && region) {
-            label = `${name}, ${region}`
-          }
-          break
-        }
-        case 'libid': {
-          const name = this.getClaimValue('P34')
-          const location = this.getClaimValue('P47')
-          if (name && location) {
-            label = `${name}, ${location}`
-          }
-          break
-        }
-        case 'subid': {
-          const name = this.getClaimValue('P34')
-          if (name) {
-            label = name
-          }
-          break
-        }
-        default:
-          break
-      }
-
-      this.label = label || ''
     }
   }
+
+  return null
+}
+
+async function loadInitialClaims () {
+  try {
+    const res = await $wikibase.getTableLastItem(props.database, props.table)
+    if (res?.length && res[0]) {
+      await getDefaultClaims(res[0].item_number)
+      initialClaimsLoaded.value = true
+    }
+  } catch (error) {
+    // eslint-disable-next-line no-console
+    console.error(error)
+    $notification.error(
+      error?.body?.error?.info || t('messages.error.something_went_wrong')
+    )
+  }
+}
+
+function buildClaim (entity, qualifiers = [], value = null, removable = true) {
+  const lbl = $wikibase.getValueByLang(entity.labels, locale.value)?.value || entity.id
+  return {
+    default: true,
+    removable,
+    property: {
+      label: lbl,
+      id: entity.id,
+      datatype: entity.datatype
+    },
+    mainsnak: {
+      property: entity.id
+    },
+    claimsValues: [],
+    value: {
+      property: entity.id,
+      datatype: entity.datatype,
+      datavalue: {
+        default: true,
+        value
+      }
+    },
+    qualifiers
+  }
+}
+
+function buildQualifier (claim, qualifier) {
+  const lbl = $wikibase.getValueByLang(qualifier.labels, locale.value)?.value || qualifier.id
+  return {
+    default: true,
+    property: {
+      id: qualifier.id,
+      label: lbl,
+      datatype: qualifier.datatype
+    },
+    datatype: qualifier.datatype,
+    datavalue: {
+      value: null
+    }
+  }
+}
+
+async function getDefaultClaims (itemNumber) {
+  const def = ['P476', 'P131']
+  const res = await $wikibase.getClaimsOrderForNewItem(props.table)
+  const propertyIds = [...new Set([...def, ...Object.keys(res)])]
+  const qualifiersProperties = [...new Set(Object.values(res).flat())]
+  const entities = await $wikibase.getEntities(propertyIds, locale.value)
+  const qualifiersArr = await $wikibase.getEntities(qualifiersProperties, locale.value)
+
+  Object.values(entities).forEach((entity) => {
+    if (isValidPropertyEntity(entity)) {
+      const qualifiers = []
+
+      res[entity.id]?.forEach((property) => {
+        if (isValidPropertyEntity(qualifiersArr[property])) {
+          qualifiers.push(buildQualifier(entity, qualifiersArr[property]))
+        }
+      })
+
+      let claim = buildClaim(entity, qualifiers, null)
+
+      if (entity.id === 'P476') {
+        claim = buildClaim(entity, [], generatePbId(itemNumber), false)
+      } else if (entity.id === 'P131') {
+        const bibliographyMap = {
+          BETA: 'Q254471',
+          BITECA: 'Q256810',
+          BITAGAP: 'Q256809'
+        }
+        const bibliographyId = bibliographyMap[props.database] || null
+
+        const bibliographyQualifiers = [
+          {
+            default: true,
+            property: 'P700',
+            datatype: 'wikibase-item',
+            datavalue: {
+              value: {
+                id: 'Q447226'
+              }
+            }
+          }
+        ]
+
+        claim = buildClaim(entity, bibliographyQualifiers, bibliographyId ? { id: bibliographyId } : null)
+      } else if (props.table === 'cnum' && entity.id === 'P590') {
+        claim = buildClaim(entity, qualifiers, null, false)
+      } else if (props.table === 'copid' && entity.id === 'P839') {
+        claim = buildClaim(entity, qualifiers, null, false)
+      }
+
+      initialClaims.value.push(claim)
+    }
+  })
+}
+
+function isValidPropertyEntity (entity) {
+  return entity?.title?.startsWith('Property:') && entity?.labels
+}
+
+function generatePbId (lastItemPbId) {
+  return `${props.database} ${props.table} ${parseInt(lastItemPbId) + 1}`
+}
+
+function updateClaims (data) {
+  initialClaims.value = data
+  claims.value = generateClaimsData(data)
+  generateLabelFromClaims()
+}
+
+function generateClaimsData (data) {
+  const result = {}
+  data.forEach((claim) => {
+    if (claim.property) {
+      const claimKey = claim?.property?.id
+
+      result[claimKey] = result[claimKey] || []
+      const extractValue = v => v?.datavalue?.value?.id ?? v?.datavalue?.value
+
+      const createClaim = (val, qualifiers = {}) => ({
+        value: extractValue(val),
+        qualifiers
+      })
+
+      const qualifiers = Object.fromEntries(
+        (claim.qualifiers || []).map(q => [q.property, extractValue(q)])
+      )
+
+      result[claimKey].push(createClaim(claim.value, qualifiers))
+
+      const values = Object.values(claim.claimsValues || {}) || []
+      values.forEach((v) => {
+        result[claimKey].push(createClaim(v))
+      })
+    }
+  })
+  return result
+}
+
+function cleanClaims (claimsToClean) {
+  const cleanedClaims = {}
+
+  for (const [propertyId, claimArray] of Object.entries(claimsToClean)) {
+    const cleanedClaimArray = []
+
+    for (const claim of claimArray) {
+      const value = claim?.value
+      if (value == null || value === '') {
+        continue
+      }
+
+      const cleanedQualifiers = {}
+      for (const [qualKey, qualVal] of Object.entries(claim.qualifiers || {})) {
+        if (
+          qualKey &&
+          qualKey !== 'null' &&
+          qualVal != null &&
+          qualVal !== 'null' &&
+          qualVal !== ''
+        ) {
+          cleanedQualifiers[qualKey] = qualVal
+        }
+      }
+
+      cleanedClaimArray.push({
+        value,
+        qualifiers: cleanedQualifiers
+      })
+    }
+
+    if (cleanedClaimArray.length) {
+      cleanedClaims[propertyId] = cleanedClaimArray
+    }
+  }
+
+  return cleanedClaims
+}
+
+async function create () {
+  const existingPBID = await $wikibase.getEntityFromPBID(pbid.value)
+  if (existingPBID === null) {
+    try {
+      const cleanedClaims = cleanClaims(claims.value)
+
+      const data = {
+        labels: {
+          [locale.value]: label.value
+        },
+        descriptions: {
+          [locale.value]: description.value || ' '
+        },
+        claims: {
+          ...cleanedClaims
+        }
+      }
+
+      const response = await $wikibase.getWbEdit().entity.create(data, authStore.requestConfig)
+
+      if (response.success) {
+        await router.push(localePath('/item/' + response.entity.id))
+      } else {
+        $notification.error(t('messages.error.something_went_wrong'))
+      }
+    } catch (error) {
+      $notification.error(
+        error.body.error.info ?? t('messages.error.something_went_wrong')
+      )
+    }
+  } else {
+    $notification.error(t('messages.error.creation.pbid_already_exists', {
+      pbid: pbid.value,
+      item: `&nbsp;<a target="_blank" style="color: #ffffff; font-weight: bold;" href="${$wikibase.getQItemUrl(existingPBID)}">${existingPBID}</a>`
+    }))
+  }
+}
+
+function formatTime (raw) {
+  const cleaned = raw.replace(/^\+/, '')
+  const date = new Date(cleaned)
+  return new Intl.DateTimeFormat('en', {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric'
+  }).format(date)
+}
+
+function safeFormatTime (timeString) {
+  if (!timeString || typeof timeString !== 'string' || !timeString.trim()) {
+    return undefined
+  }
+  const datePattern = /^[+-]?\d{4}-\d{2}-\d{2}/
+  if (!datePattern.test(timeString)) {
+    return undefined
+  }
+  try {
+    return formatTime(timeString)
+  } catch (error) {
+    return undefined
+  }
+}
+
+function getClaimValue (claimPbid) {
+  const claim = initialClaims.value.find(cl => cl.property?.id === claimPbid)
+  const val = claim?.value?.datavalue?.value
+
+  if (!val) {
+    return null
+  }
+  if (typeof val === 'object') {
+    if (val.time !== undefined) {
+      const formatted = safeFormatTime(val.time)
+      return val.label || val.text || formatted || val.id
+    }
+    return val.label || val.text || val.id
+  }
+  return val
+}
+
+function generateLabelFromClaims () {
+  let generatedLabel = ''
+  switch (props.table) {
+    case 'texid': {
+      const author = getClaimValue('P21')
+      const title = getClaimValue('P11')
+      if (author && title) {
+        generatedLabel = `${author}. ${title}`
+      }
+      break
+    }
+    case 'cnum': {
+      const work = getClaimValue('P590')
+      const partOf = getClaimValue('P8')
+      if (work && partOf) {
+        generatedLabel = `Witness of ${work}, part of ${partOf}`
+      }
+      break
+    }
+    case 'bibid': {
+      const surname = getClaimValue('P247')
+      const author = getClaimValue('P21')
+      const creator = getClaimValue('P1134')
+      const title = getClaimValue('P11')
+      const date = getClaimValue('P222')
+
+      const name = surname || author || creator
+
+      if (name && title) {
+        const datePart = date ? ` (${date})` : ''
+        generatedLabel = `${name}${datePart}, ${title}`
+      }
+      break
+    }
+    case 'bioid': {
+      const fallbackProps = ['P34', 'P77', 'P173', 'P291', 'P165', 'P746']
+      for (const bioPbid of fallbackProps) {
+        const val = getClaimValue(bioPbid)
+        if (val) {
+          generatedLabel = val
+          break
+        }
+      }
+      break
+    }
+    case 'manid': {
+      const holding = getClaimValue('P329')
+      const position = getClaimValue('P10')
+      if (holding && position) {
+        generatedLabel = `${holding}, ${position}`
+      }
+      break
+    }
+    case 'copid': {
+      const holding = getClaimValue('P329')
+      const position = getClaimValue('P10')
+      const edition = getClaimValue('P839')
+      if (holding && position && edition) {
+        generatedLabel = `${holding}, ${position} (${edition})`
+      }
+      break
+    }
+    case 'geoid':
+    case 'insid': {
+      const name = getClaimValue('P34')
+      const region = getClaimValue('P297')
+      if (name && region) {
+        generatedLabel = `${name}, ${region}`
+      }
+      break
+    }
+    case 'libid': {
+      const name = getClaimValue('P34')
+      const location = getClaimValue('P47')
+      if (name && location) {
+        generatedLabel = `${name}, ${location}`
+      }
+      break
+    }
+    case 'subid': {
+      const name = getClaimValue('P34')
+      if (name) {
+        generatedLabel = name
+      }
+      break
+    }
+    default:
+      break
+  }
+
+  label.value = generatedLabel || ''
 }
 </script>
 

--- a/frontend/components/item/Notes.vue
+++ b/frontend/components/item/Notes.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="notes">
     <div v-if="loadingContent">
-      {{ $t('common.loading' ) }}
+      {{ t('common.loading') }}
     </div>
     <!-- eslint-disable-next-line vue/no-v-html -->
     <span v-else-if="!isUserLogged" v-html="contentView" />
@@ -9,120 +9,114 @@
   </div>
 </template>
 
-<script>
+<script setup>
+import { computed, onMounted, ref } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { useAuthStore } from '~/stores/auth'
 
-export default {
-  props: {
-    itemId: {
-      type: String,
-      default: null
-    }
-  },
-  data () {
-    return {
-      content: null,
-      loadingContent: false
-    }
-  },
-  computed: {
-    isUserLogged () {
-      return this.$store.state.auth.isLogged
-    },
-    contentView () {
-      return this.$sanitize(this.content?.value)
-    }
-  },
-  async mounted () {
-    this.loadingContent = true
-    this.content = await this.$wikibase.getDiscussionPage(this.itemId)
-    this.$emit('has-notes', !!this.content?.value)
-    if (this.content?.value) {
-      this.content.value = this.convertWikiLinksToHtml(this.content.value)
-    }
-    this.loadingContent = false
-  },
-  methods: {
-    async editValue (value) {
-      try {
-        value = this.convertHtmlLinksToWiki(value)
-        const response = await this.$wikibase.updateDiscussionPage(this.itemId, value)
-        if (response.status === 200) {
-          const data = await response.json()
-          if (data.edit?.result === 'Success') {
-            this.content.value = value
-            this.$notification.success(this.$t('messages.success.updated'))
-          } else {
-            this.$notification.error(`Error editing notes page: ${data.error?.info}`)
-          }
-        } else {
-          this.$notification.error(`HTTP error editing notes: ${response.status}`)
-        }
-      } catch (error) {
-        // eslint-disable-next-line no-console
-        console.error('Error editing notes:', error)
-        this.$notification.error(`Error editing notes: ${error}`)
+const props = defineProps({
+  itemId: { type: String, default: null }
+})
+
+const emit = defineEmits(['has-notes'])
+
+const { $notification, $wikibase, $sanitize } = useNuxtApp()
+const { t } = useI18n()
+const config = useRuntimeConfig().public
+const authStore = useAuthStore()
+
+const content = ref(null)
+const loadingContent = ref(false)
+
+const isUserLogged = computed(() => authStore.isLogged)
+const contentView = computed(() => $sanitize(content.value?.value))
+
+onMounted(async () => {
+  loadingContent.value = true
+  content.value = await $wikibase.getDiscussionPage(props.itemId)
+  emit('has-notes', !!content.value?.value)
+  if (content.value?.value) {
+    content.value.value = convertWikiLinksToHtml(content.value.value)
+  }
+  loadingContent.value = false
+})
+
+async function editValue (value) {
+  try {
+    value = convertHtmlLinksToWiki(value)
+    const response = await $wikibase.updateDiscussionPage(props.itemId, value)
+    if (response.status === 200) {
+      const data = await response.json()
+      if (data.edit?.result === 'Success') {
+        content.value.value = value
+        $notification.success(t('messages.success.updated'))
+      } else {
+        $notification.error(`Error editing notes page: ${data.error?.info}`)
       }
-    },
-    convertWikiLinksToHtml (content) {
-      // convert external links
-      content = content.replace(/\[(https?:\/\/[^\s\]]+)(?:\s([^\]]+))?\]/g, (match, url, label) => {
-        label = label || url
-        label = label.replace(/&/g, '&amp;')
-          .replace(/</g, '&lt;')
-          .replace(/>/g, '&gt;')
-        return `<a href="${url}" target="_blank">${label}</a>`
-      })
-      // convert internal links
-      content = content.replace(/\[\[(.+?)\]\]/g, (match, inner) => {
-        let [target, label] = inner.split('|')
-        label = label || target
-
-        label = label.replace(/&/g, '&amp;')
-          .replace(/</g, '&lt;')
-          .replace(/>/g, '&gt;')
-
-        target = target.trim()
-        let url = target
-        if (target.startsWith('Item:')) {
-          target = target.replace(/^Item:/, '')
-          url = this.$wikibase.getQItemUrl(target)
-        }
-
-        return `<a href="${url}" target="_blank">${label}</a>`
-      })
-
-      return content
-    },
-    convertHtmlLinksToWiki (content) {
-      return content.replace(/<a\s+[^>]*href=["']([^"']+)["'][^>]*>(.*?)<\/a>/gi, (match, href, text) => {
-        const cleanHref = href.trim()
-        const cleanText = text.trim()
-
-        const wikibasePrefix = this.$config.wikibaseBaseUrl + '/wiki/'
-        const isInternal = cleanHref.startsWith(wikibasePrefix)
-
-        if (isInternal) {
-          // convert internal links
-          const internalTarget = cleanHref.slice(wikibasePrefix.length)
-          if (internalTarget === cleanText) {
-            return `[[${internalTarget}]]`
-          } else {
-            return `[[${internalTarget}|${cleanText}]]`
-          }
-        } else {
-          // convert external links
-          /* eslint-disable-next-line no-lonely-if */
-          if (cleanHref === cleanText) {
-            return `[${cleanHref}]`
-          } else {
-            return `[${cleanHref} ${cleanText}]`
-          }
-        }
-      })
+    } else {
+      $notification.error(`HTTP error editing notes: ${response.status}`)
     }
+  } catch (error) {
+    // eslint-disable-next-line no-console
+    console.error('Error editing notes:', error)
+    $notification.error(`Error editing notes: ${error}`)
   }
 }
 
+function convertWikiLinksToHtml (str) {
+  str = str.replace(/\[(https?:\/\/[^\s\]]+)(?:\s([^\]]+))?\]/g, (match, url, label) => {
+    label = label || url
+    label = label.replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+    return `<a href="${url}" target="_blank">${label}</a>`
+  })
+  str = str.replace(/\[\[(.+?)\]\]/g, (match, inner) => {
+    let [target, label] = inner.split('|')
+    label = label || target
+
+    label = label.replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+
+    target = target.trim()
+    let url = target
+    if (target.startsWith('Item:')) {
+      target = target.replace(/^Item:/, '')
+      url = $wikibase.getQItemUrl(target)
+    }
+
+    return `<a href="${url}" target="_blank">${label}</a>`
+  })
+
+  return str
+}
+
+function convertHtmlLinksToWiki (str) {
+  return str.replace(/<a\s+[^>]*href=["']([^"']+)["'][^>]*>(.*?)<\/a>/gi, (match, href, text) => {
+    const cleanHref = href.trim()
+    const cleanText = text.trim()
+
+    const wikibasePrefix = config.wikibaseBaseUrl + '/wiki/'
+    const isInternal = cleanHref.startsWith(wikibasePrefix)
+
+    if (isInternal) {
+      const internalTarget = cleanHref.slice(wikibasePrefix.length)
+      if (internalTarget === cleanText) {
+        return `[[${internalTarget}]]`
+      } else {
+        return `[[${internalTarget}|${cleanText}]]`
+      }
+    } else {
+      /* eslint-disable-next-line no-lonely-if */
+      if (cleanHref === cleanText) {
+        return `[${cleanHref}]`
+      } else {
+        return `[${cleanHref} ${cleanText}]`
+      }
+    }
+  })
+}
 </script>
 
 <style scoped>

--- a/frontend/components/item/value/Base.vue
+++ b/frontend/components/item/value/Base.vue
@@ -9,146 +9,127 @@
       :delete="isEditable ? deleteValue : null"
       :mode="mode"
       :value-to-view="valueToView"
-      @on-blur="$emit('on-blur', $event)"
-      @new-value="$emit('new-value', $event)"
+      @on-blur="emit('on-blur', $event)"
+      @new-value="emit('new-value', $event)"
     />
   </div>
 </template>
 
-<script>
-export default {
-  props: {
-    claim: {
-      type: Object,
-      default: null
-    },
-    reference: {
-      type: Object,
-      default: null
-    },
-    label: {
-      type: String,
-      default: null
-    },
-    value: {
-      type: Object,
-      default: null
-    },
-    type: {
-      type: String,
-      default: null
-    },
-    mode: {
-      type: String,
-      default: 'edit'
-    }
-  },
-  data () {
-    return {
-      valueToView: null
-    }
-  },
-  computed: {
-    isEditable () {
-      return this.mode === 'edit'
-    }
-  },
-  async mounted () {
-    this.valueToView = await this.$wikibase.getWbValue(
-      this.value.property,
-      this.value.datatype,
-      this.value.datavalue?.value,
-      this.$i18n.locale
-    )
-  },
-  methods: {
-    editValue (editableData) {
-      if (!editableData.validation.valid ||
-        (JSON.stringify(editableData.values.newValue) === JSON.stringify(editableData.values.oldValue))) {
-        if (editableData.validation.message) {
-          this.$notification.error(editableData.validation.message)
-        }
-        return new Promise((resolve, _reject) => {
-          return resolve()
-        })
-      }
+<script setup>
+import { computed, onMounted, ref } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { useAuthStore } from '~/stores/auth'
 
-      if (this.type === 'claim') {
-        return this.$wikibase.getWbEdit().claim.update({
-          guid: this.claim.id,
-          newValue: editableData.values.newValue
-        },
-        this.$store.getters['auth/getRequestConfig'])
-      } else if (this.type === 'qualifier') {
-        return this.$wikibase.getWbEdit().qualifier.update({
-          guid: this.claim.id,
-          property: this.value.property,
-          oldValue: editableData.values.oldValue,
-          newValue: editableData.values.newValue
-        },
-        this.$store.getters['auth/getRequestConfig'])
-      } else if (this.type === 'reference') {
-        const snaks = Object.entries(this.reference.snaks).reduce((acc, [key, values]) => {
-          acc[key] = values.map(v => v.hash === this.value.hash ? editableData.values.newValue : v.datavalue.value.id ?? v.datavalue.value)
-          return acc
-        }, {})
+const props = defineProps({
+  claim: { type: Object, default: null },
+  reference: { type: Object, default: null },
+  label: { type: String, default: null },
+  value: { type: Object, default: null },
+  type: { type: String, default: null },
+  mode: { type: String, default: 'edit' }
+})
 
-        return this.setReference(snaks)
-      } else {
-        // eslint-disable-next-line no-console
-        console.error(`Unknown type to edit: ${this.type}`)
-      }
-    },
-    deleteValue () {
-      if (this.type === 'claim') {
-        const res = this.$wikibase.getWbEdit().claim.remove({
-          guid: this.claim.id
-        }, this.$store.getters['auth/getRequestConfig'])
-        this.$emit('delete-claim', this.claim)
-        return res
-      } else if (this.type === 'reference') {
-        const snaks = Object.entries(this.reference.snaks).reduce((acc, [key, values]) => {
-          const filteredValues = values.filter(v => v.hash !== this.value.hash)
-          if (filteredValues.length > 0) {
-            acc[key] = filteredValues.map(v => v.datavalue.value.id ?? v.datavalue.value)
-          }
-          return acc
-        }, {})
+const emit = defineEmits(['on-blur', 'new-value', 'delete-claim', 'delete-qualifier', 'create-reference', 'delete-reference'])
 
-        if (!Object.keys(snaks).length) {
-          return this.removeReference()
-        } else {
-          return this.setReference(snaks)
-        }
-      } else {
-        const res = this.$wikibase.getWbEdit().qualifier.remove({
-          guid: this.claim.id,
-          hash: this.value.hash
-        }, this.$store.getters['auth/getRequestConfig'])
-        this.$emit('delete-qualifier', this.value)
-        return res
-      }
-    },
-    setReference (snaks) {
-      return this.$wikibase.getWbEdit().reference.set({
-        snaks,
-        guid: this.claim.id,
-        hash: this.reference.hash,
-        property: this.value.property
-      }, this.$store.getters['auth/getRequestConfig']).then((res) => {
-        this.$emit('create-reference', res)
-        return res
-      })
-    },
-    removeReference () {
-      return this.$wikibase.getWbEdit().reference.remove({
-        guid: this.claim.id,
-        hash: this.reference.hash
-      }, this.$store.getters['auth/getRequestConfig']).then((res) => {
-        this.$emit('delete-reference', this.reference)
-        return res
-      })
+const { $notification, $wikibase } = useNuxtApp()
+const { locale } = useI18n()
+const authStore = useAuthStore()
+
+const valueToView = ref(null)
+const isEditable = computed(() => props.mode === 'edit')
+
+onMounted(async () => {
+  valueToView.value = await $wikibase.getWbValue(
+    props.value.property,
+    props.value.datatype,
+    props.value.datavalue?.value,
+    locale.value
+  )
+})
+
+function editValue (editableData) {
+  if (!editableData.validation.valid ||
+    (JSON.stringify(editableData.values.newValue) === JSON.stringify(editableData.values.oldValue))) {
+    if (editableData.validation.message) {
+      $notification.error(editableData.validation.message)
     }
+    return Promise.resolve()
   }
+
+  if (props.type === 'claim') {
+    return $wikibase.getWbEdit().claim.update({
+      guid: props.claim.id,
+      newValue: editableData.values.newValue
+    }, authStore.requestConfig)
+  } else if (props.type === 'qualifier') {
+    return $wikibase.getWbEdit().qualifier.update({
+      guid: props.claim.id,
+      property: props.value.property,
+      oldValue: editableData.values.oldValue,
+      newValue: editableData.values.newValue
+    }, authStore.requestConfig)
+  } else if (props.type === 'reference') {
+    const snaks = Object.entries(props.reference.snaks).reduce((acc, [key, values]) => {
+      acc[key] = values.map(v => v.hash === props.value.hash ? editableData.values.newValue : v.datavalue.value.id ?? v.datavalue.value)
+      return acc
+    }, {})
+
+    return setReference(snaks)
+  } else {
+    console.error(`Unknown type to edit: ${props.type}`)
+  }
+}
+
+function deleteValue () {
+  if (props.type === 'claim') {
+    const res = $wikibase.getWbEdit().claim.remove({
+      guid: props.claim.id
+    }, authStore.requestConfig)
+    emit('delete-claim', props.claim)
+    return res
+  } else if (props.type === 'reference') {
+    const snaks = Object.entries(props.reference.snaks).reduce((acc, [key, values]) => {
+      const filteredValues = values.filter(v => v.hash !== props.value.hash)
+      if (filteredValues.length > 0) {
+        acc[key] = filteredValues.map(v => v.datavalue.value.id ?? v.datavalue.value)
+      }
+      return acc
+    }, {})
+
+    if (!Object.keys(snaks).length) {
+      return removeReference()
+    } else {
+      return setReference(snaks)
+    }
+  } else {
+    const res = $wikibase.getWbEdit().qualifier.remove({
+      guid: props.claim.id,
+      hash: props.value.hash
+    }, authStore.requestConfig)
+    emit('delete-qualifier', props.value)
+    return res
+  }
+}
+
+function setReference (snaks) {
+  return $wikibase.getWbEdit().reference.set({
+    snaks,
+    guid: props.claim.id,
+    hash: props.reference.hash,
+    property: props.value.property
+  }, authStore.requestConfig).then((res) => {
+    emit('create-reference', res)
+    return res
+  })
+}
+
+function removeReference () {
+  return $wikibase.getWbEdit().reference.remove({
+    guid: props.claim.id,
+    hash: props.reference.hash
+  }, authStore.requestConfig).then((res) => {
+    emit('delete-reference', props.reference)
+    return res
+  })
 }
 </script>

--- a/frontend/components/privacy-policy/Base.vue
+++ b/frontend/components/privacy-policy/Base.vue
@@ -1,51 +1,54 @@
 <template>
   <div class="container">
-    <h2>{{ $i18n.t('privacyPolicy.label') }}</h2>
-    <h3>{{ $i18n.t('privacyPolicy.consent.title') }}</h3>
+    <h2>{{ t('privacyPolicy.label') }}</h2>
+    <h3>{{ t('privacyPolicy.consent.title') }}</h3>
     <!-- eslint-disable-next-line vue/no-v-html -->
-    <p v-html="$i18n.t('privacyPolicy.consent.desc')" />
-    <h3>{{ $i18n.t('privacyPolicy.comments.title') }}</h3>
+    <p v-html="t('privacyPolicy.consent.desc')" />
+    <h3>{{ t('privacyPolicy.comments.title') }}</h3>
     <p>
-      <strong>{{ $i18n.t('privacyPolicy.comments.subtitle') }}:</strong>
-      {{ $i18n.t('privacyPolicy.comments.subtitleDesc') }}
+      <strong>{{ t('privacyPolicy.comments.subtitle') }}:</strong>
+      {{ t('privacyPolicy.comments.subtitleDesc') }}
     </p>
     <!-- eslint-disable-next-line vue/no-v-html -->
-    <p v-html="$i18n.t('privacyPolicy.comments.desc')" />
+    <p v-html="t('privacyPolicy.comments.desc')" />
     <p>
-      <strong>{{ $i18n.t('privacyPolicy.userAgent.subtitle') }}:</strong>
-      {{ $i18n.t('privacyPolicy.userAgent.subtitleDesc') }}
+      <strong>{{ t('privacyPolicy.userAgent.subtitle') }}:</strong>
+      {{ t('privacyPolicy.userAgent.subtitleDesc') }}
     </p>
     <p>
-      <strong>{{ $i18n.t('privacyPolicy.retentionPeriod.subtitle') }}:</strong>
-      {{ $i18n.t('privacyPolicy.retentionPeriod.subtitleDesc') }}
+      <strong>{{ t('privacyPolicy.retentionPeriod.subtitle') }}:</strong>
+      {{ t('privacyPolicy.retentionPeriod.subtitleDesc') }}
     </p>
-    <h3>{{ $i18n.t('privacyPolicy.legitimateInterest.title') }}</h3>
+    <h3>{{ t('privacyPolicy.legitimateInterest.title') }}</h3>
     <!-- eslint-disable-next-line vue/no-v-html -->
-    <p v-html="$i18n.t('privacyPolicy.legitimateInterest.desc')" />
-    <h3>{{ $i18n.t('privacyPolicy.statistics.title') }}</h3>
+    <p v-html="t('privacyPolicy.legitimateInterest.desc')" />
+    <h3>{{ t('privacyPolicy.statistics.title') }}</h3>
     <!-- eslint-disable-next-line vue/no-v-html -->
-    <p v-html="$i18n.t('privacyPolicy.statistics.desc')" />
-    <h3>{{ $i18n.t('privacyPolicy.embedContent.title') }}</h3>
+    <p v-html="t('privacyPolicy.statistics.desc')" />
+    <h3>{{ t('privacyPolicy.embedContent.title') }}</h3>
     <!-- eslint-disable-next-line vue/no-v-html -->
-    <p v-html="$i18n.t('privacyPolicy.embedContent.desc')" />
-    <h3>{{ $i18n.t('privacyPolicy.rights.title') }}</h3>
+    <p v-html="t('privacyPolicy.embedContent.desc')" />
+    <h3>{{ t('privacyPolicy.rights.title') }}</h3>
     <!-- eslint-disable-next-line vue/no-v-html -->
-    <p v-html="$i18n.t('privacyPolicy.rights.desc')" />
+    <p v-html="t('privacyPolicy.rights.desc')" />
     <!-- eslint-disable-next-line vue/no-v-html -->
-    <p v-html="$i18n.t('privacyPolicy.rights.data')" />
+    <p v-html="t('privacyPolicy.rights.data')" />
   </div>
 </template>
 
-<script>
-export default {
-  props: {
-    breadcrumbItems: {
-      type: Array,
-      default: null
-    }
-  },
-  mounted () {
-    this.$store.commit('breadcrumb/setItems', this.breadcrumbItems)
-  }
-}
+<script setup>
+import { onMounted } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { useBreadcrumbStore } from '~/stores/breadcrumb'
+
+const props = defineProps({
+  breadcrumbItems: { type: Array, default: null }
+})
+
+const { t } = useI18n()
+const breadcrumbStore = useBreadcrumbStore()
+
+onMounted(() => {
+  breadcrumbStore.setItems(props.breadcrumbItems)
+})
 </script>

--- a/frontend/components/search/Base.vue
+++ b/frontend/components/search/Base.vue
@@ -34,132 +34,121 @@
   </div>
 </template>
 
-<script>
-export default {
+<script setup>
+import { computed, onBeforeUnmount, onMounted, ref } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { useBreadcrumbStore } from '~/stores/breadcrumb'
+import { useQueryStatusStore } from '~/stores/queryStatus'
 
-  props: {
-    table: {
-      type: String,
-      default: null
-    },
-    formDefinition: {
-      type: Object,
-      default: null
-    },
-    breadcrumbItems: {
-      type: Array,
-      default: null
-    }
-  },
+const props = defineProps({
+  table: { type: String, default: null },
+  formDefinition: { type: Object, default: null },
+  breadcrumbItems: { type: Array, default: null }
+})
 
-  data () {
-    return {
-      database: null,
-      form: null,
-      showResults: false,
-      waitingCount: false,
-      waitingItems: false,
-      sparqlQuery: null,
-      resultsPerPage: 50,
-      results: [],
-      totalResults: 0
-    }
-  },
+const { $notification, $wikibase } = useNuxtApp()
+const { locale } = useI18n()
+const router = useRouter()
+const localePath = useLocalePath()
+const breadcrumbStore = useBreadcrumbStore()
+const queryStatusStore = useQueryStatusStore()
 
-  computed: {
-    waitingResults () {
-      return this.waitingItems || this.waitingCount
-    }
-  },
+const database = ref(null)
+const form = ref(null)
+const showResults = ref(false)
+const waitingCount = ref(false)
+const waitingItems = ref(false)
+const sparqlQuery = ref(null)
+const resultsPerPage = 50
+const results = ref([])
+const totalResults = ref(0)
+const qs = ref(null)
 
-  created () {
-    if (this.$store.state.queryStatus.currentTable !== this.table) {
-      this.$store.commit('queryStatus/resetStatus', this.table)
-    }
-    const form = this.$store.state.queryStatus.form
-    if (form) {
-      this.form = form
-    } else {
-      this.form = this.formDefinition
-    }
-    if (this.$store.state.queryStatus.showResults === true) {
-      this.countAndSearch()
-    }
-  },
+const waitingResults = computed(() => waitingItems.value || waitingCount.value)
 
-  mounted () {
-    this.$store.commit('breadcrumb/setItems', this.breadcrumbItems)
-    this.$store.commit('breadcrumb/setClass', 'large-font-breadcrumb')
-  },
+if (queryStatusStore.currentTable !== props.table) {
+  queryStatusStore.resetStatus(props.table)
+}
+const storedForm = queryStatusStore.form
+if (storedForm) {
+  form.value = storedForm
+} else {
+  form.value = props.formDefinition
+}
+if (queryStatusStore.showResults === true) {
+  countAndSearch()
+}
 
-  destroyed () {
-    this.$store.commit('breadcrumb/setClass', '')
-  },
+onMounted(() => {
+  breadcrumbStore.setItems(props.breadcrumbItems)
+  breadcrumbStore.setClass('large-font-breadcrumb')
+})
 
-  methods: {
-    countAndSearch () {
-      this.$store.commit('queryStatus/setForm', JSON.parse(JSON.stringify(this.form)))
-      this.count()
-      this.search()
-    },
+onBeforeUnmount(() => {
+  breadcrumbStore.setClass('')
+})
 
-    count () {
-      this.waitingCount = true
-      this.$wikibase.runSparqlQuery(this.$wikibase.$query.countQuery(this.table, this.form, this.$i18n.locale), true)
-        .then((results) => {
-          this.totalResults = results[0]
-          this.waitingCount = false
-        })
-        .catch((err) => {
-          this.waitingCount = false
-          this.$notification.error(err)
-        })
-    },
+function countAndSearch () {
+  queryStatusStore.setForm(JSON.parse(JSON.stringify(form.value)))
+  count()
+  search()
+}
 
-    search () {
-      this.waitingItems = true
-      this.sparqlQuery = this.$wikibase.$query.itemsQuery(this.table, this.form, this.$i18n.locale, this.resultsPerPage)
-      this.results = []
-      this.$wikibase.runSparqlQuery(this.sparqlQuery)
-        .then((results) => {
-          Object.entries(results).forEach(
-            ([key, result]) => this.results.push(result)
-          )
-          this.waitingItems = false
-          this.showResults = true
-        })
-        .catch((err) => {
-          this.waitingItems = false
-          this.$refs.qs.back()
-          this.$notification.error(err)
-        })
-    },
+function count () {
+  waitingCount.value = true
+  $wikibase.runSparqlQuery($wikibase.$query.countQuery(props.table, form.value, locale.value), true)
+    .then((res) => {
+      totalResults.value = res[0]
+      waitingCount.value = false
+    })
+    .catch((err) => {
+      waitingCount.value = false
+      $notification.error(err)
+    })
+}
 
-    clearResults () {
-      this.showResults = false
-      this.waitingCount = false
-      this.waitingItems = false
-      this.$store.commit('queryStatus/setShowResults', this.showResults)
-      this.$store.commit('queryStatus/setPage', 1)
-      this.$store.commit('queryStatus/setSortBy', 'name')
-      this.$store.commit('queryStatus/setSortDescending', false)
-    },
-
-    onDatabaseChange (newDatabase) {
-      this.database = newDatabase
-    },
-
-    goToItem (id) {
-      this.$router.push(
-        this.localePath({
-          path: '/item/' + id,
-          query: {
-            database: this.database,
-            table: this.table
-          }
-        })
+function search () {
+  waitingItems.value = true
+  sparqlQuery.value = $wikibase.$query.itemsQuery(props.table, form.value, locale.value, resultsPerPage)
+  results.value = []
+  $wikibase.runSparqlQuery(sparqlQuery.value)
+    .then((res) => {
+      Object.entries(res).forEach(
+        ([, result]) => results.value.push(result)
       )
-    }
-  }
+      waitingItems.value = false
+      showResults.value = true
+    })
+    .catch((err) => {
+      waitingItems.value = false
+      qs.value?.back()
+      $notification.error(err)
+    })
+}
+
+function clearResults () {
+  showResults.value = false
+  waitingCount.value = false
+  waitingItems.value = false
+  queryStatusStore.setShowResults(showResults.value)
+  queryStatusStore.setPage(1)
+  queryStatusStore.setSortBy('name')
+  queryStatusStore.setSortDescending(false)
+}
+
+function onDatabaseChange (newDatabase) {
+  database.value = newDatabase
+}
+
+function goToItem (id) {
+  router.push(
+    localePath({
+      path: '/item/' + id,
+      query: {
+        database: database.value,
+        table: props.table
+      }
+    })
+  )
 }
 </script>

--- a/frontend/components/search/Filters.vue
+++ b/frontend/components/search/Filters.vue
@@ -4,17 +4,17 @@
       <v-row dense>
         <v-col cols="7">
           <v-radio-group
-            v-model="search_group.value"
-            :disabled="search_group.disabled"
-            row
-            @change="onGroupChange"
+            v-model="searchGroup.value"
+            :disabled="searchGroup.disabled"
+            inline
+            @update:model-value="onGroupChange"
           >
             <template #label>
-              {{ $t('search.form.common.group.label') }}
+              {{ t('search.form.common.group.label') }}
             </template>
             <v-radio
               v-for="group in groups"
-              :key="'g-'+group"
+              :key="'g-' + (group.value ? group.value : group)"
               class="group-option"
               :label="group.text ? group.text : group"
               :value="group.value ? group.value : group"
@@ -24,45 +24,44 @@
         <v-col cols="1">
           <v-select
             v-if="isBitagapSelected"
-            v-model="bitagap_group.value"
-            :disabled="bitagap_group.disabled"
+            v-model="bitagapGroup.value"
+            :disabled="bitagapGroup.disabled"
             :items="bitagapOptions"
-            item-text="text"
+            item-title="text"
             item-value="value"
-            :label="$t('search.form.common.bitagap_group.label')"
+            :label="t('search.form.common.bitagap_group.label')"
           />
         </v-col>
       </v-row>
-      <template v-for="(section) in form.section">
-        <v-row v-if="!isPrimarySection(section) && existsSectionFilters(section) && !showResults" :key="'header-' + section" dense>
-          <span class="section-search text-caption mb-2 primary--text" @click="toggleSectionDisplay(section)">
-            {{ $t(`search.form.common.section.${section}`) }} <v-icon class="primary--text">{{ isSectionDisplayed(section) ? 'mdi-chevron-up' : 'mdi-chevron-down' }}</v-icon>
+      <template v-for="(section) in form.section" :key="`section-${section}`">
+        <v-row v-if="!isPrimarySection(section) && existsSectionFilters(section) && !showResults" dense>
+          <span class="section-search text-caption mb-2 text-primary" @click="toggleSectionDisplay(section)">
+            {{ t(`search.form.common.section.${section}`) }} <v-icon class="text-primary">{{ isSectionDisplayed(section) ? 'mdi-chevron-up' : 'mdi-chevron-down' }}</v-icon>
           </span>
         </v-row>
-        <v-row v-if="isSectionDisplayed(section)" :key="'body-' + section" dense>
-          <template v-for="(item, name) in getInputsBySection(section)">
+        <v-row v-if="isSectionDisplayed(section)" dense>
+          <template v-for="(item, name) in getInputsBySection(section)" :key="'i-' + name">
             <v-col
               v-if="(item.active && !item.permanent && item.visible)"
-              :key="'i-'+name"
               cols="4"
             >
               <search-util-text-field
                 v-if="item.type === 'text'"
                 v-model="item.value"
-                :label="$t(item.label)"
-                :hint="$t(item.hint)"
+                :label="t(item.label)"
+                :hint="t(item.hint)"
                 :disabled="item.disabled"
               />
               <search-util-autocomplete-field
                 v-if="item.type === 'autocomplete'"
-                :id="'auto-'+name"
+                :id="'auto-' + name"
                 v-model="item.value"
-                :label="$t(item.label)"
-                :hint="$t(item.hint)"
+                :label="t(item.label)"
+                :hint="t(item.hint)"
                 :disabled="item.disabled"
                 :table="table"
-                :database="search_group.value"
-                :bitagap-group="bitagap_group.value"
+                :database="searchGroup.value"
+                :bitagap-group="bitagapGroup.value"
                 :autocomplete="item.autocomplete"
                 @click.stop
                 @reset-value="(val) => item.value = val"
@@ -70,8 +69,8 @@
               <search-util-date-field
                 v-if="item.type === 'date'"
                 :value="item.value"
-                :label="$t(item.label)"
-                :hint="$t(item.hint)"
+                :label="t(item.label)"
+                :hint="t(item.hint)"
                 :disabled="item.disabled"
                 @update-begin-date="item.value['begin'] = $event"
                 @update-end-date="item.value['end'] = $event"
@@ -81,53 +80,46 @@
         </v-row>
       </template>
       <v-row dense>
-        <v-col
-          cols="7"
-        >
+        <v-col cols="7">
           <v-btn
             v-if="!showResults"
-            ref="search"
+            ref="searchBtn"
             class="mr-4"
-            small
+            size="small"
             elevation="2"
             @click="search"
           >
-            {{ $t('search.button.search') }}
+            {{ t('search.button.search') }}
           </v-btn>
           <v-btn
             v-if="showResults"
             elevation="2"
             class="mr-4"
-            small
+            size="small"
             :disabled="waitingResults"
             @click="back"
           >
-            {{ $t('search.button.back') }}
+            {{ t('search.button.back') }}
           </v-btn>
           <v-btn
             elevation="2"
             class="mr-4"
-            small
+            size="small"
             :disabled="waitingResults"
             @click="clear"
           >
-            {{ $t('search.button.clear') }}
+            {{ t('search.button.clear') }}
           </v-btn>
         </v-col>
-        <v-col
-          cols="4"
-          class="search-type"
-        >
+        <v-col cols="4" class="search-type">
           <v-switch
-            v-model="search_type.value"
-            dense
-            :disabled="search_type.disabled"
-            :label="search_type.value ? $t('search.form.common.search_type.all_words') : $t('search.form.common.search_type.any_word')"
+            v-model="searchType.value"
+            density="compact"
+            :disabled="searchType.disabled"
+            :label="searchType.value ? t('search.form.common.search_type.all_words') : t('search.form.common.search_type.any_word')"
           />
         </v-col>
-        <v-col
-          cols="1"
-        >
+        <v-col cols="1">
           <v-icon
             color="primary"
             @click="goToHelp()"
@@ -140,233 +132,217 @@
   </v-form>
 </template>
 
-<script>
-export default {
+<script setup>
+import { computed, onBeforeUnmount, onMounted, reactive, ref, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { useAuthStore } from '~/stores/auth'
+import { useQueryStatusStore } from '~/stores/queryStatus'
 
-  props: {
-    table: {
-      type: String,
-      required: true
-    },
-    form: {
-      type: Object,
-      default: null
-    },
-    waitingResults: {
-      type: Boolean,
-      default: false
+const props = defineProps({
+  table: { type: String, required: true },
+  form: { type: Object, default: null },
+  waitingResults: { type: Boolean, default: false }
+})
+
+const emit = defineEmits(['on-search', 'back-search', 'clear-search', 'database-change'])
+
+const { t, locale } = useI18n()
+const router = useRouter()
+const authStore = useAuthStore()
+const queryStatusStore = useQueryStatusStore()
+
+const searchGroup = reactive(props.form.input.group)
+const searchType = reactive(props.form.input.search_type)
+const bitagapGroup = reactive(props.form.input.bitagap_group)
+const filtersBySection = reactive(groupFiltersBySection(props.form))
+const showResults = ref(false)
+const isBitagapSelected = ref(false)
+const searchBtn = ref(null)
+
+// eslint-disable-next-line no-unused-vars
+const isUserLogged = computed(() => authStore.isLogged)
+
+const groups = computed(() => [
+  'BETA',
+  'BITAGAP',
+  'BITECA',
+  { text: t('search.form.common.group_all.label'), value: 'ALL' }
+])
+
+const bitagapOptions = computed(() => [
+  { text: t('search.form.common.bitagap_group.options.all'), value: 'ALL' },
+  { text: t('search.form.common.bitagap_group.options.original'), value: 'ORIG' },
+  { text: t('search.form.common.bitagap_group.options.cartas'), value: 'CARTAS' }
+])
+
+watch(showResults, (newValue) => {
+  queryStatusStore.setShowResults(newValue)
+})
+
+if (queryStatusStore.showResults) {
+  showResults.value = queryStatusStore.showResults
+}
+loadDefaultBibliography()
+
+onMounted(() => {
+  calculateSectionsToDisplay()
+  window.addEventListener('keydown', keyDownHandler)
+})
+
+onBeforeUnmount(() => {
+  window.removeEventListener('keydown', keyDownHandler)
+})
+
+function calculateSectionsToDisplay () {
+  Object.keys(filtersBySection).forEach((section) => {
+    filtersBySection[section].show = existsSectionFiltersSelected(section)
+  })
+}
+
+function existsSectionFiltersSelected (section) {
+  return Object.values(props.form.input).some(item => item.section === section && isFieldValueNotEmpty(item.value))
+}
+
+function getInputsBySection (section) {
+  return filtersBySection[section].input.reduce((acc, key) => {
+    if (key in props.form.input) {
+      acc[key] = props.form.input[key]
     }
-  },
+    return acc
+  }, {})
+}
 
-  data () {
-    return {
-      search_group: {},
-      search_type: {},
-      bitagap_group: {},
-      filtersBySection: {},
-      showResults: false,
-      isBitagapSelected: false
+function isPrimarySection (section) {
+  return section === 'primary'
+}
+
+function isSectionDisplayed (section) {
+  return isPrimarySection(section) || filtersBySection[section].show
+}
+
+function toggleSectionDisplay (section) {
+  filtersBySection[section].show = !filtersBySection[section].show
+}
+
+function groupFiltersBySection (form) {
+  const result = {}
+  Object.entries(form.input).forEach(([key, value]) => {
+    const section = value.section
+    if (section) {
+      if (!result[section]) {
+        result[section] = { input: [], show: false }
+      }
+      result[section].input.push(key)
     }
-  },
+  })
+  return result
+}
 
-  computed: {
-    isUserLogged () {
-      return this.$store.state.auth.isLogged
-    },
-    groups () {
-      return ['BETA', 'BITAGAP', 'BITECA', { text: this.$t('search.form.common.group_all.label'), value: 'ALL' }]
-    },
-    bitagapOptions () {
-      return [{ text: this.$t('search.form.common.bitagap_group.options.all'), value: 'ALL' },
-        { text: this.$t('search.form.common.bitagap_group.options.original'), value: 'ORIG' },
-        { text: this.$t('search.form.common.bitagap_group.options.cartas'), value: 'CARTAS' }]
+function existsSectionFilters (section) {
+  return Object.values(props.form.input).some(item => item.section === section)
+}
+
+function keyDownHandler (event) {
+  if (event.code === 'Enter') {
+    if (document.activeElement.id && document.activeElement.id.startsWith('auto')) {
+      return
     }
-  },
+    searchBtn.value?.$el.focus()
+    search()
+  }
+}
 
-  watch: {
-    showResults (newValue, oldValue) {
-      this.$store.commit('queryStatus/setShowResults', newValue)
+function search () {
+  for (const key in props.form.input) {
+    const item = props.form.input[key]
+    if (!item.value ||
+      (item.value instanceof Object && Object.keys(item.value).length === 0)) {
+      item.visible = false
+      if (item.type === 'autocomplete') {
+        item.value = ''
+      }
     }
-  },
+    item.disabled = true
+  }
+  showResults.value = true
+  emit('on-search', props.form)
+}
 
-  created () {
-    this.search_group = this.form.input.group
-    this.search_type = this.form.input.search_type
-    this.bitagap_group = this.form.input.bitagap_group
-    this.filtersBySection = this.groupFiltersBySection(this.form)
-    const showResults = this.$store.state.queryStatus.showResults
-    if (showResults) {
-      this.showResults = showResults
+function back () {
+  for (const key in props.form.input) {
+    const item = props.form.input[key]
+    item.visible = true
+    item.disabled = false
+  }
+  showResults.value = false
+  calculateSectionsToDisplay()
+  queryStatusStore.setForm(JSON.parse(JSON.stringify(props.form)))
+  emit('back-search')
+}
+
+function clear () {
+  for (const key in props.form.input) {
+    const item = props.form.input[key]
+    if (item.type === 'date') {
+      item.value = {}
+    } else {
+      item.value = ''
     }
-    // Load saved default bibliography from localStorage
-    this.loadDefaultBibliography()
-  },
+    item.visible = true
+    item.disabled = false
+  }
+  searchGroup.value = 'ALL'
+  isBitagapSelected.value = false
+  bitagapGroup.value = 'ALL'
+  searchType.value = true
+  showResults.value = false
+  calculateSectionsToDisplay()
+  queryStatusStore.setForm(null)
+  emit('clear-search')
+}
 
-  mounted () {
-    this.calculateSectionsToDisplay()
-    window.addEventListener('keydown', this.keyDownHandler)
-  },
+function goToHelp () {
+  router.push(`../../wiki/${locale.value}_Help`)
+}
 
-  destroyed () {
-    window.removeEventListener('keydown', this.keyDownHandler)
-  },
+function isFieldValueNotEmpty (item) {
+  if (typeof item === 'string' && item !== '') {
+    return true
+  }
+  if (typeof item === 'object' && item != null && Object.keys(item).length > 0) {
+    return true
+  }
+  return false
+}
 
-  methods: {
-    calculateSectionsToDisplay () {
-      Object.keys(this.filtersBySection).forEach((section) => {
-        if (this.existsSectionFiltersSelected(section)) {
-          this.filtersBySection[section].show = true
-        } else {
-          this.filtersBySection[section].show = false
-        }
-      })
-    },
-    existsSectionFiltersSelected (section) {
-      return Object.values(this.form.input).some(item => item.section === section && this.isFieldValueNotEmpty(item.value))
-    },
-    getInputsBySection (section) {
-      return this.filtersBySection[section].input.reduce((acc, key) => {
-        if (key in this.form.input) {
-          acc[key] = this.form.input[key]
-        }
-        return acc
-      }, {})
-    },
-    isPrimarySection (section) {
-      return section === 'primary'
-    },
-    isSectionDisplayed (section) {
-      return this.isPrimarySection(section) || this.filtersBySection[section].show
-    },
-    toggleSectionDisplay (section) {
-      this.filtersBySection[section].show = !this.filtersBySection[section].show
-    },
-    groupFiltersBySection (form) {
-      const filtersBySection = {}
-      Object.entries(form.input).forEach(([key, value]) => {
-        const section = value.section
-        if (section) {
-          if (!filtersBySection[section]) {
-            filtersBySection[section] = {}
-            filtersBySection[section].input = []
-            filtersBySection[section].show = false
-          }
-          filtersBySection[section].input.push(key)
-        }
-      })
-      return filtersBySection
-    },
-    existsSectionFilters (section) {
-      return Object.values(this.form.input).some(item => item.section === section)
-    },
-    keyDownHandler (event) {
-      if (event.code === 'Enter') {
-        // Not search in autocomplete fields to avoid weird display errors
-        if (document.activeElement.id && document.activeElement.id.startsWith('auto')) {
-          return
-        }
-        this.$refs.search.$el.focus()
-        this.search()
-      }
-    },
-    search () {
-      for (const key in this.form.input) {
-        const item = this.form.input[key]
-        if (!item.value ||
-          (item.value instanceof Object && Object.keys(item.value).length === 0)) {
-          item.visible = false
-          // force to change empty object to empty string for autocomplete fields
-          // if not, query service detects that a value was filled
-          if (item.type === 'autocomplete') {
-            item.value = ''
-          }
-        }
-        item.disabled = true
-      }
-      this.showResults = true
-      this.$emit('on-search', this.form)
-    },
-    back () {
-      for (const key in this.form.input) {
-        const item = this.form.input[key]
-        item.visible = true
-        item.disabled = false
-      }
-      this.showResults = false
-      this.calculateSectionsToDisplay()
-      this.$store.commit('queryStatus/setForm', JSON.parse(JSON.stringify(this.form)))
-      this.$emit('back-search')
-    },
-    clear () {
-      for (const key in this.form.input) {
-        const item = this.form.input[key]
-        if (item.type === 'date') {
-          item.value = {}
-        } else {
-          item.value = ''
-        }
-        item.visible = true
-        item.disabled = false
-      }
-      this.search_group.value = 'ALL'
-      this.isBitagapSelected = false
-      this.bitagap_group.value = 'ALL'
-      this.search_type.value = true
-      this.showResults = false
-      this.calculateSectionsToDisplay()
-      this.$store.commit('queryStatus/setForm', null)
-      this.$emit('clear-search')
-    },
-    goTo (path, params) {
-      if (this.$i18n.locale !== 'en') {
-        path = `/${this.$i18n.locale}${path}`
-      }
-      this.$router.push({
-        path,
-        query: params
-      })
-    },
-    goToHelp () {
-      this.$router.push(`../../wiki/${this.$i18n.locale}_Help`)
-    },
-    isFieldValueNotEmpty (item) {
-      if (typeof item === 'string' && item !== '') {
-        return true
-      }
-      if (typeof item === 'object' && item != null && Object.keys(item).length > 0) {
-        return true
-      }
-      return false
-    },
-    onGroupChange (newDatabase) {
-      if (newDatabase === 'BITAGAP' && this.table !== 'libid') {
-        this.isBitagapSelected = true
-      } else {
-        this.isBitagapSelected = false
-        this.bitagap_group.value = 'ALL'
-      }
-      // Save selected bibliography to localStorage for next session
-      this.saveDefaultBibliography(newDatabase)
-      this.$emit('database-change', newDatabase)
-    },
-    loadDefaultBibliography () {
-      // Only load default if no specific bibliography is already set
-      if (this.search_group.value === 'ALL' && typeof localStorage !== 'undefined') {
-        const savedBibliography = localStorage.getItem('philobiblon_default_bibliography')
-        if (savedBibliography && ['BETA', 'BITAGAP', 'BITECA'].includes(savedBibliography)) {
-          this.search_group.value = savedBibliography
-          // Trigger the change handler to update related state
-          this.onGroupChange(savedBibliography)
-        }
-      }
-    },
-    saveDefaultBibliography (bibliography) {
-      if (typeof localStorage !== 'undefined' && ['BETA', 'BITAGAP', 'BITECA'].includes(bibliography)) {
-        localStorage.setItem('philobiblon_default_bibliography', bibliography)
-      }
+function onGroupChange (newDatabase) {
+  if (newDatabase === 'BITAGAP' && props.table !== 'libid') {
+    isBitagapSelected.value = true
+  } else {
+    isBitagapSelected.value = false
+    bitagapGroup.value = 'ALL'
+  }
+  saveDefaultBibliography(newDatabase)
+  emit('database-change', newDatabase)
+}
+
+function loadDefaultBibliography () {
+  if (searchGroup.value === 'ALL' && typeof localStorage !== 'undefined') {
+    const savedBibliography = localStorage.getItem('philobiblon_default_bibliography')
+    if (savedBibliography && ['BETA', 'BITAGAP', 'BITECA'].includes(savedBibliography)) {
+      searchGroup.value = savedBibliography
+      onGroupChange(savedBibliography)
     }
   }
 }
+
+function saveDefaultBibliography (bibliography) {
+  if (typeof localStorage !== 'undefined' && ['BETA', 'BITAGAP', 'BITECA'].includes(bibliography)) {
+    localStorage.setItem('philobiblon_default_bibliography', bibliography)
+  }
+}
+
+defineExpose({ back })
 </script>
 
 <style scoped>

--- a/frontend/components/search/Results.vue
+++ b/frontend/components/search/Results.vue
@@ -5,98 +5,93 @@
       v-model="currentTab"
       height="20"
     >
-      <v-tab key="results">
-        {{ $t('search.results.results') }} ({{ totalResults }})
+      <v-tab value="results">
+        {{ t('search.results.results') }} ({{ totalResults }})
       </v-tab>
     </v-tabs>
-    <v-tabs-items
+    <v-window
       v-if="showResults"
       v-model="currentTab"
     >
-      <v-tab-item key="results">
+      <v-window-item value="results">
         <v-container v-if="totalResults == 0">
-          <span>{{ $t('search.results.not_found') }}</span>
+          <span>{{ t('search.results.not_found') }}</span>
         </v-container>
         <v-container v-if="totalResults > 0" class="container-max">
           <v-row dense>
             <v-col class="order-last order-sm-first" cols="10">
-              <v-list>
-                <v-list-item-group
-                  v-model="selectedItem"
-                  color="primary"
+              <v-list v-model:selected="selectedItem" color="primary">
+                <v-list-item
+                  v-for="(result, index) in results"
+                  :key="'r-' + index"
+                  :value="result.item"
+                  @click="goToItem(result.item)"
                 >
-                  <v-list-item v-for="(result, index) in results" :key="'r-'+index" @click="goToItem(result.item)">
-                    <v-list-item-content>
-                      <v-list-item-title>
-                        {{ result.label }}&nbsp;&nbsp;&nbsp;<span class="text-caption">{{ result.pbids }}</span>
-                      </v-list-item-title>
-                      <v-list-item-subtitle class="my-item-subtitle">
-                        {{ result.desc }}
-                      </v-list-item-subtitle>
-                    </v-list-item-content>
-                  </v-list-item>
-                </v-list-item-group>
+                  <v-list-item-title>
+                    {{ result.label }}&nbsp;&nbsp;&nbsp;<span class="text-caption">{{ result.pbids }}</span>
+                  </v-list-item-title>
+                  <v-list-item-subtitle class="my-item-subtitle">
+                    {{ result.desc }}
+                  </v-list-item-subtitle>
+                </v-list-item>
               </v-list>
             </v-col>
             <v-col>
               <v-container class="container-max">
                 <v-row justify="end" dense>
                   <v-col class="text-right text-caption">
-                    <span>{{ $t('search.results.sort_by') }}</span>
+                    <span>{{ t('search.results.sort_by') }}</span>
                   </v-col>
                   <v-col cols="auto" class="sort-select-field">
                     <v-select
                       v-model="sortBy"
                       :items="sortItems"
-                      items-text="text"
-                      items-value="value"
+                      item-title="text"
+                      item-value="value"
                       class="text-body-2"
-                      dense
-                      @change="changeSortByID"
+                      density="compact"
+                      @update:model-value="changeSortByID"
                     />
                   </v-col>
                   <v-col cols="auto">
-                    <!-- Alphabetical sort icons (name) -->
                     <v-icon
                       v-if="isSortByName && !isSortDescending"
-                      dense
+                      density="compact"
                       @click="changeSortDescending"
                     >
                       mdi-sort-alphabetical-ascending
                     </v-icon>
                     <v-icon
                       v-if="isSortByName && isSortDescending"
-                      dense
+                      density="compact"
                       @click="changeSortDescending"
                     >
                       mdi-sort-alphabetical-descending
                     </v-icon>
-                    <!-- Numeric sort icons (id) -->
                     <v-icon
                       v-if="isSortByID && !isSortDescending"
-                      dense
+                      density="compact"
                       @click="changeSortDescending"
                     >
                       mdi-sort-numeric-ascending
                     </v-icon>
                     <v-icon
                       v-if="isSortByID && isSortDescending"
-                      dense
+                      density="compact"
                       @click="changeSortDescending"
                     >
                       mdi-sort-numeric-descending
                     </v-icon>
-                    <!-- Date sort icons -->
                     <v-icon
                       v-if="isSortByDate && !isSortDescending"
-                      dense
+                      density="compact"
                       @click="changeSortDescending"
                     >
                       mdi-sort-calendar-ascending
                     </v-icon>
                     <v-icon
                       v-if="isSortByDate && isSortDescending"
-                      dense
+                      density="compact"
                       @click="changeSortDescending"
                     >
                       mdi-sort-calendar-descending
@@ -105,7 +100,7 @@
                 </v-row>
                 <v-row justify="end" dense>
                   <v-col class="text-right text-caption">
-                    <a :href="$config.sparqlBaseUrl+'/#'+encodeURI(sparqlQuery)" target="_blank">SPARQL</a>
+                    <a :href="config.sparqlBaseUrl + '/#' + encodeURI(sparqlQuery)" target="_blank">SPARQL</a>
                   </v-col>
                 </v-row>
               </v-container>
@@ -118,107 +113,70 @@
             v-model="currentPage"
             :length="Math.ceil(totalResults / resultsPerPage)"
             :total-visible="5"
-            circle
-            @input="changePage"
+            @update:model-value="changePage"
           />
         </div>
-      </v-tab-item>
-    </v-tabs-items>
+      </v-window-item>
+    </v-window>
   </div>
 </template>
 
-<script>
-export default {
+<script setup>
+import { computed, onBeforeUpdate, ref } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { useQueryStatusStore } from '~/stores/queryStatus'
 
-  props: {
-    sparqlQuery: {
-      type: String,
-      default: null
-    },
-    results: {
-      type: Array,
-      default: null
-    },
-    totalResults: {
-      type: Number,
-      default: 0
-    },
-    resultsPerPage: {
-      type: Number,
-      default: 0
-    },
-    showResults: {
-      type: Boolean,
-      default: false
-    }
-  },
+const props = defineProps({
+  sparqlQuery: { type: String, default: null },
+  results: { type: Array, default: null },
+  totalResults: { type: Number, default: 0 },
+  resultsPerPage: { type: Number, default: 0 },
+  showResults: { type: Boolean, default: false }
+})
 
-  data () {
-    return {
-      currentTab: null,
-      selectedItem: '',
-      sortItems: [
-        {
-          text: this.$i18n.t('search.results.sort_option.id'),
-          value: 'id'
-        },
-        {
-          text: this.$i18n.t('search.results.sort_option.name'),
-          value: 'name'
-        },
-        {
-          text: this.$i18n.t('search.results.sort_option.date'),
-          value: 'date'
-        }
-      ],
-      sortBy: null,
-      currentPage: null
-    }
-  },
+const emit = defineEmits(['on-sort-by-id', 'on-sort-descending', 'on-pagination', 'go-to-item'])
 
-  computed: {
-    isSortDescending () {
-      return this.$store.state.queryStatus.isSortDescending
-    },
+const { t } = useI18n()
+const config = useRuntimeConfig().public
+const queryStatusStore = useQueryStatusStore()
 
-    isSortByID () {
-      return this.sortBy === 'id'
-    },
+const currentTab = ref(null)
+const selectedItem = ref([])
+const sortItems = [
+  { text: t('search.results.sort_option.id'), value: 'id' },
+  { text: t('search.results.sort_option.name'), value: 'name' },
+  { text: t('search.results.sort_option.date'), value: 'date' }
+]
+const sortBy = ref(null)
+const currentPage = ref(null)
 
-    isSortByName () {
-      return this.sortBy === 'name'
-    },
+const isSortDescending = computed(() => queryStatusStore.isSortDescending)
+const isSortByID = computed(() => sortBy.value === 'id')
+const isSortByName = computed(() => sortBy.value === 'name')
+const isSortByDate = computed(() => sortBy.value === 'date')
 
-    isSortByDate () {
-      return this.sortBy === 'date'
-    }
-  },
+onBeforeUpdate(() => {
+  sortBy.value = queryStatusStore.sortBy
+  currentPage.value = queryStatusStore.currentPage
+})
 
-  beforeUpdate () {
-    this.sortBy = this.$store.state.queryStatus.sortBy
-    this.currentPage = this.$store.state.queryStatus.currentPage
-  },
+function changePage (val) {
+  queryStatusStore.setPage(val)
+  emit('on-pagination', val)
+}
 
-  methods: {
-    changePage (val) {
-      this.$store.commit('queryStatus/setPage', val)
-      this.$emit('on-pagination', val)
-    },
+function changeSortByID () {
+  queryStatusStore.setSortBy(sortBy.value)
+  emit('on-sort-by-id', isSortByID.value)
+}
 
-    changeSortByID () {
-      this.$store.commit('queryStatus/setSortBy', this.sortBy)
-      this.$emit('on-sort-by-id', this.isSortByID)
-    },
+function changeSortDescending () {
+  queryStatusStore.setSortDescending(!isSortDescending.value)
+  emit('on-sort-descending', !isSortDescending.value)
+}
 
-    changeSortDescending () {
-      this.$store.commit('queryStatus/setSortDescending', !this.isSortDescending)
-      this.$emit('on-sort-descending', !this.isSortDescending)
-    },
-
-    goToItem (id) {
-      this.$emit('go-to-item', id)
-    }
-  }
+function goToItem (id) {
+  emit('go-to-item', id)
 }
 </script>
 

--- a/frontend/components/search/Simple.vue
+++ b/frontend/components/search/Simple.vue
@@ -2,80 +2,74 @@
   <div class="search-container" :class="{'welcome-container': isWelcome}">
     <v-autocomplete
       rounded
-      item-props
       :items="items"
       item-value="id"
-      item-text="title"
+      item-title="title"
       class="search-bar"
       :class="{welcome: isWelcome}"
       style="max-width: 450px;"
       :loading="loading"
-      :search-input.sync="search"
+      v-model:search="search"
       prepend-inner-icon="mdi-magnify"
-      :placeholder="$t('wiki.search.placeholder')"
+      :placeholder="t('wiki.search.placeholder')"
       append-inner-icon="mdi-microphone"
-      @change="onItemSelected"
+      @update:model-value="onItemSelected"
     />
   </div>
 </template>
 
-<script>
-export default {
-  data () {
-    return {
-      items: [],
-      search: '',
-      loading: false
-    }
-  },
-  computed: {
-    isWelcome () {
-      return this.$route.path.includes('Welcome')
-    }
-  },
-  watch: {
-    search (val) {
-      if (val) {
-        this.searchItems(val)
-      }
-    }
-  },
-  methods: {
-    async searchItems (search) {
-      if (search.length < 2) {
-        this.items = []
-        return
-      }
+<script setup>
+import { computed, ref, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
 
-      this.loading = true
+const { $wikibase } = useNuxtApp()
+const { t, locale } = useI18n()
+const router = useRouter()
+const route = useRoute()
+const localePath = useLocalePath()
 
-      try {
-        this.results = []
-        const sparqlQuery = this.$wikibase.$query.allItemsQuery(search, this.$i18n.locale)
+const items = ref([])
+const search = ref('')
+const loading = ref(false)
 
-        const items = await this.$wikibase.runSparqlQuery(sparqlQuery)
-        console.log(items)
-        this.items = this.customizeSearchData(items)
-      } catch (error) {
-        // eslint-disable-next-line no-console
-        console.error('Error fetching items:', error)
-      } finally {
-        this.loading = false
-      }
-    },
-    customizeSearchData (items) {
-      return items.map((item) => {
-        return {
-          id: item.pbid,
-          title: item.label
-        }
-      })
-    },
-    onItemSelected (id) {
-      if (id) {
-        this.$router.push(this.localePath(`/item/${id}`))
-      }
-    }
+const isWelcome = computed(() => route.path.includes('Welcome'))
+
+watch(search, (val) => {
+  if (val) {
+    searchItems(val)
+  }
+})
+
+async function searchItems (query) {
+  if (query.length < 2) {
+    items.value = []
+    return
+  }
+
+  loading.value = true
+
+  try {
+    const sparqlQuery = $wikibase.$query.allItemsQuery(query, locale.value)
+    const res = await $wikibase.runSparqlQuery(sparqlQuery)
+    items.value = customizeSearchData(res)
+  } catch (error) {
+    // eslint-disable-next-line no-console
+    console.error('Error fetching items:', error)
+  } finally {
+    loading.value = false
+  }
+}
+
+function customizeSearchData (res) {
+  return res.map(item => ({
+    id: item.pbid,
+    title: item.label
+  }))
+}
+
+function onItemSelected (id) {
+  if (id) {
+    router.push(localePath(`/item/${id}`))
   }
 }
 </script>
@@ -96,11 +90,11 @@ export default {
   justify-content: center;
 }
 
-::v-deep .search-bar .v-text-field__details{
+:deep(.search-bar .v-text-field__details) {
   display: none;
 }
 
-::v-deep .search-bar:not(.welcome) .v-input__slot {
+:deep(.search-bar:not(.welcome) .v-input__slot) {
   padding-top: unset!important;
   margin: unset;
 }
@@ -110,41 +104,41 @@ export default {
   padding-top: unset;
 }
 
-::v-deep .v-application .v-autocomplete__content.v-menu__content {
+:deep(.v-application .v-autocomplete__content.v-menu__content) {
   width: 598px!important;
 }
 
-::v-deep .v-autocomplete .v-input__control {
+:deep(.v-autocomplete .v-input__control) {
   background-color: white !important;
   border: 1px solid #dcdcdc !important;
   border-radius: 24px !important;
   transition: border-color 0.3s, box-shadow 0.3s;
 }
 
-::v-deep .v-autocomplete .v-input__append-inner,
-::v-deep .v-autocomplete .v-input__prepend-inner {
+:deep(.v-autocomplete .v-input__append-inner),
+:deep(.v-autocomplete .v-input__prepend-inner) {
   display: flex;
   align-items: center;
   justify-content: center;
 }
 
-::v-deep .v-autocomplete .v-input__append-inner .v-icon,
-::v-deep .v-autocomplete .v-input__prepend-inner .v-icon {
+:deep(.v-autocomplete .v-input__append-inner .v-icon),
+:deep(.v-autocomplete .v-input__prepend-inner .v-icon) {
   color: rgba(0, 0, 0, 0.54);
 }
 
-::v-deep .v-autocomplete .v-input__control .v-input__slot {
+:deep(.v-autocomplete .v-input__control .v-input__slot) {
   padding-top: 10px;
   border-radius: 24px;
 }
 
-::v-deep .v-autocomplete .v-input__control:hover,
-::v-deep .v-autocomplete .v-input__control:focus-within {
+:deep(.v-autocomplete .v-input__control:hover),
+:deep(.v-autocomplete .v-input__control:focus-within) {
   border-color: #4285f4 !important;
   box-shadow: 0 1px 6px rgba(32, 33, 36, 0.28) !important;
 }
 
-::v-deep .v-autocomplete .v-list-item__title {
+:deep(.v-autocomplete .v-list-item__title) {
   color: black;
 }
 </style>


### PR DESCRIPTION
## Summary

Sub-PR #7 of the Nuxt 3 migration. Converts the 13 orchestrator components
(the top-level pages use these directly) from Vue 2 Options API to Vue 3
`<script setup>` Composition API with Pinia stores and Vuetify 3 patterns.

Stacked on top of #418 (`feat/nuxt3-components-mid`).

## Components migrated

- \`item/value/Base.vue\` — value dispatcher
- \`item/Base.vue\` — item view orchestrator
- \`item/Claims.vue\` — claims list dispatcher
- \`item/Create.vue\` — new item creation form
- \`item/Notes.vue\` — discussion page (quill)
- \`search/Base.vue\` — search orchestrator
- \`search/Filters.vue\` — filters form
- \`search/Results.vue\` — results list
- \`search/Simple.vue\` — top-bar autocomplete
- \`create/Base.vue\` — create entry point
- \`LanguagesMenu.vue\` — language menu
- \`PhiloFooter.vue\` — footer
- \`privacy-policy/Base.vue\` — static policy

## Cross-cutting patterns applied

- \`this.\$store.state.*\` → \`useXxxStore()\` Pinia accessors
- \`this.\$i18n.t\` / \`this.\$t\` → \`const { t, locale } = useI18n()\`
- \`this.\$router.push\` / \`this.localePath()\` → \`useRouter()\` + \`useLocalePath()\`
- \`v-radio-group row\` → \`inline\`
- \`v-list-item-group\` → plain \`v-list\` with \`v-model:selected\`
- \`v-tabs-items\` / \`v-tab-item\` → \`v-window\` / \`v-window-item\`
- \`v-btn text/outlined\` → \`variant="text|outlined"\`
- \`v-btn small\` → \`size="small"\`
- \`dense\` → \`density="compact"\`
- \`@change\` on selects → \`@update:model-value\`
- \`v-tooltip top/right/bottom\` → \`location="..."\`
- \`v-pagination @input\` → \`@update:model-value\`, drop \`circle\`
- \`primary--text\` / \`grey--text\` → \`text-primary\` / \`text-grey\`
- \`:search-input.sync\` → \`v-model:search\`
- \`item-text\` → \`item-title\`
- \`v-tooltip\` activator \`{on,attrs}\` → \`{props}\`
- \`::v-deep\` → \`:deep()\`
- \`destroyed()\` → \`onBeforeUnmount()\`

## Test plan

- [ ] \`yarn lint\` passes on \`feat/nuxt3-components-orchestrators\`
- [ ] \`yarn dev\` boots with no Vue compilation errors
- [ ] Navigate to \`/en/search/texid/query\` — filters render, search runs, results list renders
- [ ] Click a result → item view opens with label/description, claims, related items
- [ ] Language menu cycles \`ca/es/en/gl/pt\` with correct URL prefix
- [ ] Footer links navigate correctly
- [ ] Privacy policy page renders with breadcrumb
- [ ] Create flow (logged-in): \`/en/create/texid/query?database=BETA\` → form valid → submit persists

🤖 Generated with [Claude Code](https://claude.com/claude-code)