### PR TITLE
feat(frontend): Nuxt 3 migration — Dockerfile update (Sub-PR #9)

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,17 +1,16 @@
 # build stage
-FROM node:lts-alpine AS build-stage
+FROM node:22-alpine AS build-stage
 WORKDIR /app
 COPY package.json ./
 ARG BASE_URL
 ARG API_BASE_URL
 RUN yarn install
 COPY . .
-ENV NODE_OPTIONS --openssl-legacy-provider
-RUN yarn run build
+RUN yarn run generate
 
 # production stage
 FROM nginx:stable-alpine AS production-stage
-COPY --from=build-stage /app/dist /usr/share/nginx/html
+COPY --from=build-stage /app/.output/public /usr/share/nginx/html
 EXPOSE 80 443
 COPY entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh


### PR DESCRIPTION
## Summary

Sub-PR #9 of the Nuxt 3 migration. Brings the Docker build pipeline in line
with Nuxt 3:

- \`node:lts-alpine\` → \`node:22-alpine\`
- Drop \`NODE_OPTIONS=--openssl-legacy-provider\` (Vite replaces webpack 4)
- Build command: \`yarn run build\` → \`yarn run generate\` (static SPA)
- Copy \`.output/public/\` instead of \`dist/\` into the nginx image

Stacked on top of #420 (\`feat/nuxt3-vuetify-theme\`).

## Why

Nuxt 3's default build output lives at \`.output/public/\` when generated with
\`nuxi generate\`, not \`dist/\`. The OpenSSL legacy flag was a workaround for
the webpack 4 / Node 17+ interaction and is unnecessary under Vite.

## Not changed

- \`nginx.conf.template\` — \`try_files ... /index.html\` still correct for SPA
- \`entrypoint.sh\` — still substitutes env vars on the nginx config template
- \`.github/workflows/{staging,production}.yml\` — already reference
  \`frontend/nuxt.config.ts\`; the version-sed regex
  \`version: '[^']*'\` continues to work against the single-quoted literal

## Test plan

- [ ] \`docker build ./frontend --build-arg BASE_URL=/ --build-arg API_BASE_URL=/\` succeeds
- [ ] Built image exposes \`/usr/share/nginx/html/index.html\`
- [ ] Running the container + nginx + backend locally serves the SPA
- [ ] Staging workflow (workflow_dispatch) completes end-to-end on this branch
- [ ] Version-sed step confirms \`version: '<x>'\` is still rewritten correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)