### PR TITLE
#306 flexible date input for item editing and search

### DIFF
--- a/frontend/components/item/qualifier/Create.vue
+++ b/frontend/components/item/qualifier/Create.vue
@@ -34,6 +34,7 @@
             :value="qualifier"
             type="qualifier"
             mode="creation"
+            :parent-property-id="claim?.mainsnak?.property ?? null"
             @on-blur="onNewValue($event, qualifier)"
           />
         </div>

--- a/frontend/components/item/util/EditDatePickerField.vue
+++ b/frontend/components/item/util/EditDatePickerField.vue
@@ -2,6 +2,7 @@
   <v-menu
     v-model="isDatePickerActive"
     :close-on-content-click="false"
+    :disabled="!useCalendar"
   >
     <template #activator="{ props: activatorProps }">
       <v-text-field
@@ -9,8 +10,10 @@
         :label="t('common.date')"
         class="date-input"
         density="compact"
-        readonly
-        v-bind="activatorProps"
+        :readonly="useCalendar"
+        :placeholder="useCalendar ? '' : t('common.date_placeholder')"
+        :error-messages="validationError ? [validationError] : []"
+        v-bind="useCalendar ? activatorProps : {}"
         @focus="focus"
         @blur="blur"
       >
@@ -71,6 +74,7 @@
     </template>
 
     <v-date-picker
+      v-if="useCalendar"
       v-model="pickerDate"
       :max="today"
       min="0001-01-01"
@@ -89,7 +93,8 @@ const props = defineProps({
   value: { type: String, default: null },
   save: { type: Function, default: null },
   delete: { type: Function, default: null },
-  mode: { type: String, default: 'edit' }
+  mode: { type: String, default: 'edit' },
+  useCalendar: { type: Boolean, default: false }
 })
 
 const emit = defineEmits(['on-blur', 'new-value'])
@@ -103,21 +108,39 @@ const consolidatedText = ref(null)
 const pickerDate = ref(null)
 const focussed = ref(false)
 const isDatePickerActive = ref(false)
+const validationError = ref(null)
 
 const isEditable = computed(() => props.mode === 'edit')
 const today = computed(() => new Date().toISOString().slice(0, 10))
