### PR TITLE
docs(frontend): update docs for Vue 3 / Nuxt 3 / Vuetify 4 migration

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,17 +4,19 @@ This file provides guidance to AI coding agents when working with code in this r
 
 ## Commands
 
-### Frontend (Nuxt 2 / Vue 2)
+### Frontend (Nuxt 3 / Vue 3 / Vuetify 4)
 
 ```bash
 cd frontend
 yarn install
 yarn dev        # Dev server (sets API_BASE_URL to the staging backend)
 yarn build      # Production build
+yarn preview    # Preview production build locally
 yarn lint       # ESLint
 ```
 
-The dev script hardcodes `API_BASE_URL=https://philobiblon.cog.berkeley.edu/ui-dev/` as the backend.
+The dev script hardcodes `API_BASE_URL=https://philobiblon.cog.berkeley.edu/ui-local/` as the backend.
+Yarn 4 (Berry) is required — enable it with `corepack enable`.
 
 ### Backend (Spring Boot / Java 17)
 
@@ -38,12 +40,12 @@ docker compose down -v   # Remove everything including volumes
 
 Two modules behind an nginx reverse proxy:
 
-- **Frontend** (`frontend/`) — Nuxt 2 SPA (SSR disabled). Talks to Wikibase API directly for reads, and to the backend for writes (proxied through OAuth) and cached SPARQL queries.
+- **Frontend** (`frontend/`) — Nuxt 3 SPA (SSR disabled), Vue 3 + Vuetify 4 + Pinia. Talks to Wikibase API directly for reads, and to the backend for writes (proxied through OAuth) and cached SPARQL queries.
 - **Backend** (`backend/`) — Spring Boot 3 middleware. Handles OAuth 1.0a with Wikibase, proxies edit requests, and caches SPARQL queries with Caffeine LoadingCache (24h refresh, 36h expiry).
 
 ### Two-level SPARQL caching
 
-- **Frontend** (`store/queryCache.js`): Vuex in-memory cache, 2-min TTL, 100 entries max, keyed by query hash.
+- **Frontend** (`stores/queryCache.js`): Pinia in-memory cache, 2-min TTL, 100 entries max, keyed by query hash.
 - **Backend** (`SparqlServiceImpl`): Caffeine LoadingCache, 24h refresh, 36h expiry, no max-size limit. Inspect via `GET /api/sparql/cacheinfo`.
 
 `wikibase-edit` on the frontend is configured to point to the **backend** (`apiBaseUrl`), not Wikibase directly — this ensures all writes go through the OAuth proxy.
@@ -57,11 +59,12 @@ The frontend reads special Wikibase wiki pages to drive UI behaviour:
 
 ### Item types
 
-The app handles 8 PhiloBiblon record types, each with a dedicated search page (`pages/search/<type>/`) and item-view page (`pages/item/<type>/`): `bibid`, `bioid`, `geoid`, `insid`, `libid`, `manid`, `subid`, `texid`.
+The app handles 8 PhiloBiblon record types, each with a dedicated search page (`pages/search/<type>/query.vue`) and item-view page (`pages/item/[id].vue`): `bibid`, `bioid`, `geoid`, `insid`, `libid`, `manid`, `subid`, `texid`. Item creation uses `pages/item/[table]/create.vue`.
 
 ### Frontend service injection
 
-Services are injected as Nuxt plugins and available as `this.$wikibase`, `this.$query`, `this.$oauth`, `this.$notification` in all components and pages. Never call Axios directly; use the services.
+Services are injected as Nuxt plugins and accessed in `<script setup>` via `useNuxtApp()`:
+`const { $wikibase, $notification, $sanitize } = useNuxtApp()`. Never call `fetch` directly in components; use the services.
 
 ### Backend design
 
@@ -95,8 +98,8 @@ ghcr.io/philobiblon/philobiblon-ui-frontend
 
 GitHub Environments (`staging` / `production`) hold the secrets and variables — see `docs/cicd.md` for the full list.
 
-The frontend version (`publicRuntimeConfig.version` in `nuxt.config.js`) is automatically updated at build time: staging gets `{version}-{sha}`, production gets the tag version without the `v` prefix.
+The frontend version (`runtimeConfig.public.version` in `nuxt.config.ts`) is automatically updated at build time: staging gets `{version}-{sha}`, production gets the tag version without the `v` prefix.
 
 ## i18n
 
-Translations live in `frontend/lang/` (`en`, `ca`, `es`, `gl`, `pt`). The active locale is stored in a cookie (`language`). All user-facing strings must be added to all five locale files.
+Translations live in `frontend/lang/` (`en`, `ca`, `es`, `gl`, `pt`). The active locale is stored in a cookie (`language`) and all routes are prefixed with the locale code (e.g. `/ca/search/manid/query`). All user-facing strings must be added to all five locale files. Use `const { t } = useI18n()` in `<script setup>` components.

--- a/docs/frontend/architecture.md
+++ b/docs/frontend/architecture.md
@@ -4,248 +4,255 @@ This document explains the architecture and structure of the PhiloBiblon UI fron
 
 ## Technology Stack
 
-- **Nuxt.js 2.18.1**: Vue.js framework with SPA mode
-- **Vue 2**: Progressive JavaScript framework
-- **Vuetify**: Material Design component framework
-- **Axios**: HTTP client for API requests
-- **Vuex**: State management pattern + library
+- **Nuxt 3**: Vue.js framework with SPA mode (SSR disabled)
+- **Vue 3**: Progressive JavaScript framework (Composition API)
+- **Vuetify 4**: Material Design component framework (`vuetify-nuxt-module`)
+- **Pinia**: State management library (replaces Vuex)
+- **Vue I18n 11 / @nuxtjs/i18n 10**: Internationalization
+- **@kyvg/vue3-notification**: Toast notifications (replaces vue-toastification)
+- **Yarn 4 (Berry)**: Package manager
+- **Vite**: Build tool (replaces Webpack)
+- **TypeScript**: Used in config files (`nuxt.config.ts`, `i18n.config.ts`)
 
 ## Application Mode
 
-The frontend runs in **SPA (Single Page Application)** mode with **client-side rendering (CSR)**. This means:
+The frontend runs in **SPA (Single Page Application)** mode with **client-side rendering (CSR)**:
 
-- All rendering happens in the browser
-- Initial page load downloads the full JavaScript bundle
-- Navigation is handled client-side (no page reloads)
-- SEO is not a primary concern (internal tool)
+```typescript
+// nuxt.config.ts
+export default defineNuxtConfig({
+  ssr: false,
+  ...
+})
+```
 
 ## Directory Structure
 
 ```
 frontend/
-├── components/         # Vue components
-│   ├── common/         # Shared UI components
-│   ├── item/           # Wikibase item components
-│   │   ├── claim/      # Claim/statement components
-│   │   ├── qualifier/  # Qualifier components
-│   │   ├── reference/  # Reference components
-│   │   ├── util/       # Utility components (editable fields)
-│   │   └── value/      # Value type components (URL, Date, etc.)
-│   └── search/         # Search interface components
-├── lang/               # i18n translation files
-├── layouts/            # Nuxt layout components
-├── pages/              # Route pages (auto-routing)
-├── plugins/            # Nuxt plugins
-├── service/            # Business logic and API services
-├── static/             # Static assets
-└── store/              # Vuex store modules
+├── app.vue              # Root component (mounts NuxtLayout + NuxtPage)
+├── assets/              # Processed assets (CSS, SCSS variables)
+│   ├── css/main.css
+│   └── variables.scss   # Vuetify SCSS overrides
+├── components/          # Vue components (auto-imported by Nuxt)
+│   ├── common/          # Shared UI components
+│   ├── create/          # Item creation components
+│   ├── item/            # Wikibase item display/edit components
+│   │   ├── claim/       # Claim/statement components
+│   │   ├── qualifier/   # Qualifier components
+│   │   ├── reference/   # Reference components
+│   │   ├── related/     # Related items components
+│   │   ├── util/        # Utility components (editable fields)
+│   │   └── value/       # Value type components (URL, Date, Entity, etc.)
+│   ├── search/          # Search interface components
+│   ├── LanguagesMenu.vue
+│   └── PhiloFooter.vue
+├── composables/         # Auto-imported Vue composables
+│   └── useNotifyError.js
+├── i18n.config.ts       # Vue I18n configuration
+├── lang/                # Translation files (en, ca, es, gl, pt)
+├── layouts/             # Nuxt layout components
+│   └── default.vue      # Main layout with navigation drawer + app bar
+├── nuxt.config.ts       # Main Nuxt configuration
+├── pages/               # File-based routing (auto-routing)
+│   ├── index.vue
+│   ├── item/
+│   │   ├── [id].vue           # View/edit item
+│   │   └── [table]/create.vue # Create new item
+│   ├── oauth_callback.vue
+│   ├── privacy-policy.vue
+│   ├── search/<type>/query.vue # Per-type search pages
+│   └── wiki/[page].vue         # Wiki page viewer
+├── plugins/             # Nuxt plugins (client-side only, numbered for order)
+│   ├── 00.vuetify-i18n.client.js
+│   ├── 01.config.client.js
+│   ├── 02.notification.client.js
+│   ├── 03.wikibase.client.js
+│   ├── dompurify.client.js
+│   └── version-check.client.js
+├── public/              # Static assets served as-is (was `static/` in Nuxt 2)
+├── service/             # Business logic and API services
+└── stores/              # Pinia store modules (was `store/` in Nuxt 2)
 ```
 
 ## Plugin System
 
-Nuxt plugins are used to inject functionality globally. Located in `plugins/`:
+Plugins use Nuxt 3's `defineNuxtPlugin` API and the `.client.js` suffix to run client-side only. They are loaded in filename order (numbered prefix).
 
