### PR TITLE
fix(frontend): Nuxt 3 bump follow-up fixes

### DIFF
--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -94,8 +94,8 @@ jobs:
           script: |
             set -e
             cd ${{ vars.DEPLOY_PATH }}
-            docker compose -f docker-compose.ui-dev.yml pull
-            docker compose -f docker-compose.ui-dev.yml up -d
+            docker compose -f docker-compose.ui-local.yml -f docker-compose.ui-dev.yml pull
+            docker compose -f docker-compose.ui-local.yml -f docker-compose.ui-dev.yml up -d
             docker images --filter "dangling=true" --filter "label=org.opencontainers.image.source=https://github.com/PhiloBiblon/philobiblon-ui" -q | xargs -r docker rmi -f
 
   cleanup:

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ target/
 !.mvn/wrapper/maven-wrapper.jar
 !**/src/main/**/target/
 !**/src/test/**/target/
+.playwright*/
 
 ### IntelliJ IDEA ###
 .idea/modules.xml

--- a/frontend/components/item/claim/Values.vue
+++ b/frontend/components/item/claim/Values.vue
@@ -133,6 +133,10 @@ async function deleteQualifier (qualifier, index) {
 </script>
 
 <style scoped>
+:deep(table) {
+  table-layout: fixed;
+}
+
 :deep(.v-data-table thead th) {
   background-color: #e0e0e0;
   color: #424242 !important;

--- a/frontend/components/item/util/EditDatePickerField.vue
+++ b/frontend/components/item/util/EditDatePickerField.vue
@@ -212,7 +212,7 @@ async function deleteValue () {
 }
 
 .date-input {
-  width: 200px;
+  width: 140px;
 }
 
 :deep(.v-field__input) {

--- a/frontend/components/item/value/type/Entity.vue
+++ b/frontend/components/item/value/type/Entity.vue
@@ -143,7 +143,12 @@ function setOptionsAutocomplete () {
         })
         const defaultValue = props.valueToView.useDefault === false ? null : autocomplete.default_value
         const currentId = getDefaultValue(props.valueToView.item, defaultValue)
-        selectedOption.value = options.value.find(o => o.id === currentId) || currentId
+        let foundOption = options.value.find(o => o.id === currentId)
+        if (!foundOption && currentId && props.valueToView.item) {
+          foundOption = { id: props.valueToView.item, label: props.valueToView.value }
+          options.value.push(foundOption)
+        }
+        selectedOption.value = foundOption || null
       })
   } else {
     options.value = [{

--- a/frontend/components/item/value/type/Quantity.vue
+++ b/frontend/components/item/value/type/Quantity.vue
@@ -26,6 +26,7 @@
               :mode="mode"
               :filter="acceptAll"
               style="width: 200px"
+              class="ma-0 pa-0 mt-2"
               @update-options="unitOptions = $event"
               @input="oninput($event)"
               @new-value="newUnitValue"
@@ -62,7 +63,7 @@ const valueToView_ = reactive(getInitialValue())
 const newValue_ = reactive({ amount: null, unit: null })
 const unitItemId = ref(null)
 const unitLabel = ref(null)
-const selectedUnit = ref('')
+const selectedUnit = ref(null)
 const unitOptions = ref([])
 
 const isUserLogged = computed(() => authStore.isLogged)
@@ -130,11 +131,12 @@ async function handleSearchChange (value) {
 }
 
 function setUnitOptions () {
-  unitOptions.value = [{
+  const option = {
     id: unitItemId.value,
     label: unitLabel.value.value
-  }]
-  selectedUnit.value = unitItemId.value
+  }
+  unitOptions.value = [option]
+  selectedUnit.value = option
 }
 
 function deleteValue () {

--- a/frontend/components/item/value/type/Time.vue
+++ b/frontend/components/item/value/type/Time.vue
@@ -4,30 +4,25 @@
       {{ valueToView.value }} <sup>{{ valueToView.calendar }}</sup>
     </template>
     <template v-else>
-      <v-container class="pa-0">
-        <v-row dense class="justify-start">
-          <v-col dense class="flex-shrink-1">
-            <item-util-edit-date-picker-field
-              :value="valueToView_.value"
-              :mode="mode"
-              style="width: 200px"
-              class="ma-0 pa-0"
-              :save="editValue"
-              :delete="deleteValue"
-              @new-value="newDateValue"
-            />
-            <v-select
-              v-model="valueToView_.calendar"
-              :label="t('common.calendar')"
-              :items="['Gregorian', 'Julian']"
-              class="ma-0 pa-0 mt-2"
-              density="compact"
-              style="width: 100px"
-              @update:model-value="onChangeCalendarType"
-            />
-          </v-col>
-        </v-row>
-      </v-container>
+      <div style="display: inline-flex; flex-direction: column; align-items: flex-start;">
+        <item-util-edit-date-picker-field
+          :value="valueToView_.value"
+          :mode="mode"
+          class="ma-0 pa-0"
+          :save="editValue"
+          :delete="deleteValue"
+          @new-value="newDateValue"
+        />
+        <v-select
+          v-model="valueToView_.calendar"
+          :label="t('common.calendar')"
+          :items="['Gregorian', 'Julian']"
+          class="ma-0 pa-0 mt-2"
+          density="compact"
+          style="width: 90px"
+          @update:model-value="onChangeCalendarType"
+        />
+      </div>
     </template>
   </div>
 </template>

--- a/frontend/nuxt.config.ts
+++ b/frontend/nuxt.config.ts
@@ -19,10 +19,7 @@ export default defineNuxtConfig({
         { name: 'format-detection', content: 'telephone=no' }
       ],
       link: [
-        { rel: 'icon', type: 'image/x-icon', href: '/favicon.ico' },
-        { rel: 'preconnect', href: 'https://fonts.googleapis.com' },
-        { rel: 'preconnect', href: 'https://fonts.gstatic.com', crossorigin: '' },
-        { rel: 'stylesheet', href: 'https://fonts.googleapis.com/css2?family=Roboto:wght@100;300;400;500;700;900&display=swap' }
+        { rel: 'icon', type: 'image/x-icon', href: '/favicon.ico' }
       ]
     }
   },
@@ -42,6 +39,12 @@ export default defineNuxtConfig({
 
   css: [
     '@mdi/font/css/materialdesignicons.css',
+    '@fontsource/roboto/100.css',
+    '@fontsource/roboto/300.css',
+    '@fontsource/roboto/400.css',
+    '@fontsource/roboto/500.css',
+    '@fontsource/roboto/700.css',
+    '@fontsource/roboto/900.css',
     '@/assets/css/main.css'
   ],
 
@@ -136,6 +139,9 @@ export default defineNuxtConfig({
     compilation: {
       strictMessage: false,
       jit: true
+    },
+    bundle: {
+      optimizeTranslationDirective: false
     }
   },
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,6 +14,7 @@
     "lint": "npm run lint:js"
   },
   "dependencies": {
+    "@fontsource/roboto": "^5.2.10",
     "@kyvg/vue3-notification": "^3.4.1",
     "@mdi/font": "^7.4.47",
     "@nuxtjs/i18n": "^9",


### PR DESCRIPTION
## Summary

Follow-up fixes after the Nuxt 3 migration (#423):

- **Quantity.vue**: fix unit select showing Q-number instead of label — `setUnitOptions` now passes the full `{id, label}` object to `selectedUnit` so `v-autocomplete` (with `return-object`) can match and display the name correctly; add `ma-0 pa-0 mt-2` to prevent the floating label from overlapping the amount field above
- **Time.vue**: replace `v-container/v-row/v-col` layout with `inline-flex` column to fix the calendar select overlapping the date picker
- **Entity.vue**: when the current item value is not found in the controlled vocabulary options, fall back to `{id, label}` built from the raw claim data instead of setting `null`
- **Values.vue**: add `table-layout: fixed` to prevent claim table columns from jumping on edit
- **EditDatePickerField.vue**: reduce date input width from 200 px to 140 px
- **staging.yml**: include `docker-compose.ui-local.yml` overlay in deploy commands
- **.gitignore**: ignore `.playwright*/` directories
- **nuxt.config.ts**: load Roboto from `@fontsource/roboto` (self-hosted) instead of Google Fonts CDN; add `optimizeTranslationDirective: false` to fix i18n build warning
- **package.json**: add `@fontsource/roboto` dependency

## Test plan

- [ ] Check quantity claims (e.g. "Mida") in edit mode: unit select shows label, not Q-number; no overlap between amount and unit fields
- [ ] Check time/date claims in edit mode: no overlap between date picker and calendar select
- [ ] Check entity claims with values not in the controlled vocabulary list

🤖 Generated with [Claude Code](https://claude.com/claude-code)