### PR TITLE
fix(frontend): enable Corepack in Dockerfile for Yarn 4

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -6,7 +6,7 @@ ARG BASE_URL
 ARG API_BASE_URL
 ENV BASE_URL=$BASE_URL
 ENV API_BASE_URL=$API_BASE_URL
-RUN yarn install
+RUN corepack enable && yarn install
 COPY . .
 RUN yarn run generate
 


### PR DESCRIPTION
## Summary

- `package.json` declares `"packageManager": "yarn@4.12.0"` but `node:22-alpine` ships with Yarn 1.x, causing CI builds to fail with: *"This project's package.json defines packageManager: yarn@4.12.0. However the current global version of Yarn is 1.22.22"*
- Adding `corepack enable` before `yarn install` lets Node.js resolve the correct Yarn version automatically via Corepack, which is bundled with Node.js 16.9+.

## Test plan

- [ ] Verify staging CI build completes successfully after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)