-### `config.js`
-Fetches backend configuration and makes it available as `$config`:
-
-```javascript
-export default async ({ $axios }, inject) => {
-  const config = await $axios.$get('/api/config')
-  inject('config', config)
-}
-```
-
-Usage in components: `this.$config.wikibaseBaseUrl`
-
-### `wikibase.js`
-Injects the Wikibase service:
+### `01.config.client.js`
+Fetches backend configuration and merges it into `useRuntimeConfig().public`:
 
 ```javascript
-import WikibaseService from '~/service/wikibase.service'
-
-export default ({ $axios, store }, inject) => {
-  inject('wikibase', new WikibaseService($axios, store))
-}
-```
-
-Usage: `this.$wikibase.getEntities(['Q123'])`
-
-### `notification.js`
-Injects the notification service:
-
-```javascript
-import { NotificationService } from '~/service/notification.service'
-
-export default ({ $toast }, inject) => {
-  inject('notification', new NotificationService($toast))
-}
-```
-
-Usage: `this.$notification.success('Item saved!')`
-
-### `dompurify.js`
-Sanitizes HTML to prevent XSS attacks when rendering user content.
-
-### `language.js`
-Sets up i18n (internationalization) with Catalan as the default language.
-
-### `version-check.js`
-Checks if the frontend version matches the backend version to prompt users to refresh.
-
-## Routing
-
-Nuxt automatically generates routes from the `pages/` directory:
-
-| File | Route | Purpose |
-|------|-------|---------|
-| `pages/index.vue` | `/` | Home page |
-| `pages/item/_id.vue` | `/item/:id` | View/edit item (e.g., `/item/Q123`) |
-| `pages/search/index.vue` | `/search` | Advanced search interface |
-| `pages/login.vue` | `/login` | OAuth login page |
-
-### Dynamic Routes
-
-The `_id.vue` syntax creates a dynamic route. Access the parameter via:
-
-```javascript
-this.$route.params.id  // e.g., "Q123"
-```
-
-## Component Communication
-
-### Props Down, Events Up
-
-Standard Vue pattern:
-
-```vue
-<!-- Parent -->
-<EditTextField 
-  :value="currentValue"
-  @new-value="handleNewValue"
-/>
-
-<!-- Child emits -->
-this.$emit('new-value', newValue)
-```
-
-### Vuex for Global State
-
-For data needed across multiple components:
-
-```javascript
-// Set state
-this.$store.commit('auth/login', { username, accessToken })
-
-// Read state
-this.$store.state.auth.isLogged
-```
-
-## API Communication
-
-All API calls go through Axios, configured in `nuxt.config.js`:
-
-```javascript
-axios: {
-  baseURL: process.env.API_BASE_URL || 'http://localhost:8080'
-}
-```
-
-### Service Layer Pattern
-
-Instead of calling `$axios` directly in components, use service classes:
-
-```javascript
-// In component
-const entities = await this.$wikibase.getEntities(['Q123'])
-
-// In service (wikibase.service.js)
-async getEntities(ids) {
-  const response = await this.$axios.get('/api/wikibase/entities', {
-    params: { ids: ids.join('|') }
+export default defineNuxtPlugin(async () => {
+  const config = useRuntimeConfig()
+  const response = await fetch(`${config.public.apiBaseUrl}/api/config`)
+  const data = await response.json()
+  Object.entries(data).forEach(([key, value]) => {
+    config.public[key] = value
   })
-  return response.data
-}
-```
-
-This provides:
-- Centralized API logic
-- Easier testing
-- Consistent error handling
-
-## Error Handling
-
-### Global Error Handler
-
-Axios interceptors catch errors:
-
-```javascript
-this.$axios.onError((error) => {
-  if (error.response?.status === 401) {
-    this.$notification.error('Session expired')
-    this.$router.push('/login')
-  }
 })
 ```
 
-### Component-Level
+Config values are accessible anywhere via `useRuntimeConfig().public`.
+
+### `02.notification.client.js`
+Registers `@kyvg/vue3-notification` and injects the `$notification` service:
 
 ```javascript
+import Notifications, { useNotification } from '@kyvg/vue3-notification'
+import { NotificationService } from '~/service/notification.service'
+
+export default defineNuxtPlugin((nuxtApp) => {
+  nuxtApp.vueApp.use(Notifications)
+  const { notify } = useNotification()
+  return { provide: { notification: new NotificationService(notify) } }
+})
+```
+
+Usage in components: `const { $notification } = useNuxtApp()`
+
+### `03.wikibase.client.js`
+Injects the `$wikibase` service and starts the query cache cleanup interval:
+
+```javascript
+export default defineNuxtPlugin((nuxtApp) => {
+  const config = useRuntimeConfig().public
+  const wikibaseService = new WikibaseService({ config, $notification: nuxtApp.$notification })
+  setInterval(() => useQueryCacheStore().clearCache(), 3000)
+  return { provide: { wikibase: wikibaseService } }
+})
+```
+
+Usage: `const { $wikibase } = useNuxtApp()`
+
+### `00.vuetify-i18n.client.js`
+Merges Vuetify's own locale messages into Vue I18n so Vuetify components render translated strings.
+
+### `dompurify.client.js`
+Provides `$sanitize` to safely render HTML content.
+
+### `version-check.client.js`
+Forces a page reload when the deployed version changes (detected via `localStorage`).
+
+## Routing
+
+Nuxt 3 uses bracket syntax for dynamic routes:
+
+| File | Route | Purpose |
+|------|-------|---------|
+| `pages/index.vue` | `/` (redirects to locale prefix) | Home |
+| `pages/item/[id].vue` | `/item/:id` | View/edit item |
+| `pages/item/[table]/create.vue` | `/item/:table/create` | Create new item |
+| `pages/search/<type>/query.vue` | `/search/<type>/query` | Search by type |
+| `pages/wiki/[page].vue` | `/wiki/:page` | Wiki page viewer |
+| `pages/oauth_callback.vue` | `/oauth_callback` | OAuth callback |
+
+All routes are prefixed with the active locale (e.g. `/en/item/Q123`, `/ca/search/manid/query`) via the `'prefix'` i18n strategy.
+
+Access route parameters in components:
+
+```javascript
+const route = useRoute()
+const id = route.params.id       // e.g. "Q123"
+const table = route.params.table // e.g. "manid"
+```
+
+## Component Style — Composition API
+
+All components use `<script setup>` (Composition API). There is no `this` context.
+
+```vue
+<script setup>
+import { ref, computed, onMounted } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { useAuthStore } from '~/stores/auth'
+
+const { t } = useI18n()
+const { $wikibase } = useNuxtApp()
+const authStore = useAuthStore()
+const route = useRoute()
+
+const entity = ref(null)
+
+onMounted(async () => {
+  entity.value = await $wikibase.getEntity(route.params.id, 'ca')
+})
+</script>
+```
+
+## Composables
+
+Reusable logic is extracted into composables in `composables/` (auto-imported by Nuxt):
+
+### `useNotifyError`
+Centralised error handling with friendly i18n messages and automatic logout on session expiry:
+
+```javascript
+const { notifyError } = useNotifyError()
 try {
-  await this.$wikibase.saveClaim(claim)
-  this.$notification.success('Saved!')
+  await $wikibase.saveClaim(claim)
 } catch (error) {
-  this.$notification.error(error)
+  notifyError(error)
 }
 ```
+
+## State Management
+
+Vuex has been replaced by **Pinia**. Stores are in `stores/` and use the Composition API style. See [State Management](state-management.md) for details.
+
+## API Communication
+
+Direct Axios usage has been replaced by native `fetch` in plugins. In service classes, fetch is used directly:
+
+```javascript
+const response = await fetch(`${config.apiBaseUrl}/api/config`)
+const data = await response.json()
+```
+
+Runtime configuration (instead of `process.env` in components):
+
+```javascript
+const config = useRuntimeConfig().public
+config.wikibaseBaseUrl
+config.apiBaseUrl
+```
+
+## i18n
+
+Configured via `@nuxtjs/i18n` module with `'prefix'` strategy. All routes get a locale prefix. Locale detection uses a `language` cookie.
+
+```javascript
+// In components
+const { t, locale } = useI18n()
+const localePath = useLocalePath()
+
+// Navigate to localized route
+router.push(localePath('/search/manid/query'))
+```
+
+Configuration is split between `nuxt.config.ts` (module config) and `i18n.config.ts` (Vue I18n options, `legacy: false` for Composition API).
 
 ## Build Process
 
-### Development Build
+The build tool is **Vite** (Nuxt 3 default), replacing Webpack.
+
+### Development
 
 ```bash
 yarn dev
+# Starts Vite dev server with HMR at http://localhost:3000
+# API_BASE_URL is hardcoded to https://philobiblon.cog.berkeley.edu/ui-local/
 ```
 
-- Webpack dev server with HMR
-- Source maps enabled
-- No minification
-- Fast rebuild times
-
-### Production Build
+### Production
 
 ```bash
-yarn build
-```
-
-- Code minification
-- Tree shaking (removes unused code)
-- CSS extraction
-- Optimized chunks
-- Gzip compression
-
-## Performance Considerations
-
-### Code Splitting
-
-Nuxt automatically splits code by route. Each page is a separate chunk loaded on demand.
-
-### Client-Side Caching
-
-- **Vuex stores**: `itemCache` and `queryCache` reduce API calls
-- **Browser cache**: Static assets cached via HTTP headers
-
-### Lazy Loading
-
-Components can be lazy-loaded:
-
-```javascript
-components: {
-  HeavyComponent: () => import('~/components/HeavyComponent.vue')
-}
+yarn build    # Produces .output/ directory
+yarn preview  # Preview the production build locally
 ```
 
 ## Next Steps
 
