### PR TITLE
feat(frontend): Nuxt 3 migration — layouts + Vuetify 3 polish (Sub-PR #8)

### DIFF
--- a/frontend/error.vue
+++ b/frontend/error.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-app dark>
+  <v-app theme="dark">
     <h1 v-if="error.statusCode === 404">
       {{ pageNotFound }}
     </h1>

--- a/frontend/layouts/default.vue
+++ b/frontend/layouts/default.vue
@@ -4,81 +4,66 @@
       v-model="drawer"
       style="height: 99vh;"
       color="primary"
-      :permanent="!$vuetify.breakpoint.sm && !$vuetify.breakpoint.xs && !$vuetify.breakpoint.md"
-      app
-      dark
+      :permanent="!mdAndDown"
+      theme="dark"
     >
       <template #prepend>
-        <v-list-item v-if="username" two-line>
-          <v-list-item-avatar>
-            <v-icon>
-              mdi-account
-            </v-icon>
-          </v-list-item-avatar>
-          <v-list-item-content>
-            {{ username }}
-          </v-list-item-content>
+        <v-list-item v-if="username" lines="two">
+          <template #prepend>
+            <v-avatar>
+              <v-icon>mdi-account</v-icon>
+            </v-avatar>
+          </template>
+          <v-list-item-title>{{ username }}</v-list-item-title>
         </v-list-item>
       </template>
 
       <v-divider />
 
       <v-list class="mainmenu">
-        <v-list-item :to="localePath('/wiki/Welcome')">
-          <v-list-item-action>
-            <v-icon>
-              mdi-apps
-            </v-icon>
-          </v-list-item-action>
-          <v-list-item-content>
-            <v-list-item-title>{{ $t('menu.item.welcome.label') }}</v-list-item-title>
-          </v-list-item-content>
+        <v-list-item :to="localePath('/wiki/Welcome')" prepend-icon="mdi-apps">
+          <v-list-item-title>{{ t('menu.item.welcome.label') }}</v-list-item-title>
         </v-list-item>
-        <v-list-group
-          prepend-icon="mdi-magnify"
-        >
-          <template #activator>
-            <v-list-item-title>{{ $t('menu.item.search.label') }}</v-list-item-title>
+        <v-list-group value="search">
+          <template #activator="{ props: activatorProps }">
+            <v-list-item v-bind="activatorProps" prepend-icon="mdi-magnify">
+              <v-list-item-title>{{ t('menu.item.search.label') }}</v-list-item-title>
+            </v-list-item>
           </template>
           <v-list-item
             v-for="item in searchItems"
             :key="item.path"
             :to="localePath(item.path)"
-            router
             exact
             class="subitem"
           >
-            <v-list-item-title>{{ $t(item.label) }}</v-list-item-title>
+            <v-list-item-title>{{ t(item.label) }}</v-list-item-title>
           </v-list-item>
         </v-list-group>
-        <v-list-group
-          v-if="$store.state.auth.isLogged"
-          prepend-icon="mdi-plus"
-        >
-          <template #activator>
-            <v-list-item-title>{{ $t('item.create.button.text') }}</v-list-item-title>
+        <v-list-group v-if="authStore.isLogged" value="create">
+          <template #activator="{ props: activatorProps }">
+            <v-list-item v-bind="activatorProps" prepend-icon="mdi-plus">
+              <v-list-item-title>{{ t('item.create.button.text') }}</v-list-item-title>
+            </v-list-item>
           </template>
           <v-list-item
             v-for="item in createItems"
             :key="item.path"
             :to="localePath(item.path)"
-            router
             exact
             class="subitem"
           >
-            <v-list-item-title>{{ $t(item.label) }}</v-list-item-title>
+            <v-list-item-title>{{ t(item.label) }}</v-list-item-title>
           </v-list-item>
         </v-list-group>
       </v-list>
     </v-navigation-drawer>
     <v-app-bar
-      fixed
-      app
-      dark
+      theme="dark"
     >
-      <template #img="{ props }">
+      <template #image="{ props: imgProps }">
         <v-img
-          v-bind="props"
+          v-bind="imgProps"
           gradient="to top right, rgba(33, 33, 33,.7), rgba(250, 250, 250,.7)"
         />
       </template>
@@ -93,29 +78,29 @@
       <v-spacer />
       <languages-menu />
       <v-btn
-        v-if="$store.state.auth.isLogged"
-        text
+        v-if="authStore.isLogged"
+        variant="text"
         height="0"
         min-width="0"
         class="lowercase"
         @click="logout"
       >
-        {{ $t('auth.logout.label') }}
+        {{ t('auth.logout.label') }}
       </v-btn>
       <v-btn
         v-else
-        text
+        variant="text"
         height="0"
         min-width="0"
         class="lowercase"
         @click="login"
       >
-        {{ $t('auth.login.label') }}
+        {{ t('auth.login.label') }}
       </v-btn>
     </v-app-bar>
     <v-main class="min-height-full-display">
-      <v-container fluid ma-50>
-        <v-breadcrumbs :items="$store.state.breadcrumb.items" :class="$store.state.breadcrumb.class" />
+      <v-container fluid>
+        <v-breadcrumbs :items="breadcrumbStore.items" :class="breadcrumbStore.class" />
         <slot />
       </v-container>
     </v-main>
@@ -123,80 +108,90 @@
   </v-app>
 </template>
 
-<script>
+<script setup>
+import { computed, onBeforeUnmount, onMounted, ref } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { useDisplay } from 'vuetify'
+import { useAuthStore } from '~/stores/auth'
+import { useBreadcrumbStore } from '~/stores/breadcrumb'
 
-export default {
-  data () {
-    return {
-      title_1: 'Philo',
-      title_2: 'Biblon',
-      drawer: false,
-      searchItems: [
-        { path: '/search/texid/query', label: 'menu.item.search.item.texid.label' },
-        { path: '/search/libid/query', label: 'menu.item.search.item.libid.label' },
-        { path: '/search/insid/query', label: 'menu.item.search.item.insid.label' },
-        { path: '/search/bioid/query', label: 'menu.item.search.item.bioid.label' },
-        { path: '/search/bibid/query', label: 'menu.item.search.item.bibid.label' },
-        { path: '/search/manid/query', label: 'menu.item.search.item.manid.label' },
-        { path: '/search/geoid/query', label: 'menu.item.search.item.geoid.label' },
-        { path: '/search/subid/query', label: 'menu.item.search.item.subid.label' }
-      ],
-      createItems: [
-        { path: '/item/texid/create', label: 'menu.item.create.item.texid.label' },
-        { path: '/item/libid/create', label: 'menu.item.create.item.libid.label' },
-        { path: '/item/insid/create', label: 'menu.item.create.item.insid.label' },
-        { path: '/item/bioid/create', label: 'menu.item.create.item.bioid.label' },
-        { path: '/item/bibid/create', label: 'menu.item.create.item.bibid.label' },
-        { path: '/item/manid/create', label: 'menu.item.create.item.manid.label' },
-        { path: '/item/geoid/create', label: 'menu.item.create.item.geoid.label' },
-        { path: '/item/subid/create', label: 'menu.item.create.item.subid.label' },
-        { path: '/item/cnum/create', label: 'menu.item.create.item.cnum.label' },
-        { path: '/item/copid/create', label: 'menu.item.create.item.copid.label' }
-      ]
-    }
-  },
-  computed: {
-    username () {
-      return this.$store.state.auth.username ? this.$store.state.auth.username : ''
-    }
-  },
-  mounted () {
-    this.$wikibase.$oauth.autoLoginByCookie()
-    window.addEventListener('keydown', this.keyDownHandler)
-  },
-  unmounted () {
-    window.removeEventListener('keydown', this.keyDownHandler)
-  },
-  methods: {
-    keyDownHandler (event) {
-      if (event.code === 'Escape') {
-        this.drawer = false
-      }
-      if (event.code === 'F1') {
-        this.drawer = !this.drawer
-      }
-    },
-    goTo (path) {
-      this.$router.push(this.localePath(path))
-    },
-    login () {
-      this.$cookies.set('previous-path', this.$route.path, {
-        path: '/',
-        maxAge: 5 * 60
-      })
-      this.$wikibase.$oauth.step1()
-    },
-    logout () {
-      this.$store.commit('auth/logout')
-      this.$notification.success(this.$i18n.t('auth.logout.success'))
-      this.$cookies.remove('oauth')
-    }
+const { $notification, $wikibase } = useNuxtApp()
+const { t } = useI18n()
+const router = useRouter()
+const route = useRoute()
+const localePath = useLocalePath()
+const { mdAndDown } = useDisplay()
+const authStore = useAuthStore()
+const breadcrumbStore = useBreadcrumbStore()
+
+const previousPathCookie = useCookie('previous-path', { path: '/', maxAge: 5 * 60 })
+const oauthCookie = useCookie('oauth')
+
+const title_1 = 'Philo'
+const title_2 = 'Biblon'
+const drawer = ref(false)
+
+const searchItems = [
+  { path: '/search/texid/query', label: 'menu.item.search.item.texid.label' },
+  { path: '/search/libid/query', label: 'menu.item.search.item.libid.label' },
+  { path: '/search/insid/query', label: 'menu.item.search.item.insid.label' },
+  { path: '/search/bioid/query', label: 'menu.item.search.item.bioid.label' },
+  { path: '/search/bibid/query', label: 'menu.item.search.item.bibid.label' },
+  { path: '/search/manid/query', label: 'menu.item.search.item.manid.label' },
+  { path: '/search/geoid/query', label: 'menu.item.search.item.geoid.label' },
+  { path: '/search/subid/query', label: 'menu.item.search.item.subid.label' }
+]
+const createItems = [
+  { path: '/item/texid/create', label: 'menu.item.create.item.texid.label' },
+  { path: '/item/libid/create', label: 'menu.item.create.item.libid.label' },
+  { path: '/item/insid/create', label: 'menu.item.create.item.insid.label' },
+  { path: '/item/bioid/create', label: 'menu.item.create.item.bioid.label' },
+  { path: '/item/bibid/create', label: 'menu.item.create.item.bibid.label' },
+  { path: '/item/manid/create', label: 'menu.item.create.item.manid.label' },
+  { path: '/item/geoid/create', label: 'menu.item.create.item.geoid.label' },
+  { path: '/item/subid/create', label: 'menu.item.create.item.subid.label' },
+  { path: '/item/cnum/create', label: 'menu.item.create.item.cnum.label' },
+  { path: '/item/copid/create', label: 'menu.item.create.item.copid.label' }
+]
+
+const username = computed(() => authStore.username || '')
+
+onMounted(() => {
+  $wikibase.$oauth.autoLoginByCookie()
+  window.addEventListener('keydown', keyDownHandler)
+})
+
+onBeforeUnmount(() => {
+  window.removeEventListener('keydown', keyDownHandler)
+})
+
+function keyDownHandler (event) {
+  if (event.code === 'Escape') {
+    drawer.value = false
   }
+  if (event.code === 'F1') {
+    drawer.value = !drawer.value
+  }
+}
+
+function goTo (path) {
+  router.push(localePath(path))
+}
+
+function login () {
+  previousPathCookie.value = route.path
+  $wikibase.$oauth.step1()
+}
+
+function logout () {
+  authStore.logout()
+  $notification.success(t('auth.logout.success'))
+  oauthCookie.value = null
 }
 </script>
 
 <style scoped>
-.mainmenu >>> .v-list-item--active {
+.mainmenu :deep(.v-list-item--active) {
   color: white;
 }
 .subitem {
@@ -206,10 +201,8 @@ export default {
   min-height: 100vh;
 }
 
-::v-deep .large-font-breadcrumb {
-  li {
-    font-size: large !important;
-  }
+:deep(.large-font-breadcrumb) li {
+  font-size: large !important;
 }
 
 .lowercase {


### PR DESCRIPTION
## Summary

Sub-PR #8 of the Nuxt 3 migration. Completes the Vuetify 3 adoption by
migrating the root layout (the last Options API holdout) and removing the
remaining Vuetify 2 idioms (breakpoint helpers, dark prop, ::v-deep).

Stacked on top of #419 (\`feat/nuxt3-components-orchestrators\`).

## Scope

- \`layouts/default.vue\` — full \`<script setup>\` rewrite
  - \$vuetify.breakpoint → useDisplay()
  - v-list-item-content/avatar/action → #prepend slot
  - v-list-group activator slot signature updated
  - \$cookies → useCookie
  - \$store → Pinia stores
  - ::v-deep → :deep()
- \`error.vue\` — \`v-app dark\` → \`v-app theme="dark"\`

Theme colors and MDI icon defaults were configured in \`nuxt.config.ts\` back in
Sub-PR #1, so nothing to add there.

## Test plan

- [ ] \`yarn lint\` passes
- [ ] Dev server boots; left drawer permanent on ≥lg, overlay on ≤md
- [ ] Drawer prepend shows logged-in username when authenticated
- [ ] Search/Create groups expand/collapse correctly
- [ ] Escape closes drawer, F1 toggles drawer
- [ ] Login flow stores previous-path cookie; logout clears oauth cookie
- [ ] Breadcrumb renders with \`large-font-breadcrumb\` class on item/search pages
- [ ] Error page renders with dark theme

🤖 Generated with [Claude Code](https://claude.com/claude-code)