### PR TITLE
feature(frontend): add Related Institution filter to BIOID search

### DIFF
--- a/frontend/lang/ca.js
+++ b/frontend/lang/ca.js
@@ -273,6 +273,10 @@ export default {
         religion: {
           label: 'Religió',
           hint: ''
+        },
+        related_institution: {
+          label: 'Institució relacionada',
+          hint: 'Cerqueu persones associades a una institució específica.'
         }
       },
       bibid: {

--- a/frontend/lang/en.js
+++ b/frontend/lang/en.js
@@ -273,6 +273,10 @@ export default {
         religion: {
           label: 'Religion',
           hint: ''
+        },
+        related_institution: {
+          label: 'Related institution',
+          hint: 'Search for persons associated with a specific institution.'
         }
       },
       bibid: {

--- a/frontend/lang/es.js
+++ b/frontend/lang/es.js
@@ -273,6 +273,10 @@ export default {
         religion: {
           label: 'Religión',
           hint: ''
+        },
+        related_institution: {
+          label: 'Institución relacionada',
+          hint: 'Busque personas asociadas a una institución específica.'
         }
       },
       bibid: {

--- a/frontend/lang/gl.js
+++ b/frontend/lang/gl.js
@@ -273,6 +273,10 @@ export default {
         religion: {
           label: 'Relixión',
           hint: ''
+        },
+        related_institution: {
+          label: 'Institución relacionada',
+          hint: 'Busca persoas asociadas a unha institución específica.'
         }
       },
       bibid: {

--- a/frontend/lang/pt.js
+++ b/frontend/lang/pt.js
@@ -278,6 +278,10 @@ export default {
         religion: {
           label: 'Religião',
           hint: ''
+        },
+        related_institution: {
+          label: 'Instituição relacionada',
+          hint: 'Pesquise pessoas associadas a uma instituição específica.'
         }
       },
       bibid: {

--- a/frontend/pages/search/bioid/query.vue
+++ b/frontend/pages/search/bioid/query.vue
@@ -266,6 +266,34 @@ const form = {
               `
             }
           },
+          related_institution: {
+            active: true,
+            section: 'advanced',
+            label: 'search.form.bioid.related_institution.label',
+            hint: 'search.form.bioid.related_institution.hint',
+            type: 'autocomplete',
+            value: {},
+            visible: true,
+            disabled: false,
+            autocomplete: {
+              query:
+              `
+              SELECT DISTINCT ?target_item ?label ?desc WHERE {
+                {
+                  SELECT DISTINCT ?target_item WHERE {
+                    ?item wdt:P476 ?pbid .
+                    FILTER regex(?pbid, '{{database}} {{table}} ') .
+                    {{bitagapGroupFilter}}
+                    ?item wdt:P232 ?target_item .
+                    ?target_item wdt:P476 ?target_pbid .
+                    FILTER regex(?target_pbid, "(.*) insid ") .
+                  }
+                }
+                {{targetItemLangGroupPattern}}
+              }
+              `
+            }
+          },
           subject: {
             active: true,
             section: 'advanced',

--- a/frontend/service/query.service.js
+++ b/frontend/service/query.service.js
@@ -531,6 +531,12 @@ export class QueryService {
         ?item wdt:P165 wd:${form.input.profession.value.target_item} .
         `
     }
+    if (form.input.related_institution && form.input.related_institution.value && form.input.related_institution.value.target_item) {
+      filters +=
+        `
+        ?item wdt:P232 wd:${form.input.related_institution.value.target_item} .
+        `
+    }
     if (form.input.subject && form.input.subject.value) {
       filters +=
         `


### PR DESCRIPTION
## Summary

- Adds a new **Related Institution** autocomplete field to the BIOID (biographical records) advanced search form
- The field queries insid (institution) records linked to biographical entries via property P232
- Adds SPARQL filter logic in `query.service.js` to apply the selected institution as a search constraint
- Translations added for all five locales: **ca**, **en**, **es**, **gl**, **pt**

## Test plan

- [x] Open the BIOID search page and expand the advanced filters
- [x] Verify the "Related Institution" field appears and the autocomplete works
- [x] Select an institution and run a search — results should be filtered to persons linked to that institution
- [x] Check translations are displayed correctly for all five supported languages

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a "Related Institution" search filter to the BioID search form, enabling users to search for persons associated with a specific institution.
  * Full multilingual support provided in English, Spanish, Catalan, Galician, and Portuguese translations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/PhiloBiblon/philobiblon-ui/pull/442?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->