-- [State Management](state-management.md) - Deep dive into Vuex stores
+- [State Management](state-management.md) - Deep dive into Pinia stores
 - [Services](services.md) - API and business logic layer
 - [Components](components.md) - Component architecture patterns

--- a/docs/frontend/components.md
+++ b/docs/frontend/components.md
@@ -7,385 +7,124 @@ This document explains the component structure and patterns used in the PhiloBib
 ```
 components/
 ├── common/              # Reusable UI components
-│   ├── Loader.vue      # Loading spinner
-│   └── ErrorMessage.vue # Error display
-├── item/               # Wikibase item components
-│   ├── Base.vue        # Read-only item view
-│   ├── Create.vue      # Item creation form
-│   ├── claim/          # Claim/statement components
-│   │   ├── Base.vue    # Claim display
-│   │   ├── Create.vue  # Claim creation
-│   │   ├── AddValue.vue # Add value to existing claim
-│   │   └── Values.vue  # Display claim values
-│   ├── qualifier/      # Qualifier components
-│   │   └── Create.vue  # Qualifier creation
-│   ├── reference/      # Reference components
-│   │   ├── Base.vue    # Reference display
-│   │   └── List.vue    # Reference list
-│   ├── util/           # Utility components
-│   │   ├── EditTextField.vue    # Editable text field
-│   │   ├── EditSelectField.vue  # Editable dropdown
-│   │   └── EditDateField.vue    # Editable date picker
-│   └── value/          # Value type components
-│       └── type/
-│           ├── Url.vue         # URL value
-│           ├── Date.vue        # Date value
-│           ├── Entity.vue      # Wikibase item value
-│           └── Text.vue        # String value
-└── search/             # Search interface
-    └── Filters.vue     # Dynamic search form
+├── create/              # Item creation form components
+├── item/                # Wikibase item display/edit components
+│   ├── Base.vue         # Read-only item view
+│   ├── Claims.vue       # Claims list
+│   ├── Create.vue       # Item creation form (wrapper)
+│   ├── Notes.vue        # Notes section
+│   ├── claim/           # Claim/statement components
+│   ├── qualifier/       # Qualifier components
+│   ├── reference/       # Reference components
+│   ├── related/         # Related items components
+│   ├── util/            # Utility components (editable fields)
+│   └── value/           # Value type components (URL, Date, Entity, etc.)
+├── search/              # Search interface
+│   ├── Base.vue
+│   ├── Filters.vue      # Dynamic search form
+│   ├── Results.vue      # Results table
+│   └── Simple.vue       # Simple search input
+├── LanguagesMenu.vue    # Language switcher
+└── PhiloFooter.vue      # Footer
+```
+
+All components are **auto-imported** by Nuxt — no explicit `import` needed in `<script setup>`.
+
+## Component Style — Script Setup
+
+All components use `<script setup>` (Composition API). There is no `this` context. Vue lifecycle hooks, reactivity, and utilities are imported from `vue` or used via Nuxt auto-imports.
+
+```vue
+<script setup>
+import { ref, computed, onMounted } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { useAuthStore } from '~/stores/auth'
+
+const props = defineProps({ value: String, table: String })
+const emit = defineEmits(['update'])
+
+const { t } = useI18n()
+const { $wikibase } = useNuxtApp()
+const authStore = useAuthStore()
+const localValue = ref(props.value)
+
+onMounted(async () => { ... })
+</script>
 ```
 
 ## Key Components
 
-### item/Create.vue - Item Creation
+### item/Base.vue — Item Display
 
-The most complex component in the application. Handles creating new Wikibase items with automatic PBID generation and claim initialization.
-
-#### Key Features
-
-1. **Automatic PBID Generation**
-   - Queries for the last item in the table
-   - Increments the number
-   - Pre-fills P476 (PBID) claim
-
-```javascript
-async mounted() {
-  const lastItem = await this.$wikibase.getTableLastItem(this.database, this.table)
-  const { num } = this.$wikibase.parsePBID(lastItem.pbid)
-  const newNum = parseInt(num) + 1
-  const newPBID = `${this.database} ${this.table} ${newNum}`
-  
-  // Create initial claims with PBID
-  this.initialClaims = await this.generateInitialClaims(newPBID)
-}
-```
-
-2. **Smart Default Values**
-   - P131 (bibliography) automatically set based on database
-   - P700 qualifier set to Q447226 (PhiloBiblon object)
-
-```javascript
-if (entity.id === 'P131') {
-  const bibliographyMap = {
-    BETA: 'Q254471',
-    BITECA: 'Q256810',
-    BITAGAP: 'Q256809'
-  }
-  const bibliographyId = bibliographyMap[this.database]
-  
-  const qualifiers = [{
-    property: 'P700',
-    datavalue: { value: { id: 'Q447226' } }
-  }]
-  
-  claim = this.buildClaim(entity, qualifiers, { id: bibliographyId })
-}
-```
-
-3. **Validation**
-   - Label required
-   - At least one claim required
-   - PBID must be unique
-
-```javascript
-getCreateDisabledReason() {
-  if (!this.label) {
-    return this.$t('item.create.button.disabled.no_label')
-  }
-  if (this.claims.length === 0) {
-    return this.$t('item.create.button.disabled.no_claims')
-  }
-  return null
-}
-```
-
-4. **Creation Flow**
-
-```javascript
-async create() {
-  const newItem = {
-    labels: { ca: this.label },
-    descriptions: { ca: this.description },
-    claims: this.formatClaimsForWikibase(this.claims)
-  }
-  
-  const result = await this.wbEdit.entity.create({
-    type: 'item',
-    ...newItem,
-    ...this.$store.getters['auth/getRequestConfig']
-  })
-  
-  this.$notification.success('Item created!')
-  this.$router.push(`/item/${result.entity.id}`)
-}
-```
-
-### item/Base.vue - Item Display
-
-Displays a Wikibase item in read-only mode.
-
-#### Structure
-
-```vue
-<template>
-  <div>
-    <h1>{{ label }}</h1>
-    <p>{{ description }}</p>
-    
-    <!-- Claims -->
-    <item-claim-base
-      v-for="claim in orderedClaims"
-      :key="claim.property"
-      :claim="claim"
-      :table="table"
-    />
-    
-    <!-- References -->
-    <item-reference-list :references="references" />
-  </div>
-</template>
-```
+Displays a Wikibase item in read-only (or edit) mode.
 
 #### Data Loading
 
 ```javascript
-async mounted() {
-  const entity = await this.$wikibase.getEntity(this.$route.params.id, 'ca')
-  this.label = entity.labels.ca?.value
-  this.description = entity.descriptions.ca?.value
-  
-  // Order claims according to UI config
-  this.orderedClaims = await this.$wikibase.getOrderedClaims(
-    this.table,
-    entity.claims
-  )
-}
+const route = useRoute()
+const entity = ref(null)
+
+onMounted(async () => {
+  entity.value = await $wikibase.getEntity(route.params.id, 'ca')
+  orderedClaims.value = await $wikibase.getOrderedClaims(table, entity.value.claims)
+})
 ```
 
-### item/claim/Create.vue - Claim Creation
+### item/Create.vue — Item Creation
 
-Allows adding new claims to an item.
+Handles creating new Wikibase items with automatic PBID generation and claim initialization.
 
-#### Property Selection
+#### Key Features
+
+1. **Automatic PBID Generation** — queries for the last item in the table, increments, pre-fills P476
+2. **Smart Default Values** — P131 (bibliography) auto-set based on database; P700 qualifier defaults to Q447226
+3. **Validation** — label required, at least one claim required
+4. **Creation Flow** — calls `wbEdit.entity.create` with OAuth credentials from `useAuthStore().requestConfig`
+
+### item/claim/Create.vue — Claim Creation
+
+Allows adding new claims to an item. Property selection is filtered by table type and existing claims.
+
+The value input component is selected dynamically based on property datatype:
+
+```javascript
+const valueComponent = computed(() => {
+  switch (selectedProperty.value?.datatype) {
+    case 'wikibase-item': return 'ItemValueTypeEntity'
+    case 'string':        return 'ItemValueTypeText'
+    case 'time':          return 'ItemValueTypeDate'
+    case 'url':           return 'ItemValueTypeUrl'
+    default:              return 'ItemValueTypeText'
+  }
+})
+```
+
+### item/util/EditTextField.vue — Inline Editing
+
+A reusable component for inline editing of text values. Switches between display and edit mode.
+
+Props: `value`, `save` (async function), `delete` (function), `mode`
 
 ```vue
-<v-autocomplete
-  v-model="selectedProperty"
-  :items="availableProperties"
-  item-text="label"
-  item-value="id"
-  label="Select property"
+<ItemUtilEditTextField
+  :value="currentValue"
+  :save="async (newVal) => { await $wikibase.saveLabel(newVal) }"
+  :delete="() => { ... }"
+  mode="edit"
 />
 ```
 
-Properties are filtered based on:
-1. Table type (from UI config)
-2. Already existing claims (to avoid duplicates for single-value properties)
+### search/Filters.vue — Dynamic Search Form
 
-#### Value Input
+Generates search forms dynamically from per-table JSON config. Persists form state in `useQueryStatusStore`.
 
-The value input component changes based on property datatype:
+### search/Results.vue — Search Results
 
-```vue
-<component
-  :is="valueComponent"
-  v-model="value"
-  :property="selectedProperty"
-/>
-```
+Displays SPARQL query results in a paginated table. Pagination and sort state are persisted in `useQueryStatusStore`.
 
-```javascript
-computed: {
-  valueComponent() {
-    switch (this.selectedProperty.datatype) {
-      case 'wikibase-item':
-        return 'value-type-entity'
-      case 'string':
-        return 'value-type-text'
-      case 'time':
-        return 'value-type-date'
-      case 'url':
-        return 'value-type-url'
-      default:
-        return 'value-type-text'
-    }
-  }
-}
-```
+### LanguagesMenu.vue — Language Switcher
 
