### PR TITLE
fix(frontend): fix wiki page external links and anchor scroll offset

### DIFF
--- a/frontend/components/PhiloFooter.vue
+++ b/frontend/components/PhiloFooter.vue
@@ -52,7 +52,7 @@
           </v-row>
           <v-row density="comfortable">
             <v-col class="text-caption">
-              Volume 2024, Number 3 (March) ISSN 1096-6609
+              Volume 2025, Number 1 (January) ISSN 1096-6609
             </v-col>
           </v-row>
         </v-container>
@@ -61,16 +61,24 @@
         <v-container fluid>
           <v-row density="comfortable">
             <v-col>
-              <img src="/img/footer/universitat_barcelona.png">
+              <a href="https://www.ub.edu" target="_blank">
+                <img src="/img/footer/universitat_barcelona.png">
+              </a>
             </v-col>
             <v-col>
-              <img src="/img/footer/upf.png">
+              <a href="https://www.upf.edu" target="_blank">
+                <img src="/img/footer/upf.png">
+              </a>
             </v-col>
             <v-col>
-              <img src="/img/footer/the_bancroft.png">
+              <a href="https://bancroft.berkeley.edu" target="_blank">
+                <img src="/img/footer/the_bancroft.png">
+              </a>
             </v-col>
             <v-col>
-              <img src="/img/footer/ilf.png">
+              <a href="https://larramendi.es/fundacion/" target="_blank">
+                <img src="/img/footer/ilf.png">
+              </a>
             </v-col>
           </v-row>
         </v-container>

--- a/frontend/components/PhiloFooter.vue
+++ b/frontend/components/PhiloFooter.vue
@@ -52,7 +52,7 @@
           </v-row>
           <v-row density="comfortable">
             <v-col class="text-caption">
-              Volume 2025, Number 1 (January) ISSN 1096-6609
+              {{ t('footer.citation') }}
             </v-col>
           </v-row>
         </v-container>

--- a/frontend/components/PhiloFooter.vue
+++ b/frontend/components/PhiloFooter.vue
@@ -61,23 +61,23 @@
         <v-container fluid>
           <v-row density="comfortable">
             <v-col>
-              <a href="https://www.ub.edu" target="_blank">
-                <img src="/img/footer/universitat_barcelona.png">
+              <a href="https://www.ub.edu" target="_blank" rel="noopener noreferrer">
+                <img src="/img/footer/universitat_barcelona.png" alt="Universitat de Barcelona">
               </a>
             </v-col>
             <v-col>
-              <a href="https://www.upf.edu" target="_blank">
-                <img src="/img/footer/upf.png">
+              <a href="https://www.upf.edu" target="_blank" rel="noopener noreferrer">
+                <img src="/img/footer/upf.png" alt="Universitat Pompeu Fabra">
               </a>
             </v-col>
             <v-col>
-              <a href="https://bancroft.berkeley.edu" target="_blank">
-                <img src="/img/footer/the_bancroft.png">
+              <a href="https://bancroft.berkeley.edu" target="_blank" rel="noopener noreferrer">
+                <img src="/img/footer/the_bancroft.png" alt="The Bancroft Library">
               </a>
             </v-col>
             <v-col>
-              <a href="https://larramendi.es/fundacion/" target="_blank">
-                <img src="/img/footer/ilf.png">
+              <a href="https://larramendi.es/fundacion/" target="_blank" rel="noopener noreferrer">
+                <img src="/img/footer/ilf.png" alt="Fundación Ignacio Larramendi">
               </a>
             </v-col>
           </v-row>

--- a/frontend/lang/ca.js
+++ b/frontend/lang/ca.js
@@ -604,5 +604,8 @@ export default {
     search: {
       placeholder: 'Cercar en PhiloBiblon'
     }
+  },
+  footer: {
+    citation: 'Volum 2025, Número 1 (Gener) ISSN 1096-6609'
   }
 }

--- a/frontend/lang/en.js
+++ b/frontend/lang/en.js
@@ -606,5 +606,8 @@ export default {
     search: {
       placeholder: 'Search in PhiloBiblon'
     }
+  },
+  footer: {
+    citation: 'Volume 2025, Number 1 (January) ISSN 1096-6609'
   }
 }

--- a/frontend/lang/es.js
+++ b/frontend/lang/es.js
@@ -604,5 +604,8 @@ export default {
     search: {
       placeholder: 'Buscar en PhiloBiblon'
     }
+  },
+  footer: {
+    citation: 'Volumen 2025, Número 1 (Enero) ISSN 1096-6609'
   }
 }

--- a/frontend/lang/gl.js
+++ b/frontend/lang/gl.js
@@ -604,5 +604,8 @@ export default {
     search: {
       placeholder: 'Busca en PhiloBiblon'
     }
+  },
+  footer: {
+    citation: 'Volume 2025, Número 1 (Xaneiro) ISSN 1096-6609'
   }
 }

