### PR TITLE
chore: add devcontainer config and ignore build output

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -7,7 +7,6 @@
       "nodeGypDependencies": false
     }
   },
-  "appPort": [3000, 8080],
   "forwardPorts": [3000, 8080],
   "portsAttributes": {
     "3000": {

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,38 @@
+{
+  "name": "PhiloBiblon UI",
+  "image": "mcr.microsoft.com/devcontainers/java:17",
+  "features": {
+    "ghcr.io/devcontainers/features/node:1": {
+      "version": "lts",
+      "nodeGypDependencies": false
+    }
+  },
+  "appPort": [3000, 8080],
+  "forwardPorts": [3000, 8080],
+  "portsAttributes": {
+    "3000": {
+      "label": "Frontend (Nuxt)",
+      "onAutoForward": "notify"
+    },
+    "8080": {
+      "label": "Backend (Spring Boot)",
+      "onAutoForward": "notify"
+    }
+  },
+  "remoteEnv": {
+    "COREPACK_ENABLE_DOWNLOAD_PROMPT": "0"
+  },
+  "postCreateCommand": "npm install -g @anthropic-ai/claude-code && cd frontend && yarn install",
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "vscjava.vscode-java-pack",
+        "Vue.volar",
+        "dbaeumer.vscode-eslint"
+      ],
+      "settings": {
+        "java.configuration.updateBuildConfiguration": "automatic"
+      }
+    }
+  }
+}

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -42,6 +42,7 @@ bower_components
 
 # Compiled binary addons (https://nodejs.org/api/addons.html)
 build/Release
+.output/
 
 # Dependency directories
 node_modules/


### PR DESCRIPTION
- Add .devcontainer/devcontainer.json with Java 17 + Node LTS image, port forwarding for frontend (3000) and backend (8080), VS Code extensions, and Claude Code post-create install.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a containerized development environment with Java 17 and Node LTS, preconfigured editors/extensions, and startup tasks to install tooling and frontend dependencies for consistent local setup.
  * Updated version control to ignore generated frontend build output directories so build artifacts are no longer tracked.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->