-### item/util/EditTextField.vue - Editable Field
-
-A reusable component for inline editing of text values.
-
-#### States
-
-1. **Display Mode**: Shows value as plain text
-2. **Edit Mode**: Shows input field with save/cancel/delete buttons
-
-```vue
-<template>
-  <v-text-field
-    v-if="focussed"
-    v-model="currentText"
-    @blur="blur"
-    @focus="focus"
-  >
-    <template #append>
-      <v-btn icon @click.stop="edit">
-        <v-icon>mdi-check</v-icon>
-      </v-btn>
-      <v-btn icon @click.stop="restore">
-        <v-icon>mdi-close</v-icon>
-      </v-btn>
-      <v-btn v-if="isRemovable" icon @click.stop="deleteValue">
-        <v-icon>mdi-trash-can</v-icon>
-      </v-btn>
-    </template>
-  </v-text-field>
-  <span v-else @click="focus">{{ currentText }}</span>
-</template>
-```
-
-#### Props
-
-- `value`: Current value
-- `save`: Function to call on save
-- `delete`: Function to call on delete
-- `mode`: 'edit' or 'view'
-
-#### Event Handling
-
-```javascript
-methods: {
-  async edit() {
-    if (this.currentText !== this.consolidatedText) {
-      await this.save(this.currentText, this.consolidatedText)
-      this.consolidatedText = this.currentText
-      this.$notification.success('Saved!')
-    }
-  },
-  
-  restore() {
-    this.currentText = this.consolidatedText
-    this.focussed = false
-  },
-  
-  blur() {
-    this.focussed = false
-    this.restore()  // Revert changes if not saved
-  }
-}
-```
-
-### item/value/type/Url.vue - URL Value
-
-Handles URL values with special validation for email addresses.
-
-#### Email Detection
-
-```javascript
-methods: {
-  isURL(str) {
-    const urlRegex = /^(https?|ftp):\/\/[^\s/$.?#].[^\s]*$/i
-    const emailRegex = /^mailto:[^\s]+@[^\s]+\.[^\s]+$/i
-    return urlRegex.test(str) || emailRegex.test(str)
-  },
-  
-  getUrlValue(newValue, oldValue) {
-    const valid = this.isURL(newValue)
-    const message = valid ? '' : this.$i18n.t('item.messages.invalid_url')
-    
-    return {
-      validation: { valid, message },
-      values: { newValue, oldValue }
-    }
-  }
-}
-```
-
-### search/Filters.vue - Dynamic Search Form
-
-Generates search forms dynamically based on table type and database.
-
-#### Form Generation
-
-```javascript
-async mounted() {
-  const formConfig = await import(`~/static/search/${this.table}.json`)
-  this.formFields = formConfig.fields
-  
-  // Load saved form state
-  const savedForm = this.$store.state.queryStatus.form
-  if (savedForm) {
-    this.form = savedForm
-  }
-}
-```
-
-#### Field Types
-
-Different input types based on field configuration:
-
-```vue
-<template v-for="field in formFields">
-  <!-- Text input -->
-  <v-text-field
-    v-if="field.type === 'text'"
-    v-model="form[field.name]"
-    :label="field.label"
-  />
-  
-  <!-- Autocomplete (entity search) -->
-  <v-autocomplete
-    v-else-if="field.type === 'entity'"
-    v-model="form[field.name]"
-    :items="getAutocompleteOptions(field)"
-    :search-input.sync="search[field.name]"
-    @update:search-input="searchEntity(field, $event)"
-  />
-  
-  <!-- Date range -->
-  <v-row v-else-if="field.type === 'daterange'">
-    <v-col>
-      <v-text-field
-        v-model="form[field.name].begin"
-        type="number"
-        label="From"
-      />
-    </v-col>
-    <v-col>
-      <v-text-field
-        v-model="form[field.name].end"
-        type="number"
-        label="To"
-      />
-    </v-col>
-  </v-row>
-</template>
-```
-
-#### Search Execution
-
-```javascript
-async performSearch() {
-  // Save form state
-  this.$store.commit('queryStatus/setForm', this.form)
-  
-  // Generate SPARQL query
-  const query = this.$wikibase.$query.generateSearchQuery(
-    this.table,
-    this.database,
-    this.form
-  )
-  
-  // Execute query
-  const results = await this.$wikibase.runSparqlQuery(query, true, true)
-  
-  this.$emit('results', results)
-  this.$store.commit('queryStatus/setShowResults', true)
-}
-```
+Switches the active i18n locale and persists the choice in the `language` cookie.
 
 ## Component Communication Patterns
 
