### PR TITLE
Chore/backend upgrade spring4 java21

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,7 +16,7 @@ yarn lint       # ESLint
 
 The dev script hardcodes `API_BASE_URL=https://philobiblon.cog.berkeley.edu/ui-dev/` as the backend.
 
-### Backend (Spring Boot / Java 17)
+### Backend (Spring Boot / Java 21)
 
 ```bash
 cd backend
@@ -39,7 +39,7 @@ docker compose down -v   # Remove everything including volumes
 Two modules behind an nginx reverse proxy:
 
 - **Frontend** (`frontend/`) — Nuxt 2 SPA (SSR disabled). Talks to Wikibase API directly for reads, and to the backend for writes (proxied through OAuth) and cached SPARQL queries.
-- **Backend** (`backend/`) — Spring Boot 3 middleware. Handles OAuth 1.0a with Wikibase, proxies edit requests, and caches SPARQL queries with Caffeine LoadingCache (24h refresh, 36h expiry).
+- **Backend** (`backend/`) — Spring Boot 4 middleware. Handles OAuth 1.0a with Wikibase, proxies edit requests, and caches SPARQL queries with Caffeine LoadingCache (24h refresh, 36h expiry).
 
 ### Two-level SPARQL caching
 

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,9 +1,9 @@
-FROM maven:3.9-eclipse-temurin-17 AS builder
+FROM maven:3.9-eclipse-temurin-21 AS builder
 WORKDIR /app
 COPY . .
 RUN mvn clean package -DskipTests
 
-FROM eclipse-temurin:17-jdk
+FROM eclipse-temurin:21-jdk
 WORKDIR /app
 COPY --from=builder /app/target/*.jar app.jar
 ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -6,4 +6,7 @@ RUN mvn clean package -DskipTests
 FROM eclipse-temurin:21-jdk
 WORKDIR /app
 COPY --from=builder /app/target/*.jar app.jar
+RUN useradd --create-home --shell /usr/sbin/nologin appuser \
+    && chown appuser:appuser /app/app.jar
+USER appuser
 ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.0.5</version>
+        <version>4.0.6</version>
         <relativePath/>
     </parent>
 
@@ -16,13 +16,13 @@
     <version>1.0.4</version>
 
     <properties>
-        <maven.release.compiler>17</maven.release.compiler>
+        <java.version>21</java.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <scribejava.version>8.3.3</scribejava.version>
-        <parsson.version>1.1.1</parsson.version>
-        <jena.version>4.9.0</jena.version>
-        <caffeine.version>3.1.6</caffeine.version>
+        <parsson.version>1.1.6</parsson.version>
+        <jena.version>6.0.0</jena.version>
+        <caffeine.version>3.2.4</caffeine.version>
     </properties>
 
     <dependencies>
@@ -64,7 +64,7 @@
         <dependency>
             <groupId>org.apache.jena</groupId>
             <artifactId>jena-arq</artifactId>
-            <version>5.4.0</version>
+            <version>${jena.version}</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
@@ -78,7 +78,6 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
-            <version>5.10.2</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -35,14 +35,6 @@
             <artifactId>spring-boot-starter-cache</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.springframework</groupId>
-            <artifactId>spring-web</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework</groupId>
-            <artifactId>spring-context</artifactId>
-        </dependency>
-        <dependency>
             <groupId>com.github.scribejava</groupId>
             <artifactId>scribejava-apis</artifactId>
             <version>${scribejava.version}</version>

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -20,7 +20,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <scribejava.version>8.3.3</scribejava.version>
-        <parsson.version>1.1.6</parsson.version>
+        <parsson.version>1.1.7</parsson.version>
         <jena.version>6.0.0</jena.version>
         <caffeine.version>3.2.4</caffeine.version>
     </properties>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Java runtime upgraded from 17 to 21
  * Spring Boot upgraded from v3 to v4
  * Container images updated to Java 21 for build and runtime; runtime now runs as a non-root user
  * Backend dependency versions refreshed and consolidated; dependency management leveraged from Spring Boot

* **Documentation**
  * Architecture and backend runtime notes updated to reflect new Java and Spring Boot versions

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/PhiloBiblon/philobiblon-ui/pull/435)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->