### PR TITLE
fix(frontend): remove stale COPY .yarn from Dockerfile

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -2,7 +2,6 @@
 FROM node:22-alpine AS build-stage
 WORKDIR /app
 COPY package.json .yarnrc.yml ./
-COPY .yarn .yarn
 ARG BASE_URL
 ARG API_BASE_URL
 ENV BASE_URL=$BASE_URL


### PR DESCRIPTION
## Summary

- The `COPY .yarn .yarn` line in `frontend/Dockerfile` was causing CI builds to fail because `.yarn/` is listed in `.gitignore` and therefore does not exist in the checkout environment.
- The directory only ever contained `install-state.gz`, a local cache file generated automatically by `yarn install` that should never be committed.
- With `nodeLinker: node-modules` (as set in `.yarnrc.yml`), `yarn install` only needs `package.json` and `.yarnrc.yml` to run correctly.

## Test plan

- [ ] Verify staging CI build completes successfully after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)