@@ -393,105 +132,96 @@ async performSearch() {
 
 ```vue
 <!-- Parent -->
-<child-component
-  :value="parentValue"
-  @update="handleUpdate"
+<ItemClaimBase
+  :claim="claim"
+  :table="table"
+  @claim-updated="handleUpdate"
 />
 
-<!-- Child -->
-<script>
-export default {
-  props: ['value'],
-  methods: {
-    onChange(newValue) {
-      this.$emit('update', newValue)
-    }
-  }
+<!-- Child (script setup) -->
+const props = defineProps({ claim: Object, table: String })
+const emit = defineEmits(['claim-updated'])
+
+function onSave(newValue) {
+  emit('claim-updated', newValue)
 }
-</script>
 ```
 
 ### 2. Provide/Inject for Deep Hierarchies
 
 ```javascript
-// Parent (item/Create.vue)
-provide() {
-  return {
-    table: this.table,
-    database: this.database
-  }
-}
+// Ancestor component
+provide('table', table)
+provide('database', database)
 
-// Deep child
-inject: ['table', 'database']
+// Deep descendant
+const table = inject('table')
+const database = inject('database')
 ```
 
-### 3. Vuex for Global State
+### 3. Pinia for Global State
 
 ```javascript
-// Any component
-computed: {
-  isLogged() {
-    return this.$store.state.auth.isLogged
+import { useAuthStore } from '~/stores/auth'
+const authStore = useAuthStore()
+
+// Reactive in template automatically
+if (authStore.isLogged) { ... }
+```
+
+## Vuetify 4 Patterns
+
+### Key API changes from Vuetify 2/3
+
+- `v-model:search-input` (v2) → `v-model:search` (v4) on autocomplete
+- `:item-text` / `:item-value` props (v2) → `:item-title` / `:item-value` (v4)
+- `append` slot slot → `append-inner` for inside the input, `append` for outside
+- `useDisplay()` composable for breakpoints:
+
+```javascript
+import { useDisplay } from 'vuetify'
+const { mdAndDown } = useDisplay()
+```
+
+### Global Defaults
+
+Component variant defaults are configured centrally in `nuxt.config.ts`:
+
+```typescript
+vuetify: {
+  vuetifyOptions: {
+    defaults: {
+      VTextField: { variant: 'underlined', color: 'primary' },
+      VAutocomplete: { variant: 'underlined', color: 'primary' },
+      ...
+    }
   }
 }
 ```
 
-## Styling Patterns
+This means individual `<v-text-field>` components don't need `:variant` or `:color` unless overriding the default.
 
-### Scoped Styles
+### Styling
 
 ```vue
 <style scoped>
-.component-specific-class {
-  /* Only applies to this component */
-}
+/* Component-local styles */
+.my-class { ... }
+
+/* Reach into child component styles */
+:deep(.v-list-item--active) { color: white; }
 </style>
 ```
 
-### Vuetify Utility Classes
+Vuetify utility classes work as before:
 
 ```vue
 <v-row class="mt-4 mb-2">
-  <v-col cols="12" md="6">
-    <!-- Responsive grid -->
-  </v-col>
+  <v-col cols="12" md="6">...</v-col>
 </v-row>
-```
-
-### Dynamic Classes
-
-```vue
-<div :class="{ 'error-state': hasError, 'success-state': isValid }">
-```
-
-## Testing Considerations
-
-### Component Testing
-
-```javascript
-import { mount } from '@vue/test-utils'
-import EditTextField from '~/components/item/util/EditTextField.vue'
-
-describe('EditTextField', () => {
-  it('calls save function on edit', async () => {
-    const saveMock = jest.fn()
-    const wrapper = mount(EditTextField, {
-      propsData: {
-        value: 'initial',
-        save: saveMock
-      }
-    })
-    
-    await wrapper.find('input').setValue('new value')
-    await wrapper.find('[data-test="save-btn"]').trigger('click')
-    
-    expect(saveMock).toHaveBeenCalledWith('new value', 'initial')
-  })
-})
 ```
 
 ## Next Steps
 
-- [Services](services.md) - Learn how components interact with services
-- [State Management](state-management.md) - Understand Vuex integration
+- [Services](services.md) — How components use services
+- [State Management](state-management.md) — How components use Pinia stores

--- a/docs/frontend/services.md
+++ b/docs/frontend/services.md
@@ -1,6 +1,6 @@
 # Services Layer
 
-The services layer encapsulates business logic and API communication, keeping components clean and focused on presentation.
+The services layer encapsulates business logic and API communication, keeping components clean and focused on presentation. Services live in `service/` and are injected as Nuxt plugins.
 
 ## Overview
 
@@ -18,404 +18,190 @@ The primary service for all Wikibase-related operations.
 ### Initialization
 
 ```javascript
-constructor(app, store) {
-  // Initialize wikibase-sdk
-  this.wbk = require('wikibase-sdk')({
-    instance: app.$config.wikibaseApiUrl,
-    sparqlEndpoint: app.$config.sparqlEndpoint
-  })
-  
-  // Initialize wikibase-edit (points to backend proxy)
-  this.wbEdit = require('wikibase-edit')({
-    instance: app.$config.apiBaseUrl
-  })
+export class WikibaseService {
+  constructor({ config, $notification }) {
+    this.$config = config
+    this.wbk = WBK({
+      instance: config.wikibaseApiUrl,
+      sparqlEndpoint: config.sparqlEndpoint
+    })
+    this.wbEdit = wbEdit({
+      instance: config.apiBaseUrl   // writes go through the backend OAuth proxy
+    })
+    this.$query = new QueryService({ config })
+    this.$oauth = new OAuthService({ config })
+    this.$notification = $notification
+    this.sparqlBackendEndpoint = this.joinUrl(config.apiBaseUrl, 'api/sparql/query')
+  }
 }
 ```
 
-**Key Point**: `wikibase-edit` is configured to use the **backend** (`apiBaseUrl`), not Wikibase directly. This ensures all edits go through the OAuth proxy.
+**Key point**: `wikibase-edit` is configured with `config.apiBaseUrl` (the backend), not the Wikibase instance directly. All writes go through the backend OAuth proxy.
 
 ### Core Methods
 
 #### `getEntity(id, lang)`
-Fetches a single Wikibase entity by ID.
+Fetches a single Wikibase entity.
 
 ```javascript
-const entity = await this.$wikibase.getEntity('Q123', 'ca')
-// Returns: { id: 'Q123', labels: {...}, claims: {...}, ... }
+const entity = await $wikibase.getEntity('Q123', 'ca')
 ```
 
 #### `getEntities(ids, lang)`
 Fetches multiple entities in one request.
 
 ```javascript
-const entities = await this.$wikibase.getEntities(['Q123', 'Q456'], 'ca')
-// Returns: { Q123: {...}, Q456: {...} }
+const entities = await $wikibase.getEntities(['Q123', 'Q456'], 'ca')
 ```
 
 #### `runSparqlQuery(query, minimize, useBackendCache, useInternalCache)`
-Executes a SPARQL query with caching options.
+Executes a SPARQL query with optional caching.
 
-**Parameters**:
-- `query`: SPARQL query string
-- `minimize`: Simplify results (remove verbose RDF structure)
-- `useBackendCache`: Use backend Caffeine cache
-- `useInternalCache`: Use frontend Vuex cache
+- `minimize` — simplify RDF result structure
+- `useBackendCache` — use backend Caffeine cache (24h TTL)
+- `useInternalCache` — use frontend Pinia queryCache (2-min TTL)
 
 ```javascript
-const results = await this.$wikibase.runSparqlQuery(
-  'SELECT ?item WHERE { ?item wdt:P31 wd:Q5 }',
-  true,  // minimize
-  true,  // backend cache
-  false  // internal cache (disabled when backend cache is on)
-)
+const results = await $wikibase.runSparqlQuery(query, true, true, false)
 ```
-
-**Caching Strategy**:
-1. If `useInternalCache` is true, check Vuex `queryCache`
-2. If miss, execute query
-3. Store result in cache with hash key
-4. Return results
 
 #### `getOrderedClaims(table, claims)`
-Sorts claims according to UI configuration from Wikibase wiki pages.
-
-```javascript
-const orderedClaims = await this.$wikibase.getOrderedClaims('manid', entity.claims)
-// Returns: [
-//   { property: 'P476', values: [...], hasQualifiers: true },
-//   { property: 'P11', values: [...], hasQualifiers: false },
-//   ...
-// ]
-```
-
-This reads from the `Ui_SortedProperties` wiki page which defines the display order for each table type.
+Sorts claims according to the `Ui_SortedProperties` wiki page configuration.
 
 #### `getControlledVocabularyConfig(table, bibliography)`
-Fetches autocomplete configuration for controlled vocabulary fields.
-
-```javascript
-const config = await this.$wikibase.getControlledVocabularyConfig('manid', 'BETA')
-// Returns: {
-//   P297: {  // City property
-//     default_value: 'Q456',
-//     query: 'SELECT ?item WHERE { ... }'
-//   }
-// }
-```
-
-Used by autocomplete components to:
-1. Set default values
-2. Generate SPARQL queries for dropdown options
+Fetches autocomplete configuration from `Ui_ControlledVocabulary` wiki page.
 
 ### Value Formatting
 
-#### `getWbValue(property, datatype, datavalue, lang)`
-Converts raw Wikibase datavalues into display-ready objects.
-
-**Handles multiple datatypes**:
+`getWbValue(property, datatype, datavalue, lang)` converts raw Wikibase datavalues to display objects:
 
 ```javascript
-// Wikibase item
-{ 
-  value: 'Barcelona',
-  type: 'entity',
-  item: 'Q1492',
-  pbid: 'BETA geoid 1234'  // if PhiloBiblon entity
-}
-
-// External ID
-{
-  value: 'VIAF123456',
-  url: 'https://viaf.org/viaf/123456',
-  type: 'external-id'
-}
-
-// Time
-{
-  value: '1450-01-15',
-  calendar: 'Julian',
-  type: 'time'
-}
-
-// Monolingual text
-{
-  value: 'Text in Catalan',
-  language: 'ca',
-  type: 'text-lang'
-}
+// wikibase-item   → { value, type: 'entity', item, pbid }
+// external-id     → { value, url, type: 'external-id' }
+// time            → { value, calendar, type: 'time' }
+// monolingualtext → { value, language, type: 'text-lang' }
 ```
 
 ### PhiloBiblon-Specific Logic
 
-#### `isEntityFromPB(entity)`
-Checks if an entity is a PhiloBiblon entity (has a PBID).
-
 ```javascript
-if (this.$wikibase.isEntityFromPB(entity)) {
-  // Show link to item page
-}
+$wikibase.isEntityFromPB(entity)           // has a PBID?
+$wikibase.getPBID(entity, 'BETA', 'manid') // → 'BETA manid 1234'
+$wikibase.parsePBID('BETA manid 1234')     // → { group, tableid, num }
 ```
-
-#### `getPBID(entity, database, table)`
-Extracts the PhiloBiblon ID from an entity.
-
-```javascript
-const pbid = this.$wikibase.getPBID(entity, 'BETA', 'manid')
-// Returns: 'BETA manid 1234'
-```
-
-#### `parsePBID(pbid)`
-Parses a PBID string into components.
-
-```javascript
-const { group, tableid, num } = this.$wikibase.parsePBID('BETA manid 1234')
-// group: 'BETA'
-// tableid: 'manid'
-// num: '1234'
-```
-
-### Configuration Management
-
-The service reads UI configuration from special Wikibase wiki pages:
-
-- **`Ui_SortedProperties`**: Defines claim display order
-- **`Ui_SortedProperties_NewItem`**: Defines claim order for new items
-- **`Ui_ControlledVocabulary`**: Defines autocomplete behavior
-
-These are parsed and cached for performance.
 
 ## QueryService
 
-Generates complex SPARQL queries for the search interface.
-
-### Initialization
-
-```javascript
-constructor(store, config) {
-  this.$store = store
-  this.$config = config
-}
-```
+Generates SPARQL queries for the search interface. Accessed via `$wikibase.$query`.
 
 ### Key Methods
 
-#### `addPrefixes(query)`
-Prepends SPARQL prefixes from backend configuration.
-
-```javascript
-const fullQuery = this.$query.addPrefixes(`
-  SELECT ?item WHERE { ?item wdt:P31 wd:Q5 }
-`)
-```
-
-#### Table-Specific Filter Generators
-
-Each table type has a dedicated filter method:
-
-- `addInstitutionFilters(form)` - For `insid` (institutions)
-- `addWorkFilters(form)` - For `texid` (works)
-- `addPersonFilters(form)` - For `bioid` (people)
-- `addLibraryFilters(form)` - For `libid` (libraries)
-- `addReferenceFilters(form)` - For `bibid` (references)
-
-**Example**:
-
-```javascript
-const filters = this.$query.addWorkFilters({
-  input: {
-    author: { value: { target_item: 'Q789' } },
-    language: { value: { target_item: 'Q150' } },
-    date_composition: { value: { begin: '1400', end: '1500' } }
-  }
-})
-```
-
-Generates:
-
-```sparql
-?item wdt:P21 wd:Q789 .
-?item wdt:P18 wd:Q150 .
-?item p:P412 ?date_of_creation .
-OPTIONAL { ?item wdt:P412 ?begin_date }
-FILTER(?begin_date >= '1400-01-01T00:00:00Z'^^xsd:dateTime)
-...
-```
-
-#### `generateFilterByWords(form, filterField, filterValues)`
-Creates full-text search filters with diacritic normalization.
-
-```javascript
-const filter = this.$query.generateFilterByWords(
-  form,
-  'label',
-  ['barcelona', 'catalunya']
-)
-// Returns: (contains(replace(..., 'barcelona')) && contains(replace(..., 'catalunya')))
-```
-
-#### `normalize(str)`
-Removes diacritics for search matching.
-
-```javascript
-this.$query.normalize('Català')  // Returns: 'catala'
-```
-
-### BITAGAP Group Filters
-
-Special logic for BITAGAP database to filter by "Cartas" vs "Original" groups:
-
-```javascript
-generateBitagapGroupWorkFilters(bitagapGroup) {
-  if (bitagapGroup === 'CARTAS') {
-    return 'FILTER(CONTAINS(STR(?labelSubjectItem), "[Cartas de]"))'
-  } else if (bitagapGroup === 'ORIG') {
-    return 'FILTER(!CONTAINS(STR(?labelSubjectItem), "[Cartas de]"))'
-  }
-}
-```
+- `addPrefixes(query)` — prepends SPARQL prefixes from backend config
+- Table-specific filter generators: `addInstitutionFilters`, `addWorkFilters`, `addPersonFilters`, `addLibraryFilters`, `addReferenceFilters`
+- `generateFilterByWords(form, field, values)` — full-text filter with diacritic normalization
+- `normalize(str)` — strips diacritics for search matching
 
 ## OAuthService
 
-Handles the OAuth 1.0a authentication flow with the backend.
+Handles the OAuth 1.0a authentication flow. Accessed via `$wikibase.$oauth`.
 
 ### Methods
 
-#### `initiateLogin()`
-Starts the OAuth flow.
+#### `step1()`
+Starts the OAuth flow (redirects to Wikibase authorization page).
 
-```javascript
-async initiateLogin() {
-  const { token, authorizationUrl } = await this.$axios.$get('/api/oauth/request-token')
-  window.location.href = authorizationUrl
-}
-```
+#### `step2(oauthToken, oauthVerifier)`
+Completes the flow after user approval and stores the access token.
 
-#### `completeLogin(oauthToken, oauthVerifier)`
-Completes the OAuth flow after user approval.
-
-```javascript
-async completeLogin(oauthToken, oauthVerifier) {
-  const accessToken = await this.$axios.$get('/api/oauth/access-token', {
-    params: { oauth_token: oauthToken, oauth_verifier: oauthVerifier }
-  })
-  
-  const username = await this.$axios.$get('/api/oauth/username', {
-    params: {
-      oauth_token: accessToken.token,
-      oauth_tokensecret: accessToken.tokenSecret
-    }
-  })
-  
-  this.$store.commit('auth/login', { username, accessToken })
-}
-```
+#### `autoLoginByCookie()`
+Attempts to restore a session from the `oauth` cookie on page load (called from `default.vue` layout `onMounted`).
 
 ## NotificationService
 
-Provides a consistent interface for user notifications.
+Wraps `@kyvg/vue3-notification` for consistent toast messages.
 
 ### Methods
 
-#### `success(message)`
-Shows a success toast.
-
 ```javascript
-this.$notification.success('Item saved successfully!')
+$notification.success('Item saved!')
+$notification.error(error)   // smart error formatting
+$notification.info('Loading...')
 ```
 
-#### `error(error)`
-Shows an error toast with smart error parsing.
+The `error` method handles common cases:
+- `session-expired` error code → triggers logout (via `useNotifyError` composable)
+- `maxlag` → "Wikibase is slow, try again"
+- Network/timeout errors → "Wikibase unreachable"
+- Generic errors → extracts `error.body.error.info`
+
+For richer error handling (i18n messages, automatic logout), use the `useNotifyError` composable instead of `$notification.error` directly:
 
 ```javascript
+const { notifyError } = useNotifyError()
 try {
-  await this.$wikibase.saveClaim(claim)
+  await $wikibase.saveClaim(claim)
 } catch (error) {
-  this.$notification.error(error)
-  // Automatically handles:
-  // - 401 errors -> "Authentication error"
-  // - Server error responses -> extracts error.response.data.message
-  // - Network errors -> displays error message
-}
-```
-
-#### `info(message)`
-Shows an informational toast.
-
-```javascript
-this.$notification.info('Loading data...')
-```
-
-### Error Handling Logic
-
-```javascript
-error(error) {
-  if (error.response) {
-    if (error.response.status === 401) {
-      error = 'Authentication error'
-    } else if (error.response.data?.message) {
-      error = error.response.data.message
-    }
-  }
-  console.error(error)
-  this.$toast.error(error, { duration: 5000, icon: 'error' })
+  notifyError(error)
 }
 ```
 
 ## Service Injection Pattern
 
-Services are injected globally via Nuxt plugins:
+Services are injected via Nuxt plugins and accessed with `useNuxtApp()`:
 
 ```javascript
-// plugins/wikibase.js
-export default ({ $axios, store }, inject) => {
-  inject('wikibase', new WikibaseService($axios, store))
-}
+// plugins/03.wikibase.client.js
+export default defineNuxtPlugin((nuxtApp) => {
+  const config = useRuntimeConfig().public
+  return {
+    provide: {
+      wikibase: new WikibaseService({ config, $notification: nuxtApp.$notification })
+    }
+  }
+})
 ```
 
-Usage in components:
+Usage in components (`<script setup>`):
 
 ```javascript
-export default {
-  async mounted() {
-    const entity = await this.$wikibase.getEntity('Q123', 'ca')
-  }
-}
+const { $wikibase, $notification, $sanitize } = useNuxtApp()
 ```
 
 ## Best Practices
 
-### 1. Always Use Services, Not Direct Axios
+### Always Use Services, Not Direct Fetch
 
 ```javascript
 // ❌ Bad
-const response = await this.$axios.get('/api/wikibase/entities?ids=Q123')
+const response = await fetch(`${config.apiBaseUrl}/api/wikibase/entities?ids=Q123`)
 
 // ✅ Good
-const entity = await this.$wikibase.getEntity('Q123', 'ca')
+const entity = await $wikibase.getEntity('Q123', 'ca')
 ```
 
-### 2. Leverage Caching
+### Use useNotifyError for User-Visible Errors
 
 ```javascript
-// For frequently accessed data, use backend cache
-const results = await this.$wikibase.runSparqlQuery(query, true, true)
-
-// For one-time queries, skip caching
-const results = await this.$wikibase.runSparqlQuery(query, true, false, false)
-```
-
-### 3. Handle Errors Consistently
-
-```javascript
+const { notifyError } = useNotifyError()
 try {
-  await this.$wikibase.saveClaim(claim)
-  this.$notification.success('Saved!')
+  await $wikibase.saveClaim(claim)
+  $notification.success(t('messages.saved'))
 } catch (error) {
-  this.$notification.error(error)  // Let the service handle formatting
+  notifyError(error)
 }
+```
+
+### Leverage Caching
+
+```javascript
+// Backend cache for shared/slow queries
+const results = await $wikibase.runSparqlQuery(query, true, true, false)
+
+// Skip all caching for one-off queries
+const results = await $wikibase.runSparqlQuery(query, true, false, false)
 ```
 
 ## Next Steps
 
-- [Components](components.md) - See how components use these services
-- [State Management](state-management.md) - Understand how services interact with Vuex
+- [Components](components.md) — How components use these services
+- [State Management](state-management.md) — How services interact with Pinia stores

--- a/docs/frontend/setup.md
+++ b/docs/frontend/setup.md
@@ -4,9 +4,15 @@ This guide will help you set up the PhiloBiblon UI frontend for local developmen
 
 ## Prerequisites
 
-- **Node.js**: v14 or later (v16 recommended)
-- **Yarn**: Package manager (v1.22+)
+- **Node.js**: v18 or later (v20 LTS recommended)
+- **Yarn**: v4 (Berry) — managed via `packageManager` field in `package.json`
 - **Git**: For version control
+
+Yarn 4 is declared in `package.json` as `"packageManager": "yarn@4.x.x"`. Enable it with Corepack:
+
+```bash
+corepack enable
+```
 
 ## Installation
 
@@ -23,32 +29,40 @@ cd philobiblon-ui/frontend
 yarn install
 ```
 
-This will install all required npm packages defined in `package.json`.
+After installation, `nuxt prepare` runs automatically (`postinstall` script) to generate Nuxt type definitions.
 
 ## Configuration
 
 ### Environment Variables
 
-The frontend requires the `API_BASE_URL` environment variable to know where the backend API is located.
+The frontend uses `API_BASE_URL` to know where the backend API is located. This is a **Vite build argument** baked into the SPA at build time, not a runtime variable.
 
-**For remote backend:**
+**For the staging backend (default for `yarn dev`):**
+The dev script in `package.json` already sets this:
 ```bash
-export API_BASE_URL=https://philobiblon.cog.berkeley.edu/ui-fg/
+API_BASE_URL=https://philobiblon.cog.berkeley.edu/ui-local/ nuxt dev
 ```
 
-**For local backend:**
+**For a local backend:**
 ```bash
-export API_BASE_URL=http://localhost:8080/
+API_BASE_URL=http://localhost:8080/ yarn dev
 ```
+
+The full list of environment variables is in the root [AGENTS.md](../../AGENTS.md#key-environment-variables).
+
+### Runtime Configuration
+
+Configuration is managed through `nuxt.config.ts` via `runtimeConfig.public`. After the app starts, `01.config.client.js` fetches additional config from the backend (`GET /api/config`) and merges it in.
 
 ### Nuxt Configuration
 
-The main configuration file is `nuxt.config.js`. Key settings:
+The main configuration file is `nuxt.config.ts`. Key settings:
 
-- **mode**: `'spa'` - Client-side rendering only
-- **target**: `'server'` - Build target
-- **axios**: Base URL configured from `API_BASE_URL`
-- **vuetify**: Material Design theme configuration
+- **`ssr: false`** — Client-side rendering only (SPA mode)
+- **`app.baseURL`** — Configured from `BASE_URL` env var (e.g. `/ui-fg/`)
+- **`modules`** — `@pinia/nuxt`, `@nuxtjs/i18n`, `vuetify-nuxt-module`, `@nuxt/eslint`
+- **`vuetify`** — Theme, global component defaults, locale messages
+- **`i18n`** — Locale files, `'prefix'` strategy, cookie-based detection
 
 ## Running the Development Server
 
@@ -56,80 +70,73 @@ The main configuration file is `nuxt.config.js`. Key settings:
 yarn dev
 ```
 
-Or with the environment variable inline:
-
-```bash
-export API_BASE_URL=https://philobiblon.cog.berkeley.edu/ui-fg/ && yarn dev
-```
-
 The application will be available at `http://localhost:3000`.
 
 ### Development Features
 
-- **Hot Module Replacement (HMR)**: Changes to `.vue` files automatically reload
-- **ESLint**: Code quality checks run on save
-- **Source Maps**: For debugging in browser DevTools
+- **Hot Module Replacement (HMR)**: Vite-powered instant updates on file save
+- **ESLint**: Code quality checks (run `yarn lint`)
+- **Auto-imports**: Components, composables, and Nuxt/Vue utilities are imported automatically
 
 ## Building for Production
 
-### Generate Static Files
-
-```bash
-yarn generate
-```
-
-This creates a `dist/` directory with static HTML/JS/CSS files.
-
-### Build for Server Deployment
-
 ```bash
 yarn build
-yarn start
 ```
 
-This creates an optimized production build and starts the Nuxt server.
+Produces the `.output/` directory with a Node.js server and static assets.
+
+```bash
+yarn preview
+```
+
+Serves the production build locally for testing.
 
 ## Common Commands
 
 | Command | Description |
 |---------|-------------|
-| `yarn dev` | Start development server with hot reload |
+| `yarn dev` | Start Vite dev server with HMR |
 | `yarn build` | Build for production |
-| `yarn start` | Start production server |
-| `yarn generate` | Generate static site |
+| `yarn preview` | Preview the production build |
+| `yarn generate` | Generate a fully static site |
 | `yarn lint` | Run ESLint |
-| `yarn lint --fix` | Auto-fix ESLint errors |
+| `yarn postinstall` | Regenerate Nuxt types (runs automatically after `yarn install`) |
 
 ## Troubleshooting
 
 ### Port Already in Use
 
-If port 3000 is already in use, you can specify a different port:
-
 ```bash
 PORT=3001 yarn dev
 ```
 
-### Module Not Found Errors
+### Module Not Found / Type Errors
 
-Clear the Nuxt cache and reinstall:
+Clear Nuxt's generated files and reinstall:
 
 ```bash
-rm -rf node_modules .nuxt
+rm -rf node_modules .nuxt .output
 yarn install
 ```
 
 ### API Connection Issues
 
-Verify that:
-1. `API_BASE_URL` is set correctly
-2. The backend is running and accessible
-3. CORS is properly configured on the backend
+1. Verify `API_BASE_URL` is set and points to a running backend
+2. Check the browser console — the config plugin logs errors if `API_BASE_URL` is missing
+3. Confirm CORS is configured on the backend for your local origin
 
-Check the browser console for detailed error messages.
+### Yarn 4 Not Recognised
+
+Make sure Corepack is enabled and active:
+
+```bash
+corepack enable
+corepack prepare yarn@4 --activate
+```
 
 ## Next Steps
 
 - Read the [Architecture Guide](architecture.md) to understand the project structure
-- Review [State Management](state-management.md) to learn about Vuex stores
+- Review [State Management](state-management.md) to learn about Pinia stores
 - Explore [Components](components.md) for UI component patterns

--- a/docs/frontend/state-management.md
+++ b/docs/frontend/state-management.md
@@ -1,213 +1,127 @@
-# State Management (Vuex)
+# State Management (Pinia)
 
-The frontend uses Vuex for centralized state management. Each store module handles a specific domain of the application state.
+The frontend uses **Pinia** for centralized state management, replacing Vuex from the Nuxt 2 version. All stores live in `stores/` and use the Composition API style (`defineStore` with a setup function).
 
 ## Store Modules Overview
 
-| Module | Purpose | Key State |
-|--------|---------|-----------|
-| `auth` | User authentication | `isLogged`, `username`, `accessToken` |
-| `queryStatus` | Search form state | `currentTable`, `form`, `currentPage` |
-| `breadcrumb` | Navigation breadcrumbs | `items`, `database`, `table` |
-| `itemCache` | Entity caching | `cache` (key-value map) |
-| `queryCache` | SPARQL result caching | `cache` (with TTL) |
+| Module | File | Purpose | Key State |
+|--------|------|---------|-----------|
+| `useAuthStore` | `auth.js` | User authentication | `isLogged`, `username`, `accessToken` |
+| `useQueryStatusStore` | `queryStatus.js` | Search form state | `currentTable`, `form`, `currentPage` |
+| `useBreadcrumbStore` | `breadcrumb.js` | Navigation breadcrumbs | `items`, `database`, `table` |
+| `useItemCacheStore` | `itemCache.js` | Entity caching | `cache` (key-value map) |
+| `useQueryCacheStore` | `queryCache.js` | SPARQL result caching | `cache` (with TTL) |
 
-## auth.js - Authentication State
+## auth.js — Authentication State
 
 ### Purpose
-Manages user session state including login status and OAuth tokens.
+Manages user session including login status and OAuth tokens.
 
 ### State
 
 ```javascript
-{
-  isLogged: false,      // Boolean: is user authenticated?
-  username: null,       // String: logged-in username
-  accessToken: null     // Object: { token, tokenSecret }
-}
+const isLogged = ref(false)
+const username = ref(null)
+const accessToken = ref(null)  // { token, tokenSecret }
 ```
 
-### Mutations
-
-#### `login(state, { username, accessToken })`
-Sets the user as logged in with credentials.
+### Actions
 
 ```javascript
-this.$store.commit('auth/login', {
-  username: 'john.doe',
-  accessToken: {
-    token: 'abc123...',
-    tokenSecret: 'xyz789...'
-  }
-})
+authStore.login({ username: 'john.doe', accessToken: { token: '...', tokenSecret: '...' } })
+authStore.logout()
 ```
 
-#### `logout(state)`
-Clears all authentication data.
+### Computed Properties
 
 ```javascript
-this.$store.commit('auth/logout')
-```
-
-### Getters
-
-#### `getAuthHeaders(state)`
-Generates the OAuth 1.0 Authorization header for API requests.
-
-```javascript
-const headers = this.$store.getters['auth/getAuthHeaders']
-// Returns: { Authorization: 'OAuth oauth_token="...", oauth_token_secret="..."' }
-```
-
-This is used by the backend proxy to sign requests to Wikibase.
-
-#### `getRequestConfig(state)`
-Returns configuration for `wikibase-edit` library.
-
-```javascript
-const config = this.$store.getters['auth/getRequestConfig']
-// Used when calling wikibase-edit functions
+authStore.requestConfig   // { credentials: { oauth: { token: '...' } } }
+authStore.authHeaders     // { Authorization: 'OAuth oauth_token="...", ...' }
 ```
 
 ### Usage Example
 
 ```javascript
-// Login flow (in OAuth callback page)
-export default {
-  async mounted() {
-    const { oauth_token, oauth_verifier } = this.$route.query
-    
-    const accessToken = await this.$axios.$get('/api/oauth/access-token', {
-      params: { oauth_token, oauth_verifier }
-    })
-    
-    const username = await this.$axios.$get('/api/oauth/username', {
-      params: {
-        oauth_token: accessToken.token,
-        oauth_tokensecret: accessToken.tokenSecret
-      }
-    })
-    
-    this.$store.commit('auth/login', { username, accessToken })
-    this.$router.push('/')
-  }
-}
+import { useAuthStore } from '~/stores/auth'
+
+const authStore = useAuthStore()
+
+// Check login status
+if (authStore.isLogged) { ... }
+
+// Get username in template
+const username = computed(() => authStore.username || '')
+
+// Logout
+authStore.logout()
 ```
 
-## queryStatus.js - Search State
+## queryStatus.js — Search State
 
 ### Purpose
-Persists the state of the search interface so users can navigate away and return without losing their filters or results.
+Persists search form state so users can navigate away and return without losing filters or results.
 
 ### State
 
 ```javascript
-{
-  currentTable: null,     // String: e.g., 'manid', 'texid'
-  showResults: null,      // Boolean: are results visible?
-  currentPage: 1,         // Number: pagination
-  sortBy: 'name',         // String: sort field
-  isSortDescending: false,// Boolean: sort direction
-  form: null              // Object: the search form values
-}
+const currentTable = ref(null)     // e.g. 'manid', 'texid'
+const showResults = ref(false)
+const currentPage = ref(1)
+const sortBy = ref('name')
+const isSortDescending = ref(false)
+const form = ref(null)             // the search form values
 ```
 
-### Mutations
-
-#### `setShowResults(state, showResults)`
-Toggles result visibility.
-
-#### `setPage(state, page)`
-Updates current page for pagination.
-
-#### `setSortBy(state, sortBy)`
-Changes the sort field.
-
-#### `setSortDescending(state, isSortDescending)`
-Changes sort direction.
-
-#### `setForm(state, form)`
-Stores the entire search form state.
+### Actions
 
 ```javascript
-this.$store.commit('queryStatus/setForm', {
-  input: {
-    simple_search: { value: { textString: 'manuscript' } },
-    city: { value: { target_item: 'Q456' } }
-  }
-})
-```
-
-#### `resetStatus(state, table)`
-Resets all search state for a new table.
-
-```javascript
-this.$store.commit('queryStatus/resetStatus', 'manid')
+queryStatusStore.setShowResults(true)
+queryStatusStore.setPage(2)
+queryStatusStore.setSortBy('date')
+queryStatusStore.setSortDescending(true)
+queryStatusStore.setForm({ input: { simple_search: { value: { textString: 'manuscript' } } } })
+queryStatusStore.resetStatus('manid')  // clears all state for a new table
 ```
 
 ### Usage Example
 
 ```javascript
-// In search component
-export default {
-  computed: {
-    searchForm() {
-      return this.$store.state.queryStatus.form
-    }
-  },
-  methods: {
-    async performSearch() {
-      // Save form state
-      this.$store.commit('queryStatus/setForm', this.form)
-      this.$store.commit('queryStatus/setShowResults', true)
-      
-      // Execute search...
-    }
-  }
+import { useQueryStatusStore } from '~/stores/queryStatus'
+
+const queryStatusStore = useQueryStatusStore()
+
+async function performSearch() {
+  queryStatusStore.setForm(form.value)
+  queryStatusStore.setShowResults(true)
+  // execute search...
 }
 ```
 
-## breadcrumb.js - Navigation State
+## breadcrumb.js — Navigation State
 
 ### Purpose
-Manages the breadcrumb trail for navigation context.
+Manages the breadcrumb trail shown in the main layout.
 
 ### State
 
 ```javascript
-{
-  items: [],        // Array: breadcrumb items
-  class: '',        // String: CSS class for styling
-  database: '',     // String: current database (BETA, BITECA, BITAGAP)
-  table: ''         // String: current table (manid, texid, etc.)
-}
+const items = ref([])    // breadcrumb entries [{ title, to }]
+const cssClass = ref('')
+const database = ref('')
+const table = ref('')
 ```
 
-### Mutations
-
-#### `addItem(state, item)`
-Adds a breadcrumb item.
+### Actions
 
 ```javascript
-this.$store.commit('breadcrumb/addItem', {
-  text: 'Manuscripts',
-  to: '/search?table=manid'
-})
+breadcrumbStore.addItem({ title: 'Manuscripts', to: '/search/manid/query' })
+breadcrumbStore.setItems([...])
+breadcrumbStore.setDatabase('BETA')
+breadcrumbStore.setTable('manid')
+breadcrumbStore.resetItems()
 ```
 
-#### `setItems(state, items)`
-Replaces all breadcrumbs.
-
-#### `setDatabase(state, database)`
-Sets the current database context.
-
-#### `setTable(state, table)`
-Sets the current table context.
-
-#### `resetItems(state)`
-Clears all breadcrumbs.
-
-## itemCache.js - Entity Caching
+## itemCache.js — Entity Caching
 
 ### Purpose
 Client-side cache for Wikibase entities to avoid redundant API calls.
@@ -215,164 +129,97 @@ Client-side cache for Wikibase entities to avoid redundant API calls.
 ### State
 
 ```javascript
-{
-  cache: {}  // Object: { 'Q123': { id: 'Q123', labels: {...}, ... } }
-}
+const cache = reactive({})  // { 'Q123': { id, labels, claims, ... } }
 ```
 
-### Mutations
-
-#### `addEntry(state, { key, value })`
-Caches an entity.
+### Actions
 
 ```javascript
-this.$store.commit('itemCache/addEntry', {
-  key: 'Q123',
-  value: entityData
-})
+itemCacheStore.addEntry({ key: 'Q123', value: entityData })
 ```
 
 ### Usage Pattern
 
 ```javascript
-// Check cache before fetching
-let entity = this.$store.state.itemCache.cache['Q123']
+import { useItemCacheStore } from '~/stores/itemCache'
 
+const itemCacheStore = useItemCacheStore()
+
+let entity = itemCacheStore.cache['Q123']
 if (!entity) {
-  entity = await this.$wikibase.getEntities(['Q123'])
-  this.$store.commit('itemCache/addEntry', {
-    key: 'Q123',
-    value: entity
-  })
+  entity = await $wikibase.getEntities(['Q123'])
+  itemCacheStore.addEntry({ key: 'Q123', value: entity })
 }
 ```
 
-## queryCache.js - SPARQL Result Caching
+## queryCache.js — SPARQL Result Caching
 
 ### Purpose
-Caches SPARQL query results with automatic expiration to improve performance.
+Caches SPARQL query results with automatic expiration (2-minute TTL, 100-entry max).
 
 ### Configuration
 
 ```javascript
-const CACHE_MAX_ENTRIES = 100          // Max cached queries
-const CACHE_EXPIRATION_MILLIS = 120000 // 2 minutes TTL
+const CACHE_MAX_ENTRIES = 100
+const CACHE_EXPIRATION_MILLIS = 120000  // 2 minutes
 ```
 
 ### State
 
 ```javascript
-{
-  cache: {
-    // key: query hash
-    // value: { time: Date, value: results }
-  }
-}
-```
-
-### Mutations
-
-#### `addEntry(state, { key, value })`
-Caches query results with timestamp. Automatically evicts oldest entry if cache is full.
-
-```javascript
-this.$store.commit('queryCache/addEntry', {
-  key: hashOfQuery,
-  value: sparqlResults
-})
+const cache = reactive({})
+// key: hash of the SPARQL query
+// value: { time: Date, value: results }
 ```
 
 ### Actions
 
-#### `clearCache({ state })`
-Removes expired entries (older than 2 minutes).
-
 ```javascript
-this.$store.dispatch('queryCache/clearCache')
+queryCacheStore.addEntry({ key: queryHash, value: sparqlResults })
+queryCacheStore.clearCache()  // removes entries older than 2 minutes
 ```
 
-This is called periodically to prevent memory bloat.
+`clearCache()` is called automatically every 3 seconds by the `03.wikibase.client.js` plugin.
 
-### Cache Eviction Strategy
+## Accessing Stores in Components
 
-1. **Size-based**: When cache reaches 100 entries, oldest entry is removed
-2. **Time-based**: Entries older than 2 minutes are removed by `clearCache` action
-
-### Usage Example
+Stores are imported directly — no `this.$store` needed:
 
 ```javascript
-// In query service
-const cacheKey = this.hashQuery(sparqlQuery)
-let results = this.$store.state.queryCache.cache[cacheKey]?.value
+import { useAuthStore } from '~/stores/auth'
+import { useBreadcrumbStore } from '~/stores/breadcrumb'
 
-if (!results) {
-  results = await this.$axios.$post('/api/sparql/query', { query: sparqlQuery })
-  this.$store.commit('queryCache/addEntry', { key: cacheKey, value: results })
-}
+const authStore = useAuthStore()
+const breadcrumbStore = useBreadcrumbStore()
+
+// Read reactive state
+console.log(authStore.isLogged)
+
+// Call actions
+authStore.login({ username, accessToken })
 ```
 
-## Best Practices
+State is reactive: using store properties directly in templates or `computed()` will trigger re-renders on change.
 
-### 1. Use Mutations for State Changes
+## Migrating from Vuex
 
-Never mutate state directly:
+If you're coming from the Nuxt 2 / Vuex version:
 
-```javascript
-// ❌ Bad
-this.$store.state.auth.isLogged = true
-
-// ✅ Good
-this.$store.commit('auth/login', { username, accessToken })
-```
-
-### 2. Use Getters for Computed State
-
-For derived data, use getters instead of computing in components:
-
-```javascript
-// In store
-getters: {
-  isAuthenticated(state) {
-    return state.isLogged && state.accessToken !== null
-  }
-}
-
-// In component
-computed: {
-  canEdit() {
-    return this.$store.getters['auth/isAuthenticated']
-  }
-}
-```
-
-### 3. Namespace Your Commits
-
-Always use the module namespace:
-
-```javascript
-this.$store.commit('auth/login', data)  // ✅
-this.$store.commit('login', data)       // ❌ Won't work
-```
+| Vuex pattern | Pinia equivalent |
+|---|---|
+| `this.$store.state.auth.isLogged` | `authStore.isLogged` |
+| `this.$store.commit('auth/login', data)` | `authStore.login(data)` |
+| `this.$store.getters['auth/requestConfig']` | `authStore.requestConfig` |
+| `this.$store.dispatch('queryCache/clearCache')` | `queryCacheStore.clearCache()` |
 
 ## Debugging State
 
-### Vue DevTools
-
-Use the Vue DevTools browser extension to:
-- Inspect current state
-- View mutation history
-- Time-travel debug (replay mutations)
-
-### Console Access
-
-In development, access store from console:
-
-```javascript
-$nuxt.$store.state.auth
-$nuxt.$store.commit('auth/logout')
-```
+Use the **Vue DevTools** browser extension (Pinia tab) to:
+- Inspect current store state
+- View action history
+- Patch state directly for testing
 
 ## Next Steps
 
-- [Services](services.md) - Learn how services interact with stores
-- [Components](components.md) - See how components use Vuex
+- [Services](services.md) — How services interact with stores
+- [Components](components.md) — How components consume stores

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -1,0 +1,19 @@
+# Development workflow
+
+```mermaid
+flowchart LR
+    A[🧑‍💻 Code changes] --> B[🤖 Automated review\nCodeRabbit]
+    B -->|Auto-fix| A
+    B --> C[📋 JM review]
+    C -->|Changes needed| A
+    C -->|Approved| D[🔀 Merge PR]
+    D --> E[🚀 Auto-published\nto staging]
+    E --> F[👤 Charles review]
+    F -->|Changes needed| A
+    F -->|Approved| G[🏷️ New version tag]
+    G --> H[🌐 Auto-published\nto production]
+
+    style B fill:#f5a623,color:#000
+    style E fill:#27ae60,color:#fff
+    style H fill:#8e44ad,color:#fff
+```


### PR DESCRIPTION
Rewrites all frontend documentation to reflect the completed migration: Vuex → Pinia, Options API → Composition API, Webpack → Vite, Yarn 1 → Yarn 4, Axios → fetch, nuxt.config.js → nuxt.config.ts, store/ → stores/, static/ → public/, Nuxt 2 plugins → defineNuxtPlugin .client.js pattern, bracket-syntax dynamic routes, locale-prefixed routing.

Also updates AGENTS.md header and inline references that still said Nuxt 2 / Vue 2.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated comprehensive frontend development documentation to reflect the current technology stack and architecture, including Nuxt 3, Vue 3, Pinia, and Vite.
  * Refreshed guides for local development setup, services layer, state management patterns, and component architecture.
  * Added development workflow documentation outlining the code review cycle and publishing processes.
  * Updated setup instructions for Yarn 4 and Corepack requirements.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/PhiloBiblon/philobiblon-ui/pull/434)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->