### PR TITLE
fix(frontend): use P1054 as qualifier of P329 in MANID collection search

### DIFF
--- a/frontend/pages/search/manid/query.vue
+++ b/frontend/pages/search/manid/query.vue
@@ -142,7 +142,8 @@ const form = {
                         ?item wdt:P476 ?pbid .
                         FILTER regex(?pbid, '{{database}} {{table}} ') .
                         {{bitagapGroupFilter}}
-                        ?item wdt:P1054 ?label .
+                        ?item p:P329 ?library_stmt .
+                        ?library_stmt pq:P1054 ?label .
                       }
                       UNION
                       {
@@ -152,7 +153,8 @@ const form = {
                         ?item wdt:P476 ?pbid .
                         FILTER regex(?pbid, '{{database}} {{table}} ') .
                         {{bitagapGroupFilter}}
-                        ?copid_item wdt:P1054 ?label .
+                        ?copid_item p:P329 ?library_stmt .
+                        ?library_stmt pq:P1054 ?label .
                       }
                     }
                   }

--- a/frontend/service/query.service.js
+++ b/frontend/service/query.service.js
@@ -748,14 +748,16 @@ export class QueryService {
       filters +=
         `
         {
-          ?item wdt:P1054 ?item_collection .
+          ?item p:P329 ?library_stmt .
+          ?library_stmt pq:P1054 ?item_collection .
         }
         UNION
         {
           ?copid_item wdt:P476 ?copid_pbid .
           FILTER regex(?copid_pbid, '(.*) copid ') .
           ?copid_item wdt:P839 ?item .
-          ?copid_item wdt:P1054 ?item_collection .
+          ?copid_item p:P329 ?library_stmt .
+          ?library_stmt pq:P1054 ?item_collection .
         }
         ${collectionFilter}
         `


### PR DESCRIPTION
## Summary

- In the MANID search form autocomplete query (`pages/search/manid/query.vue`), changed P1054 lookup from a direct property (`wdt:P1054`) to a qualifier of the Library statement (`p:P329 / pq:P1054`).
- Applied the same fix to the search filter in `service/query.service.js` (`addManuscriptFilters`), for both direct manid items and copid-linked items.

## Test plan

- [x] Open the MANID search form and verify the Collection autocomplete returns results
- [x] Select a collection value and confirm the search results are filtered correctly
- [ ] Verify the copid path also works (manuscripts whose collection is set on the copid item)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated collection data retrieval mechanism in search autocomplete and manuscript filtering to optimize query patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->