### PR TITLE
 #165 display related individuals in two-line layout

### DIFF
--- a/frontend/components/item/related/Ritem.vue
+++ b/frontend/components/item/related/Ritem.vue
@@ -2,14 +2,22 @@
   <v-expansion-panels class="mb-2">
     <v-expansion-panel class="cnum">
       <v-expansion-panel-title class="cnum">
-        <div>
-          <span class="mb-0 ml-3">#{{ index + 1 }}</span>
-          <NuxtLink class="ml-1 text-black" :to="url">
-            <span>{{ pbid }}</span>
-          </NuxtLink>
-          <span class="ml-1">
-            <item-util-view-text-lang :value="label" />
-          </span>
+        <div class="ritem-header">
+          <div>
+            <span class="mb-0 ml-3">#{{ index + 1 }}</span>
+            <NuxtLink class="ml-1 text-black" :to="url">
+              <span>{{ pbid }}</span>
+            </NuxtLink>
+            <span class="ml-1">
+              <item-util-view-text-lang :value="label" />
+            </span>
+          </div>
+          <div v-if="linkingQualifiers.length" class="ritem-qualifiers text-caption text-grey mt-1">
+            <span v-for="(q, i) in linkingQualifiers" :key="q.property">
+              <span class="font-weight-medium">{{ q.propLabel }}</span>:
+              {{ q.valueDisplay }}<span v-if="i < linkingQualifiers.length - 1"> · </span>
+            </span>
+          </div>
         </div>
       </v-expansion-panel-title>
       <v-expansion-panel-text>
@@ -30,7 +38,8 @@ defineOptions({ inheritAttrs: false })
 const props = defineProps({
   table: { type: String, required: true },
   value: { type: Object, default: null },
-  index: { type: Number, default: null }
+  index: { type: Number, default: null },
+  itemId: { type: String, default: null }
 })
 
 const { $wikibase } = useNuxtApp()
@@ -41,6 +50,7 @@ const localePath = useLocalePath()
 const label = ref(null)
 const item = ref(null)
 const claims = ref(null)
+const linkingQualifiers = ref([])
 
 const pbid = computed(() => props.value.item_pbid)
 const url = computed(() => localePath(`/item/${props.value.item}`))
@@ -57,8 +67,38 @@ async function getEntity () {
     item.value = entity
     claims.value = await $wikibase.getOrderedClaims(props.table, entity.claims)
     label.value = $wikibase.getValueByLang(entity.labels, locale.value)
+    if (props.itemId) {
+      await extractLinkingQualifiers(entity.claims)
+    }
   } catch (err) {
     notifyError(err)
+  }
+}
+
+async function extractLinkingQualifiers (entityClaims) {
+  for (const statements of Object.values(entityClaims || {})) {
+    for (const stmt of statements) {
+      if (stmt.mainsnak?.datavalue?.value?.id === props.itemId && stmt.qualifiers) {
+        const order = stmt['qualifiers-order'] || Object.keys(stmt.qualifiers)
+        const resolved = await Promise.all(
+          order
+            .filter(prop => stmt.qualifiers[prop]?.length)
+            .map(async (prop) => {
+              const propLabel = await $wikibase.getEntityLabel(props.table, prop, locale.value)
+              const values = await Promise.all(
+                stmt.qualifiers[prop].map(snak => $wikibase.formatQualifierSnak(snak, locale.value))
+              )
+              return {
+                property: prop,
+                propLabel: propLabel?.value || prop,
+                valueDisplay: values.filter(Boolean).join(', ')
+              }
+            })
+        )
+        linkingQualifiers.value = resolved.filter(q => q.valueDisplay)
+        return
+      }
+    }
   }
 }
 </script>
@@ -70,5 +110,12 @@ async function getEntity () {
 :deep(.v-expansion-panel-text__wrapper),
 :deep(.claim-values) {
   background-color: white !important;
+}
+.ritem-header {
+  display: flex;
+  flex-direction: column;
+}
+.ritem-qualifiers {
+  padding-left: 12px;
 }
 </style>

--- a/frontend/components/item/related/Ritem.vue
+++ b/frontend/components/item/related/Ritem.vue
@@ -67,7 +67,7 @@ async function getEntity () {
     item.value = entity
     claims.value = await $wikibase.getOrderedClaims(props.table, entity.claims)
     label.value = $wikibase.getValueByLang(entity.labels, locale.value)
-    if (props.itemId) {
+    if (props.itemId && props.table === 'bioid') {
       await extractLinkingQualifiers(entity.claims)
     }
   } catch (err) {

--- a/frontend/components/item/related/Table.vue
+++ b/frontend/components/item/related/Table.vue
@@ -7,6 +7,7 @@
       v-for="(value, index) in items"
       :key="`related-item-${index}-${value.item}`"
       :table="table"
+      :item-id="itemId"
       :index="index + ((currentPage - 1) * resultsPerPage)"
       :value="value"
       class="mt-2"

--- a/frontend/service/wikibase.service.js
+++ b/frontend/service/wikibase.service.js
@@ -660,6 +660,22 @@ export class WikibaseService {
     }
   }
 
+  async formatQualifierSnak (snak, locale) {
+    const dv = snak.datavalue
+    if (!dv) return ''
+    if (dv.type === 'wikibase-entityid') {
+      const entity = await this.getEntity(dv.value.id, locale)
+      const label = this.getValueByLang(entity?.labels || {}, locale)
+      return label?.value || ''
+    } else if (dv.type === 'time') {
+      return this.wbk.wikibaseTimeToSimpleDay(dv.value) || ''
+    } else if (dv.type === 'monolingualtext') {
+      return dv.value?.text || ''
+    } else {
+      return String(dv.value ?? '')
+    }
+  }
+
   async getRelatedItems (pbid, refTables, currentPage, resultsPerPage) {
     return await this.runSparqlQuery(
       this.$query.getRelatedItems(pbid, refTables, currentPage, resultsPerPage),


### PR DESCRIPTION
## Summary

Closes #165

- Each record in the **Related Individuals** section of a bioid item now
  occupies **two lines**: name (+ index and PBID link) on line 1, and the
  qualifiers of the linking statement on line 2 in grey caption text.
- Line 2 is only rendered when the linking statement (P703, P33, etc.)
  actually has qualifiers â items without qualifiers keep the single-line
  layout, so no other related-table sections are affected.

## Changes

- **`Table.vue`** â passes `:item-id` down to `Ritem`
- **`Ritem.vue`** â scans entity claims to find the linking statement,
  extracts qualifiers, resolves labels/values, renders on line 2
- **`wikibase.service.js`** â adds `formatQualifierSnak()` helper

## Test plan

- [ ] Bioid with qualified Related Individuals (e.g. Q1477): confirm line 2
      shows qualifier (e.g. `Subject has role: Disciple`)
- [ ] Bioid whose Related Individuals have no qualifiers: line 2 absent
- [ ] Other related-table sections (Authors, Former ownersâ¦) unaffected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Related-item panels now show qualifier details when available, making linked entries easier to understand at a glance.
  * Qualifier values are displayed in a readable format, including labels and localized text where applicable.

* **Bug Fixes**
  * Related tables now only receive item context where needed, preventing unnecessary data usage in other views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->