+
+// Accepted partial date patterns
+const PARTIAL_DATE_REGEXES = [
+  /^\d{4}$/,               // YYYY
+  /^\d{4}-\d{2}$/,         // YYYY-MM or YYYY-DD
+  /^\d{4}-\d{2}-\d{2}$/,   // YYYY-MM-DD
+  /^\d{2}-\d{2}$/,         // MM-DD
+  /^\d{2}$/                // DD
+]
 
 watch(currentText, (newVal, oldVal) => {
   if (oldVal != null && newVal !== oldVal) {
     focussed.value = true
   }
-  pickerDate.value = parseDate(newVal)
+  if (props.useCalendar) {
+    pickerDate.value = parseDate(newVal)
+  }
+  // Clear stale error while user is typing
+  if (!props.useCalendar && validationError.value) {
+    validationError.value = null
+  }
 })
 
 onMounted(() => {
   currentText.value = props.value
   consolidatedText.value = props.value
-  pickerDate.value = parseDate(props.value)
+  if (props.useCalendar) {
+    pickerDate.value = parseDate(props.value)
+  }
 })
 
 function focus () {
@@ -126,7 +149,31 @@ function focus () {
 
 function blur () {
   focussed.value = false
+  if (!props.useCalendar) {
+    const error = validatePartialDate(currentText.value)
+    if (error) {
+      validationError.value = error
+      return
+    }
+    validationError.value = null
+  }
   emit('on-blur', currentText.value)
+}
+
+function validatePartialDate (text) {
+  if (!text) return null
+  if (!PARTIAL_DATE_REGEXES.some(r => r.test(text))) {
+    return t('common.date_format_error')
+  }
+  // For patterns that start with a 4-digit year, validate the year range
+  const yearMatch = text.match(/^(\d{4})/)
+  if (yearMatch) {
+    const year = parseInt(yearMatch[1], 10)
+    if (year > 2125) {
+      return t('search.form.common.date.error.invalid_year')
+    }
+  }
+  return null
 }
 
 function onDateSelect (newDate) {
@@ -148,12 +195,11 @@ function formatDate (date) {
 
 function parseDate (text) {
   if (!text) return null
-  // Detect ISO date-only strings (YYYY-MM-DD) and parse as local date
   const isoDatePattern = /^(\d{4})-(\d{2})-(\d{2})$/
   const match = text.match(isoDatePattern)
   if (match) {
     const year = parseInt(match[1], 10)
-    const month = parseInt(match[2], 10) - 1 // months are 0-indexed
+    const month = parseInt(match[2], 10) - 1
     const day = parseInt(match[3], 10)
     const d = new Date(year, month, day)
     return Number.isNaN(d.getTime()) ? null : d
@@ -165,6 +211,14 @@ function parseDate (text) {
 async function edit () {
   try {
     focussed.value = false
+    // Validate before saving in text mode
+    if (!props.useCalendar) {
+      const error = validatePartialDate(currentText.value)
+      if (error) {
+        validationError.value = error
+        return
+      }
+    }
     const response = await props.save(currentText.value, consolidatedText.value)
     if (response && response.success) {
       consolidatedText.value = currentText.value
@@ -179,6 +233,7 @@ async function edit () {
 
 function restore () {
   currentText.value = consolidatedText.value
+  validationError.value = null
   focussed.value = false
   emit('new-value', currentText.value)
 }
@@ -216,5 +271,9 @@ async function deleteValue () {
 
 :deep(.v-input__details) {
   display: none;
+}
+
+:deep(.v-input--error .v-input__details) {
+  display: block;
 }
 </style>

--- a/frontend/components/item/value/Base.vue
+++ b/frontend/components/item/value/Base.vue
@@ -9,6 +9,7 @@
       :delete="isEditable ? deleteValue : null"
       :mode="mode"
       :value-to-view="valueToView"
+      :parent-property-id="valueToView.type === 'time' ? parentPropertyId : undefined"
       @on-blur="emit('on-blur', $event)"
       @new-value="emit('new-value', $event)"
     />
@@ -45,7 +46,8 @@ const props = defineProps({
   label: { type: String, default: null },
   value: { type: Object, default: null },
   type: { type: String, default: null },
-  mode: { type: String, default: 'edit' }
+  mode: { type: String, default: 'edit' },
+  parentPropertyId: { type: String, default: null }
 })
 
 const emit = defineEmits(['on-blur', 'new-value', 'delete-claim', 'delete-qualifier', 'create-reference', 'delete-reference'])
@@ -66,6 +68,7 @@ onMounted(async () => {
   )
   if (result) {
     result.useDefault = props.value.datavalue?.default !== false
+    result.property = props.value.property
   }
   valueToView.value = result
 })

--- a/frontend/components/item/value/type/Time.vue
+++ b/frontend/components/item/value/type/Time.vue
@@ -113,7 +113,7 @@ function getTimeNewValue (value) {
  * Supported input formats: YYYY, YYYY-MM, YYYY-MM-DD, YYYY-DD (day>12), MM-DD, DD
  */
 function toWikibaseTime (input) {
-  if (!input) return { time: null, precision: 11 }
+  if (!input) return { time: null, precision: null }
 
   // YYYY-MM-DD — full date, precision day (11)
   const fullMatch = input.match(/^(\d{4})-(\d{2})-(\d{2})$/)
@@ -151,7 +151,8 @@ function toWikibaseTime (input) {
     }
   }
 
-  // MM-DD — month and day without year, precision day (11), year defaults to 0000
+  // MM-DD — month and day without year, precision day (11).
+  // Year defaults to +0000 which is valid ISO 8601 (= 1 BCE in proleptic Gregorian).
   const monthDayMatch = input.match(/^(\d{2})-(\d{2})$/)
   if (monthDayMatch) {
     return {
@@ -160,7 +161,7 @@ function toWikibaseTime (input) {
     }
   }
 
-  // DD — day only, precision day (11), year and month default to 0000/01
+  // DD — day only, precision day (11), year and month default to +0000/01.
   const dayMatch = input.match(/^(\d{2})$/)
   if (dayMatch) {
     return {
@@ -169,8 +170,8 @@ function toWikibaseTime (input) {
     }
   }
 
-  // Fallback: treat as YYYY-MM-DD with precision day (11)
-  return { time: `+${input}T00:00:00Z`, precision: 11 }
+  // Unrecognized format — return null rather than producing a malformed Wikibase time string.
+  return { time: null, precision: null }
 }
 </script>
 

--- a/frontend/components/item/value/type/Time.vue
+++ b/frontend/components/item/value/type/Time.vue
@@ -8,6 +8,7 @@
         <item-util-edit-date-picker-field
           :value="valueToView_.value"
           :mode="mode"
+          :use-calendar="useCalendar"
           class="ma-0 pa-0"
           :save="editValue"
           :delete="deleteValue"
@@ -38,7 +39,8 @@ const props = defineProps({
   valueToView: { type: Object, default: null },
   save: { type: Function, default: null },
   delete: { type: Function, default: null },
-  mode: { type: String, default: 'edit' }
+  mode: { type: String, default: 'edit' },
+  parentPropertyId: { type: String, default: null }
 })
 
 const emit = defineEmits(['on-blur', 'new-value'])
@@ -50,6 +52,11 @@ const authStore = useAuthStore()
 const valueToView_ = reactive({ ...props.valueToView })
 const isUserLogged = computed(() => authStore.isLogged)
 const isEditable = computed(() => props.mode === 'edit')
+
+// Calendar popup only for P106 (Date) when qualifier of P799 (Dataset status)
+const useCalendar = computed(() =>
+  props.valueToView?.property === 'P106' && props.parentPropertyId === 'P799'
+)
 
 function newDateValue (value) {
   valueToView_.value = value
@@ -93,19 +100,77 @@ function getTimeValue (newValue, oldValue) {
 }
 
 function getTimeNewValue (value) {
+  const { time, precision } = toWikibaseTime(value)
   return {
-    time: formatDate(value),
+    time,
+    precision,
     calendar: valueToView_.calendar.toLowerCase()
   }
 }
 
-function formatDate (dateString) {
-  const date = new Date(dateString)
-  const isoYear = date.getUTCFullYear()
-  const isoMonth = ('0' + (date.getUTCMonth() + 1)).slice(-2)
-  const isoDay = ('0' + date.getUTCDate()).slice(-2)
+/**
+ * Converts a partial date string to Wikibase time format with the correct precision.
+ * Supported input formats: YYYY, YYYY-MM, YYYY-MM-DD, YYYY-DD (day>12), MM-DD, DD
+ */
+function toWikibaseTime (input) {
+  if (!input) return { time: null, precision: 11 }
 
-  return `+${isoYear}-${isoMonth}-${isoDay}T00:00:00Z`
+  // YYYY-MM-DD — full date, precision day (11)
+  const fullMatch = input.match(/^(\d{4})-(\d{2})-(\d{2})$/)
+  if (fullMatch) {
+    return {
+      time: `+${fullMatch[1]}-${fullMatch[2]}-${fullMatch[3]}T00:00:00Z`,
+      precision: 11
+    }
+  }
+
+  // YYYY-MM or YYYY-DD (disambiguate: if second part > 12 it must be a day)
+  const yearTwoMatch = input.match(/^(\d{4})-(\d{2})$/)
+  if (yearTwoMatch) {
+    const n = parseInt(yearTwoMatch[2], 10)
+    if (n > 12) {
+      // YYYY-DD: day without month, precision day (11), month defaults to 01
+      return {
+        time: `+${yearTwoMatch[1]}-01-${yearTwoMatch[2]}T00:00:00Z`,
+        precision: 11
+      }
+    }
+    // YYYY-MM: precision month (10)
+    return {
+      time: `+${yearTwoMatch[1]}-${yearTwoMatch[2]}-01T00:00:00Z`,
+      precision: 10
+    }
+  }
+
+  // YYYY — year only, precision year (9)
+  const yearMatch = input.match(/^(\d{4})$/)
+  if (yearMatch) {
+    return {
+      time: `+${yearMatch[1]}-01-01T00:00:00Z`,
+      precision: 9
+    }
+  }
+
+  // MM-DD — month and day without year, precision day (11), year defaults to 0000
+  const monthDayMatch = input.match(/^(\d{2})-(\d{2})$/)
+  if (monthDayMatch) {
+    return {
+      time: `+0000-${monthDayMatch[1]}-${monthDayMatch[2]}T00:00:00Z`,
+      precision: 11
+    }
+  }
+
+  // DD — day only, precision day (11), year and month default to 0000/01
+  const dayMatch = input.match(/^(\d{2})$/)
+  if (dayMatch) {
+    return {
+      time: `+0000-01-${dayMatch[1]}T00:00:00Z`,
+      precision: 11
+    }
+  }
+
+  // Fallback: treat as YYYY-MM-DD with precision day (11)
+  return { time: `+${input}T00:00:00Z`, precision: 11 }
 }
 </script>
 

--- a/frontend/components/search/util/DateField.vue
+++ b/frontend/components/search/util/DateField.vue
@@ -4,22 +4,23 @@
       <v-menu v-model="activeBegin" :close-on-content-click="false">
         <template #activator="{ props: activatorProps }">
           <v-text-field
-            :model-value="beginValue"
+            v-model="beginValue"
             class="date-input"
             :disabled="disabled"
             :label="label + '. ' + t('common.from')"
             density="compact"
-            placeholder="YYYY-MM-DD"
-            v-bind="activatorProps"
-            append-inner-icon="mdi-calendar"
-            @click:append-inner.stop="activeBegin = true"
+            :placeholder="t('common.date_placeholder')"
             @focus="showHint"
             @blur="hideHint"
-            @change="validateBeginDate($event.target.value)"
-          />
+            @change="validateBeginDate(beginValue)"
+          >
+            <template #append-inner>
+              <v-icon v-bind="activatorProps" size="20" @click.stop>mdi-calendar</v-icon>
+            </template>
+          </v-text-field>
         </template>
         <v-date-picker
-          v-model="beginValue"
+          v-model="beginPickerDate"
           :max="today"
           min="0001-01-01"
           hide-header
@@ -30,22 +31,23 @@
       <v-menu v-model="activeEnd" :close-on-content-click="false">
         <template #activator="{ props: activatorProps }">
           <v-text-field
-            :model-value="endValue"
+            v-model="endValue"
             class="date-input"
             :disabled="disabled"
             :label="t('common.to')"
             density="compact"
-            placeholder="YYYY-MM-DD"
-            v-bind="activatorProps"
-            append-inner-icon="mdi-calendar"
-            @click:append-inner.stop="activeEnd = true"
+            :placeholder="t('common.date_placeholder')"
             @focus="showHint"
             @blur="hideHint"
-            @change="validateEndDate($event.target.value)"
-          />
+            @change="validateEndDate(endValue)"
+          >
+            <template #append-inner>
+              <v-icon v-bind="activatorProps" size="20" @click.stop>mdi-calendar</v-icon>
+            </template>
+          </v-text-field>
         </template>
         <v-date-picker
-          v-model="endValue"
+          v-model="endPickerDate"
           :max="today"
           min="0001-01-01"
           hide-header
@@ -90,9 +92,19 @@ const activeEnd = ref(false)
 const activeBegin = ref(false)
 const beginValue = ref(null)
 const endValue = ref(null)
+const beginPickerDate = ref(null)
+const endPickerDate = ref(null)
 const isHintVisible = ref(false)
 
 const today = computed(() => new Date().toISOString().slice(0, 10))
+
+const PARTIAL_DATE_REGEXES = [
+  /^\d{4}$/,
+  /^\d{4}-\d{2}$/,
+  /^\d{4}-\d{2}-\d{2}$/,
+  /^\d{2}-\d{2}$/,
+  /^\d{2}$/
+]
 
 watch(() => props.value, (newVal) => {
   beginValue.value = newVal?.begin || null
@@ -115,21 +127,20 @@ function validateEndDate (date) {
 }
 
 function validateDate (date) {
-  const DATE_REGEX = /^\d{4}-\d{2}-\d{2}$/
-  if (!date) {
-    return null
-  } else if (!DATE_REGEX.test(date)) {
+  if (!date) return null
+  if (!PARTIAL_DATE_REGEXES.some(r => r.test(date))) {
     $notification.error(t('search.form.common.date.error.invalid_date'))
     return null
-  } else {
-    const parsed = new Date(`${date}T00:00:00Z`)
-    const year = parseInt(date.substring(0, 4), 10)
-    if (isNaN(parsed.getTime()) || year > 2125) {
+  }
+  const yearMatch = date.match(/^(\d{4})/)
+  if (yearMatch) {
+    const year = parseInt(yearMatch[1], 10)
+    if (year > 2125) {
       $notification.error(t('search.form.common.date.error.invalid_year'))
       return null
     }
-    return date
   }
+  return date
 }
 
 function dateToIso (date) {
@@ -145,13 +156,13 @@ function dateToIso (date) {
 
 function onBeginDateSelect () {
   activeBegin.value = false
-  beginValue.value = dateToIso(beginValue.value)
+  beginValue.value = dateToIso(beginPickerDate.value)
   validateBeginDate(beginValue.value)
 }
 
 function onEndDateSelect () {
   activeEnd.value = false
-  endValue.value = dateToIso(endValue.value)
+  endValue.value = dateToIso(endPickerDate.value)
   validateEndDate(endValue.value)
 }
 

--- a/frontend/lang/ca.js
+++ b/frontend/lang/ca.js
@@ -12,6 +12,8 @@ export default {
     amount: 'Quantitat',
     unit: 'Unitat',
     date: 'Data',
+    date_placeholder: 'AAAA, AAAA-MM, AAAA-MM-DD, MM-DD o DD',
+    date_format_error: 'Data no vàlida. Useu: AAAA, AAAA-MM, AAAA-MM-DD, MM-DD o DD',
     calendar: 'Calendari',
     from: 'Des de',
     to: 'a',
@@ -162,7 +164,7 @@ export default {
           label: 'Data',
           hint: 'In fields that include dates, search by any combination of year (yyyy) and/or month (mm) and/or day (dd). A search returns dates as yyyy-mm-dd (1379-01-31 is January 31, 1379). Search using this format or more simply, the year: “1379” returns all texts written in 1379; “1379 01” or “01 1379” returns all texts written on the first of each month of 1379 and on any day of January of 1379. Note: Year dates frequently form part of titles in WORK and can be used to search for the same.',
           error: {
-            invalid_date: 'Data no vàlida. Utilitzeu el format AAAA-MM-DD',
+            invalid_date: 'Data no vàlida. Useu: AAAA, AAAA-MM, AAAA-MM-DD, MM-DD o DD',
             invalid_year: 'L\'any ha d\'estar entre 0 i 2125'
           }
         },

--- a/frontend/lang/en.js
+++ b/frontend/lang/en.js
@@ -12,6 +12,8 @@ export default {
     amount: 'Amount',
     unit: 'Unit',
     date: 'Date',
+    date_placeholder: 'YYYY, YYYY-MM, YYYY-MM-DD, MM-DD, or DD',
+    date_format_error: 'Invalid date. Use: YYYY, YYYY-MM, YYYY-MM-DD, MM-DD, or DD',
     calendar: 'Calendar',
     from: 'From',
     to: 'To',
@@ -162,7 +164,7 @@ export default {
           label: 'Date',
           hint: 'In fields that include dates, search by any combination of year (yyyy) and/or month (mm) and/or day (dd). A search returns dates as yyyy-mm-dd (1379-01-31 is January 31, 1379). Search using this format or more simply, the year: “1379” returns all texts written in 1379; “1379 01” or “01 1379” returns all texts written on the first of each month of 1379 and on any day of January of 1379. Note: Year dates frequently form part of titles in WORK and can be used to search for the same.',
           error: {
-            invalid_date: 'Invalid date. Use YYYY-MM-DD format',
+            invalid_date: 'Invalid date. Use: YYYY, YYYY-MM, YYYY-MM-DD, MM-DD, or DD',
             invalid_year: 'Year must be between 0 and 2125'
           }
         },

--- a/frontend/lang/es.js
+++ b/frontend/lang/es.js
@@ -12,6 +12,8 @@ export default {
     amount: 'Cantidad',
     unit: 'Unidad',
     date: 'Fecha',
+    date_placeholder: 'AAAA, AAAA-MM, AAAA-MM-DD, MM-DD o DD',
+    date_format_error: 'Fecha no válida. Usar: AAAA, AAAA-MM, AAAA-MM-DD, MM-DD o DD',
     calendar: 'Calendario',
     from: 'De',
     to: 'a',
@@ -162,7 +164,7 @@ export default {
           label: 'Fecha',
           hint: 'In fields that include dates, search by any combination of year (yyyy) and/or month (mm) and/or day (dd). A search returns dates as yyyy-mm-dd (1379-01-31 is January 31, 1379). Search using this format or more simply, the year: “1379” returns all texts written in 1379; “1379 01” or “01 1379” returns all texts written on the first of each month of 1379 and on any day of January of 1379. Note: Year dates frequently form part of titles in WORK and can be used to search for the same.',
           error: {
-            invalid_date: 'Fecha no válida. Use el formato AAAA-MM-DD',
+            invalid_date: 'Fecha no válida. Usar: AAAA, AAAA-MM, AAAA-MM-DD, MM-DD o DD',
             invalid_year: 'El año debe estar entre 0 y 2125'
           }
         },

--- a/frontend/lang/gl.js
+++ b/frontend/lang/gl.js
@@ -12,6 +12,8 @@ export default {
     amount: 'Cantidade',
     unit: 'Unidade',
     date: 'Data',
+    date_placeholder: 'AAAA, AAAA-MM, AAAA-MM-DD, MM-DD ou DD',
+    date_format_error: 'Data non válida. Usar: AAAA, AAAA-MM, AAAA-MM-DD, MM-DD ou DD',
     calendar: 'Calendario',
     from: 'Dende',
     to: 'a',
@@ -162,7 +164,7 @@ export default {
           label: 'Data',
           hint: 'In fields that include dates, search by any combination of year (yyyy) and/or month (mm) and/or day (dd). A search returns dates as yyyy-mm-dd (1379-01-31 is January 31, 1379). Search using this format or more simply, the year: “1379” returns all texts written in 1379; “1379 01” or “01 1379” returns all texts written on the first of each month of 1379 and on any day of January of 1379. Note: Year dates frequently form part of titles in WORK and can be used to search for the same.',
           error: {
-            invalid_date: 'Data non válida. Usar o formato AAAA-MM-DD',
+            invalid_date: 'Data non válida. Usar: AAAA, AAAA-MM, AAAA-MM-DD, MM-DD ou DD',
             invalid_year: 'O ano debe estar entre 0 e 2126'
           }
         },

--- a/frontend/lang/pt.js
+++ b/frontend/lang/pt.js
@@ -12,6 +12,8 @@ export default {
     amount: 'Montante',
     unit: 'Unidade',
     date: 'Data',
+    date_placeholder: 'AAAA, AAAA-MM, AAAA-MM-DD, MM-DD ou DD',
+    date_format_error: 'Data inválida. Utilizar: AAAA, AAAA-MM, AAAA-MM-DD, MM-DD ou DD',
     calendar: 'Calendário',
     advanced_search: 'Busca avançada',
     from: 'De',
@@ -163,7 +165,7 @@ export default {
           label: 'Data',
           hint: 'In fields that include dates, search by any combination of year (yyyy) and/or month (mm) and/or day (dd). A search returns dates as yyyy-mm-dd (1379-01-31 is January 31, 1379). Search using this format or more simply, the year: “1379” returns all texts written in 1379; “1379 01” or “01 1379” returns all texts written on the first of each month of 1379 and on any day of January of 1379. Note: Year dates frequently form part of titles in WORK and can be used to search for the same.',
           error: {
-            invalid_date: 'Data inválida. Utilize o formato AAAA-MM-DD',
+            invalid_date: 'Data inválida. Utilizar: AAAA, AAAA-MM, AAAA-MM-DD, MM-DD ou DD',
             invalid_year: 'O ano deve estar entre 0 e 2125'
           }
         },

--- a/frontend/service/query.service.js
+++ b/frontend/service/query.service.js
@@ -298,9 +298,33 @@ export class QueryService {
       `
   }
 
+  _normalizePartialDate (date, isEnd = false) {
+    if (!date) return null
+    if (/^\d{4}$/.test(date)) {
+      return isEnd ? `${date}-12-31` : `${date}-01-01`
+    }
+    if (/^\d{4}-\d{2}$/.test(date)) {
+      if (isEnd) {
+        const [y, m] = date.split('-').map(Number)
+        const lastDay = new Date(y, m, 0).getDate()
+        return `${date}-${String(lastDay).padStart(2, '0')}`
+      }
+      return `${date}-01`
+    }
+    if (/^\d{2}-\d{2}$/.test(date)) {
+      return `0000-${date}`
+    }
+    if (/^\d{2}$/.test(date)) {
+      return `0000-01-${date}`
+    }
+    return date
+  }
+
   _dateRangeFilters (fieldValue, { statementPattern = '', beginOptional = '', endOptional = '', beginVar = 'begin_date', endVar = 'end_date' } = {}) {
     if (!fieldValue || (!fieldValue.begin && !fieldValue.end)) { return '' }
     const { begin, end } = fieldValue
+    const beginNorm = this._normalizePartialDate(begin, false)
+    const endNorm = this._normalizePartialDate(end, true)
     const completeRange = !!(begin && end)
     let filters = statementPattern ? `
         ${statementPattern}
@@ -309,12 +333,12 @@ export class QueryService {
       filters += beginOptional
       if (completeRange) {
         filters += `
-            FILTER(!BOUND(?${beginVar}) || ?${beginVar} >= '${begin}T00:00:00Z'^^xsd:dateTime)
-            FILTER(!BOUND(?${beginVar}) || ?${beginVar} <= '${end}T00:00:00Z'^^xsd:dateTime )
+            FILTER(!BOUND(?${beginVar}) || ?${beginVar} >= '${beginNorm}T00:00:00Z'^^xsd:dateTime)
+            FILTER(!BOUND(?${beginVar}) || ?${beginVar} <= '${endNorm}T00:00:00Z'^^xsd:dateTime )
             `
       } else {
         filters += `
-            FILTER(?${beginVar} >= '${begin}T00:00:00Z'^^xsd:dateTime)
+            FILTER(?${beginVar} >= '${beginNorm}T00:00:00Z'^^xsd:dateTime)
             `
       }
     }
@@ -322,12 +346,12 @@ export class QueryService {
       filters += endOptional
       if (completeRange) {
         filters += `
-            FILTER(!BOUND(?${endVar}) || ?${endVar} <= '${end}T00:00:00Z'^^xsd:dateTime)
-            FILTER(!BOUND(?${endVar}) || ?${endVar} >= '${begin}T00:00:00Z'^^xsd:dateTime )
+            FILTER(!BOUND(?${endVar}) || ?${endVar} <= '${endNorm}T00:00:00Z'^^xsd:dateTime)
+            FILTER(!BOUND(?${endVar}) || ?${endVar} >= '${beginNorm}T00:00:00Z'^^xsd:dateTime )
             `
       } else {
         filters += `
-            FILTER(?${endVar} <= '${end}T00:00:00Z'^^xsd:dateTime)
+            FILTER(?${endVar} <= '${endNorm}T00:00:00Z'^^xsd:dateTime)
             `
       }
     }


### PR DESCRIPTION
 - Allow partial date formats (YYYY, YYYY-MM, YYYY-MM-DD, MM-DD, DD) in both the item date editor and the search date filter fields
- Decouple DateField text input from calendar picker: the calendar icon is now the sole activator, letting users type dates freely
- Add _normalizePartialDate() in query.service.js to expand partial dates to full YYYY-MM-DD before building SPARQL xsd:dateTime filters
- Support useCalendar prop in EditDatePickerField to switch between free-text partial-date entry and calendar-only mode
- Propagate parentPropertyId to qualifiers so P106/P799 calendar mode works
- Update date placeholders and error messages in all five locales

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Date fields now accept partial date formats (year, year-month, year-month-day, month-day, day).
  * Optional calendar mode for date picker with enhanced validation.

* **Improvements**
  * Clearer date input error messages and placeholders.
  * Enhanced time value editing with improved context handling.

* **Localization**
  * Updated translations in Catalan, English, Spanish, Galician, and Portuguese for date field guidance and error messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->