--- a/frontend/lang/pt.js
+++ b/frontend/lang/pt.js
@@ -604,5 +604,8 @@ export default {
     search: {
       placeholder: 'Pesquisar em PhiloBiblon'
     }
+  },
+  footer: {
+    citation: 'Volume 2025, Número 1 (Janeiro) ISSN 1096-6609'
   }
 }

--- a/frontend/pages/wiki/[page].vue
+++ b/frontend/pages/wiki/[page].vue
@@ -76,17 +76,18 @@ function contentPage (data) {
 
 function parseLinks (content) {
   const EXTERNAL_LINK_RE = /\[(https?:\/\/[^\s\]]+)(?:\s([^\]]*))?\]/g
-  const INTERNAL_LINK_RE = /\[\[([^\]|]*)\|([^\]]*)\]\]/g
+  const INTERNAL_LINK_RE = /\[\[([^\]|]+)(?:\|([^\]]*))?\]\]/g
   return content
     .replace(EXTERNAL_LINK_RE, (match, url, text) => `<a href='${url}' target='_blank' rel='noopener noreferrer'>${text || url}</a>`)
     .replace(INTERNAL_LINK_RE, (match, g1, g2) => parseInternalLink(g1, g2))
 }
 
 function parseInternalLink (link, text) {
+  const originalLink = link
   if (!link.startsWith('/')) {
     link = `/wiki/${link}`
   }
-  return `<a href='${baseURL}${localePath(link)}'>${text || link}</a>`
+  return `<a href='${baseURL}${localePath(link)}'>${text || originalLink}</a>`
 }
 </script>
 

--- a/frontend/pages/wiki/[page].vue
+++ b/frontend/pages/wiki/[page].vue
@@ -33,7 +33,6 @@ onMounted(async () => {
 function prepareContent (html) {
   return $sanitize(html)
     .replaceAll('<a href="#', '<a href="' + window.location.pathname + '#')
-    .replaceAll('<a id=', '<a style="padding-top: 50px;" id=')
     .replaceAll('<blockquote>', '<blockquote style="padding-left: 50px;">')
     .replace(/href="(?!https?:|\/|#|mailto:)([^"]+)"/g, (_, path) => {
       const hasLocale = ['en', 'ca', 'es', 'gl', 'pt'].some(l => path.startsWith(l + '/'))
@@ -76,20 +75,23 @@ function contentPage (data) {
 }
 
 function parseLinks (content) {
-  const LINK_RE = /\[\[([^\]|]*)\|([^\]]*)\]\]/g
-  return content.replace(LINK_RE, (match, g1, g2) => parseLink(match, g1, g2))
+  const EXTERNAL_LINK_RE = /\[(https?:\/\/[^\s\]]+)(?:\s([^\]]*))?\]/g
+  const INTERNAL_LINK_RE = /\[\[([^\]|]*)\|([^\]]*)\]\]/g
+  return content
+    .replace(EXTERNAL_LINK_RE, (match, url, text) => `<a href='${url}' target='_blank' rel='noopener noreferrer'>${text || url}</a>`)
+    .replace(INTERNAL_LINK_RE, (match, g1, g2) => parseInternalLink(g1, g2))
 }
 
-function parseLink (match, g1, g2) {
-  let link = g1
-  const text = g2 !== undefined ? g2 : g1
-  if (link.startsWith('http')) {
-    return `<a href='${link}'>${text}</a>`
-  } else {
-    if (!link.startsWith('/')) {
-      link = `/wiki/${link}`
-    }
-    return `<a href='${baseURL}${localePath(link)}'>${text}</a>`
+function parseInternalLink (link, text) {
+  if (!link.startsWith('/')) {
+    link = `/wiki/${link}`
   }
+  return `<a href='${baseURL}${localePath(link)}'>${text || link}</a>`
 }
 </script>
+
+<style scoped>
+:deep([id]) {
+  scroll-margin-top: 64px;
+}
+</style>


### PR DESCRIPTION
- Support MediaWiki external link format [url text] in wiki page renderer
- Fix section anchors hidden behind fixed header using scroll-margin-top
- Update footer volume/number and add links to institution logos

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Organization logos in the footer now link to their respective websites and open in a new tab

## Bug Fixes
* Fixed in-page anchor navigation links to properly direct to page sections
* Improved scroll positioning when navigating to anchors

## Updates
* Updated publication citation to Volume 2025, Number 1 (January)
* External links in wiki content now open in new tabs with security safeguards
* Enhanced blockquote spacing with left padding

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/PhiloBiblon/philobiblon-ui/pull/441?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->