### PR TITLE
fix(frontend): #335 improve error messages for Wikibase API failures

### DIFF
--- a/frontend/components/item/Create.vue
+++ b/frontend/components/item/Create.vue
@@ -362,10 +362,9 @@ async function create () {
       if (response.success) {
         await router.push(localePath('/item/' + response.entity.id))
       } else {
-        $notification.error(t('messages.error.something_went_wrong'))
+        throw response
       }
     } catch (error) {
-      console.error(error)
       notifyError(error)
     }
   } else {

--- a/frontend/components/item/Notes.vue
+++ b/frontend/components/item/Notes.vue
@@ -52,12 +52,10 @@ async function editValue (value) {
         content.value.value = value
         $notification.success(t('messages.success.updated'))
       } else {
-        console.error('Error editing notes page:', data.error)
-        $notification.error(data.error?.info ?? t('messages.error.something_went_wrong'))
+        throw data
       }
     } else {
-      console.error('HTTP error editing notes:', response.status)
-      $notification.error(t('messages.error.something_went_wrong'))
+      throw new Error(`HTTP ${response.status}`)
     }
   } catch (error) {
     notifyError(error)

--- a/frontend/components/item/claim/AddValue.vue
+++ b/frontend/components/item/claim/AddValue.vue
@@ -84,6 +84,7 @@ const emit = defineEmits(['update-claims-values', 'create-claim'])
 
 const { $notification, $wikibase } = useNuxtApp()
 const { t } = useI18n()
+const { notifyError } = useNotifyError()
 const authStore = useAuthStore()
 
 const items = reactive({})
@@ -127,18 +128,22 @@ async function createClaim (index) {
   if (value == null) {
     return
   }
-  const res = await $wikibase.getWbEdit().claim.create({
-    value,
-    id: props.item.id,
-    property: props.value.property
-  }, authStore.requestConfig)
-  if (res.success) {
-    $notification.success(t('messages.success.updated'))
-    updateClaims(res)
-  } else {
-    $notification.error(t('messages.error.something_went_wrong'))
+  try {
+    const res = await $wikibase.getWbEdit().claim.create({
+      value,
+      id: props.item.id,
+      property: props.value.property
+    }, authStore.requestConfig)
+    if (res.success) {
+      $notification.success(t('messages.success.updated'))
+      updateClaims(res)
+    } else {
+      throw res
+    }
+    return res
+  } catch (error) {
+    notifyError(error)
   }
-  return res
 }
 
 function updateClaims (res) {

--- a/frontend/components/item/claim/Create.vue
+++ b/frontend/components/item/claim/Create.vue
@@ -204,7 +204,7 @@ async function addClaim (index) {
         removeClaim(index)
         $notification.success(t('messages.success.updated'))
       } else {
-        $notification.error(t('messages.error.something_went_wrong'))
+        throw res
       }
     }).catch((error) => {
       notifyError(error)

--- a/frontend/components/item/qualifier/Create.vue
+++ b/frontend/components/item/qualifier/Create.vue
@@ -191,7 +191,7 @@ async function createQualifier (index) {
       removeQualifier(index)
       $notification.success(t('messages.success.updated'))
     } else {
-      $notification.error(t('messages.error.something_went_wrong'))
+      throw res
     }
   }).catch((error) => {
     notifyError(error)

--- a/frontend/components/item/reference/Create.vue
+++ b/frontend/components/item/reference/Create.vue
@@ -191,7 +191,7 @@ async function createReference (index) {
         removeReference(index)
         $notification.success(t('messages.success.updated'))
       } else {
-        $notification.error(t('messages.error.something_went_wrong'))
+        throw res
       }
     }).catch((error) => {
       notifyError(error)

--- a/frontend/composables/useNotifyError.js
+++ b/frontend/composables/useNotifyError.js
@@ -1,5 +1,16 @@
 import { useAuthStore } from '~/stores/auth'
 
+const WIKIBASE_ERROR_KEYS = {
+  maxlag: 'messages.error.wikibase_slow',
+  'invalid-json': 'messages.error.wikibase_malformed_input',
+  badvalue: 'messages.error.wikibase_malformed_input',
+  'failed-save': 'messages.error.wikibase_save_failed',
+  editconflict: 'messages.error.wikibase_edit_conflict',
+  readonly: 'messages.error.wikibase_readonly',
+  ratelimited: 'messages.error.wikibase_ratelimited',
+  blocked: 'messages.error.wikibase_blocked',
+}
+
 export function useNotifyError () {
   const { $notification } = useNuxtApp()
   const { t } = useI18n()
@@ -8,7 +19,8 @@ export function useNotifyError () {
   function notifyError (error) {
     console.error(error)
 
-    if (error?.body?.error?.code === 'session-expired' || error?.message === 'query is undefined') {
+    const code = error?.body?.error?.code ?? error?.error?.code
+    if (code === 'session-expired' || error?.message === 'query is undefined') {
       authStore.logout()
       $notification.error(t('messages.error.session.expired'))
       return
@@ -21,18 +33,20 @@ export function useNotifyError () {
 }
 
 function getFriendlyMessage (error, t) {
-  if (error?.name === 'maxlag' || error?.body?.error?.code === 'maxlag') {
-    return t('messages.error.wikibase_slow')
+  const code = error?.body?.error?.code ?? error?.error?.code ?? error?.name
+  if (code && WIKIBASE_ERROR_KEYS[code]) {
+    return t(WIKIBASE_ERROR_KEYS[code])
   }
   if (isNetworkOrTimeout(error)) {
     return t('messages.error.wikibase_unreachable')
   }
-  return error?.body?.error?.info ?? t('messages.error.something_went_wrong')
+  return error?.body?.error?.info ?? error?.error?.info ?? t('messages.error.something_went_wrong')
 }
 
 function getHint (error) {
-  const hint = error?.body?.error?.code ?? error?.name
-  return (hint && hint !== 'Error') ? hint : null
+  const code = error?.body?.error?.code ?? error?.error?.code ?? error?.name
+  if (!code || code === 'Error' || WIKIBASE_ERROR_KEYS[code]) return null
+  return code
 }
 
 function buildMessage (error, t) {

--- a/frontend/lang/ca.js
+++ b/frontend/lang/ca.js
@@ -583,17 +583,26 @@ export default {
       something_went_wrong: 'Alguna cosa ha fallat!',
       wikibase_slow: 'Wikibase està sobrecarregat. Torna-ho a provar en uns moments.',
       wikibase_unreachable: 'No s\'ha pogut connectar amb Wikibase. Torna-ho a provar.',
+      wikibase_malformed_input: 'Entrada malformada. Comproveu els valors i torneu-ho a intentar.',
+      wikibase_save_failed: 'El desament ha fallat. Torneu-ho a intentar.',
+      wikibase_edit_conflict: 'S\'ha detectat un conflicte d\'edició. Recarregueu la pàgina i torneu-ho a intentar.',
+      wikibase_readonly: 'Wikibase és de només lectura en aquest moment. Torneu-ho a intentar més tard.',
+      wikibase_ratelimited: 'Massa sol·licituds. Espereu i torneu-ho a intentar.',
+      wikibase_blocked: 'El vostre compte ha estat bloquejat.',
+      auth: {
+        login_failed: 'L\'inici de sessió ha fallat. Torneu-ho a intentar.'
+      },
       session: {
         expired: 'Sessió expirada'
       },
       inputs: {
-        label: 'Please fill label',
+        label: 'Si us plau, ompliu l\'etiqueta',
         fill: 'Si us plau, ompliu les entrades',
-        description: 'Please fill description',
-        initial_claims: 'Claims are still loading',
-        claim_value_missing: 'Please fill in the claim value for "{propertyLabel}"',
-        qualifier_key_missing: 'A qualifier property is missing in the claim "{claimLabel}" for "{propertyLabel}"',
-        qualifier_value_missing: 'Some qualifier(s) value are missing in the claim "{claimLabel}" for "{propertyLabel}"'
+        description: 'Si us plau, ompliu la descripció',
+        initial_claims: 'Les afirmacions s\'estan carregant',
+        claim_value_missing: 'Si us plau, ompliu el valor de l\'afirmació per a "{propertyLabel}"',
+        qualifier_key_missing: 'Falta una propietat de qualificador a l\'afirmació "{claimLabel}" per a "{propertyLabel}"',
+        qualifier_value_missing: 'Falta el valor d\'algun qualificador a l\'afirmació "{claimLabel}" per a "{propertyLabel}"'
       },
       creation: {
         pbid_already_exists: 'El PhiloBiblon ID "{pbid}" ja existeix en {item}.'

--- a/frontend/lang/en.js
+++ b/frontend/lang/en.js
@@ -585,6 +585,15 @@ export default {
       something_went_wrong: 'Something went wrong!',
       wikibase_slow: 'Wikibase is under heavy load. Please try again in a few moments.',
       wikibase_unreachable: 'Could not connect to Wikibase. Please try again.',
+      wikibase_malformed_input: 'Malformed input. Please check the values and try again.',
+      wikibase_save_failed: 'Save failed. Please try again.',
+      wikibase_edit_conflict: 'Edit conflict detected. Please reload and try again.',
+      wikibase_readonly: 'Wikibase is currently read-only. Please try again later.',
+      wikibase_ratelimited: 'Too many requests. Please wait and try again.',
+      wikibase_blocked: 'Your account has been blocked.',
+      auth: {
+        login_failed: 'Login failed. Please try again.'
+      },
       session: {
         expired: 'Session expired'
       },

--- a/frontend/lang/es.js
+++ b/frontend/lang/es.js
@@ -583,17 +583,26 @@ export default {
       something_went_wrong: 'Algo salió mal!',
       wikibase_slow: 'Wikibase está sobrecargado. Por favor, inténtalo de nuevo en unos momentos.',
       wikibase_unreachable: 'No se ha podido conectar con Wikibase. Por favor, inténtalo de nuevo.',
+      wikibase_malformed_input: 'Entrada malformada. Por favor, comprueba los valores e inténtalo de nuevo.',
+      wikibase_save_failed: 'Error al guardar. Por favor, inténtalo de nuevo.',
+      wikibase_edit_conflict: 'Se ha detectado un conflicto de edición. Por favor, recarga y vuelve a intentarlo.',
+      wikibase_readonly: 'Wikibase está en modo de solo lectura. Por favor, inténtalo más tarde.',
+      wikibase_ratelimited: 'Demasiadas solicitudes. Por favor, espera e inténtalo de nuevo.',
+      wikibase_blocked: 'Tu cuenta ha sido bloqueada.',
+      auth: {
+        login_failed: 'Error al iniciar sesión. Por favor, inténtalo de nuevo.'
+      },
       session: {
         expired: 'Sesión expirada'
       },
       inputs: {
-        label: 'Please fill label',
+        label: 'Por favor, rellena la etiqueta',
         fill: 'Por favor, rellene los campos',
-        description: 'Please fill description',
-        initial_claims: 'Claims are still loading',
-        claim_value_missing: 'Please fill in the claim value for "{propertyLabel}"',
-        qualifier_key_missing: 'A qualifier property is missing in the claim "{claimLabel}" for "{propertyLabel}"',
-        qualifier_value_missing: 'Some qualifier(s) value are missing in the claim "{claimLabel}" for "{propertyLabel}"'
+        description: 'Por favor, rellena la descripción',
+        initial_claims: 'Los enunciados todavía se están cargando',
+        claim_value_missing: 'Por favor, rellena el valor del enunciado para "{propertyLabel}"',
+        qualifier_key_missing: 'Falta una propiedad calificadora en el enunciado "{claimLabel}" para "{propertyLabel}"',
+        qualifier_value_missing: 'Falta el valor de algún calificador en el enunciado "{claimLabel}" para "{propertyLabel}"'
       },
       creation: {
         pbid_already_exists: 'El PhiloBiblon ID "{pbid}" ya existe en {item}.'

--- a/frontend/lang/gl.js
+++ b/frontend/lang/gl.js
@@ -583,17 +583,26 @@ export default {
       something_went_wrong: 'Algo salió mal!',
       wikibase_slow: 'Wikibase está sobrecargado. Por favor, tenta de novo nuns momentos.',
       wikibase_unreachable: 'Non se puido conectar con Wikibase. Por favor, téntao de novo.',
+      wikibase_malformed_input: 'Entrada malformada. Por favor, comproba os valores e téntao de novo.',
+      wikibase_save_failed: 'Erro ao gardar. Por favor, téntao de novo.',
+      wikibase_edit_conflict: 'Detectouse un conflito de edición. Por favor, recarga e téntao de novo.',
+      wikibase_readonly: 'Wikibase está en modo de só lectura. Por favor, téntao máis tarde.',
+      wikibase_ratelimited: 'Demasiadas solicitudes. Por favor, agarda e téntao de novo.',
+      wikibase_blocked: 'A túa conta foi bloqueada.',
+      auth: {
+        login_failed: 'Erro ao iniciar sesión. Por favor, téntao de novo.'
+      },
       session: {
         expired: 'A sesión caducou'
       },
       inputs: {
-        label: 'Please fill label',
+        label: 'Por favor, enche a etiqueta',
         fill: 'Por favor, enche as entradas',
-        description: 'Please fill description',
-        initial_claims: 'Claims are still loading',
-        claim_value_missing: 'Please fill in the claim value for "{propertyLabel}"',
-        qualifier_key_missing: 'A qualifier property is missing in the claim "{claimLabel}" for "{propertyLabel}"',
-        qualifier_value_missing: 'Some qualifier(s) value are missing in the claim "{claimLabel}" for "{propertyLabel}"'
+        description: 'Por favor, enche a descrición',
+        initial_claims: 'Os enunciados aínda se están cargando',
+        claim_value_missing: 'Por favor, enche o valor do enunciado para "{propertyLabel}"',
+        qualifier_key_missing: 'Falta unha propiedade cualificadora no enunciado "{claimLabel}" para "{propertyLabel}"',
+        qualifier_value_missing: 'Falta o valor dalgún cualificador no enunciado "{claimLabel}" para "{propertyLabel}"'
       },
       creation: {
         pbid_already_exists: 'O PhiloBiblon ID "{pbid}" xa existe en {item}.'

--- a/frontend/lang/pt.js
+++ b/frontend/lang/pt.js
@@ -583,17 +583,26 @@ export default {
       something_went_wrong: 'Algo correu mal!',
       wikibase_slow: 'Wikibase está sobrecarregado. Por favor, tente novamente em alguns momentos.',
       wikibase_unreachable: 'Não foi possível conectar ao Wikibase. Por favor, tente novamente.',
+      wikibase_malformed_input: 'Entrada malformada. Por favor, verifique os valores e tente novamente.',
+      wikibase_save_failed: 'Falha ao guardar. Por favor, tente novamente.',
+      wikibase_edit_conflict: 'Conflito de edição detetado. Por favor, recarregue e tente novamente.',
+      wikibase_readonly: 'O Wikibase está em modo de só leitura. Por favor, tente mais tarde.',
+      wikibase_ratelimited: 'Demasiados pedidos. Por favor, aguarde e tente novamente.',
+      wikibase_blocked: 'A sua conta foi bloqueada.',
+      auth: {
+        login_failed: 'Falha ao iniciar sessão. Por favor, tente novamente.'
+      },
       session: {
         expired: 'Sessão expirada'
       },
       inputs: {
-        label: 'Please fill label',
+        label: 'Por favor, preencha a etiqueta',
         fill: 'Por favor preencha as entradas',
-        description: 'Please fill description',
-        initial_claims: 'Claims are still loading',
-        claim_value_missing: 'Please fill in the claim value for "{propertyLabel}"',
-        qualifier_key_missing: 'A qualifier property is missing in the claim "{claimLabel}" for "{propertyLabel}"',
-        qualifier_value_missing: 'Some qualifier(s) value are missing in the claim "{claimLabel}" for "{propertyLabel}"'
+        description: 'Por favor, preencha a descrição',
+        initial_claims: 'Os enunciados ainda estão a carregar',
+        claim_value_missing: 'Por favor, preencha o valor do enunciado para "{propertyLabel}"',
+        qualifier_key_missing: 'Falta uma propriedade qualificadora no enunciado "{claimLabel}" para "{propertyLabel}"',
+        qualifier_value_missing: 'Falta o valor de algum qualificador no enunciado "{claimLabel}" para "{propertyLabel}"'
       },
       creation: {
         pbid_already_exists: 'O PhiloBiblon ID "{pbid}" já existe em {item}.'

--- a/frontend/pages/oauth_callback.vue
+++ b/frontend/pages/oauth_callback.vue
@@ -21,7 +21,8 @@ onMounted(async () => {
   if (response.status === 0) {
     $notification.success(t('auth.login.success', { name: authStore.username }))
   } else {
-    $notification.error(response.error)
+    console.error('OAuth login failed:', response.error)
+    $notification.error(t('messages.error.auth.login_failed'))
   }
   router.push(localePath(previousPathCookie.value || '/'))
 })

--- a/frontend/service/notification.service.js
+++ b/frontend/service/notification.service.js
@@ -1,4 +1,5 @@
 const DURATION = 5000
+const ERROR_DURATION = 8000
 
 export class NotificationService {
   constructor (notifyFn) {
@@ -9,21 +10,8 @@ export class NotificationService {
     this.$notify({ title: message, type: 'success', duration: DURATION })
   }
 
-  error (error) {
-    if (error.response) {
-      if (error.response.status === 401) {
-        error = 'Authentication error'
-      } else if (error.response.data) {
-        if (error.response.data.message) {
-          error = error.response.data.message
-        } else if (error.response.data.error) {
-          error = error.response.data.error
-        }
-      }
-    }
-     
-    console.error(error)
-    this.$notify({ title: String(error), type: 'error', duration: DURATION })
+  error (message) {
+    this.$notify({ title: message, type: 'error', duration: ERROR_DURATION })
   }
 
   info (message) {


### PR DESCRIPTION
## Summary

- Adds a `WIKIBASE_ERROR_KEYS` map to `useNotifyError` that maps known Wikibase error codes (`invalid-json`, `badvalue`, `failed-save`, `editconflict`, `readonly`, `ratelimited`, `blocked`, `maxlag`) to friendly translated i18n keys
- Expands `getFriendlyMessage` and `getHint` to also inspect `error?.error?.code` (in addition to `error?.body?.error?.code`) so errors returned directly from `wikibase-edit` are also caught
- Simplifies `NotificationService.error()` — all error inspection logic now lives in `useNotifyError`; error toasts now display for 8 s instead of 5 s
- Replaces `$notification.error(t('messages.error.something_went_wrong'))` fallbacks in `claim/Create`, `qualifier/Create`, `reference/Create`, `claim/AddValue` and `item/Create` with `throw res` / `throw response` so the `catch → notifyError` path applies the full error mapping
- Fixes `Notes.vue` inner and outer else branches to throw instead of calling `$notification.error` directly, routing all failures through `notifyError`
- Fixes `oauth_callback.vue` which called `$notification.error(response.error)` with a raw JS object — now logs the raw error and shows `messages.error.auth.login_failed`
- Adds new i18n keys to all five locales (en, ca, es, gl, pt): `wikibase_malformed_input`, `wikibase_save_failed`, `wikibase_edit_conflict`, `wikibase_readonly`, `wikibase_ratelimited`, `wikibase_blocked`, `auth.login_failed`
- Translates the previously-English placeholder strings in `messages.error.inputs` (label, description, initial_claims, claim_value_missing, qualifier_key_missing, qualifier_value_missing) for ca, es, gl and pt

## Files changed

| File | Change |
|---|---|
| `composables/useNotifyError.js` | WIKIBASE_ERROR_KEYS map, extended code path checks |
| `service/notification.service.js` | Simplified `error()`, ERROR_DURATION = 8000 |
| `pages/oauth_callback.vue` | i18n message instead of raw error object |
| `components/item/Notes.vue` | throw in else branches |
| `components/item/claim/AddValue.vue` | Added try/catch + notifyError + throw res |
| `components/item/claim/Create.vue` | throw res in else |
| `components/item/qualifier/Create.vue` | throw res in else |
| `components/item/reference/Create.vue` | throw res in else |
| `components/item/Create.vue` | throw response + removed console.error |
| `lang/en.js`, `ca.js`, `es.js`, `gl.js`, `pt.js` | New error keys + translated inputs |

## Test plan

- [ ] Trigger a Wikibase `invalid-json` error (e.g. malformed date on item create) — toast should show the translated "Malformed input" message instead of "Something went wrong"
- [ ] Trigger a `failed-save` error — toast should show "Save failed" message
- [ ] Trigger session expiry — should log out and show "Session expired"
- [ ] Trigger OAuth login failure — should show translated `auth.login_failed` message (not a raw JS object)
- [ ] Create/edit an item with valid data — success flow unaffected
- [ ] Verify all five locales render correctly translated strings in error toasts and in the item-creation validation messages

Closes #335

🤖 Generated with [Claude Code](https://claude.com/claude-code)