### PR TITLE
feature: add local quick search index for fast autocomplete (#449)

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "name": "PhiloBiblon UI",
-  "image": "mcr.microsoft.com/devcontainers/java:17",
+  "image": "mcr.microsoft.com/devcontainers/java:21",
   "mounts": [
     "source=${localEnv:HOME}/.gitconfig,target=/home/vscode/.gitconfig,type=bind,readonly"
   ],

--- a/.gitignore
+++ b/.gitignore
@@ -45,5 +45,8 @@ backend/data/
 ### Local dev secrets (OAuth keys) — copy backend/secrets-local.properties.template ###
 backend/secrets-local.properties
 
+### Local dev run log ###
+backend/dev.log
+
 ### Claude ###
 **/settings.local.json

--- a/.gitignore
+++ b/.gitignore
@@ -39,5 +39,11 @@ build/
 ### Docker compose internal data ###
 /data/certbot/
 
+### Local H2 search index ###
+backend/data/
+
+### Local dev secrets (OAuth keys) — copy backend/secrets-local.properties.template ###
+backend/secrets-local.properties
+
 ### Claude ###
 **/settings.local.json

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -7,6 +7,8 @@ FROM eclipse-temurin:21-jdk
 WORKDIR /app
 COPY --from=builder /app/target/*.jar app.jar
 RUN useradd --create-home --shell /usr/sbin/nologin appuser \
-    && chown appuser:appuser /app/app.jar
+    && chown appuser:appuser /app/app.jar \
+    && mkdir -p /app/data \
+    && chown appuser:appuser /app/data
 USER appuser
 ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/backend/README.md
+++ b/backend/README.md
@@ -10,7 +10,7 @@ This module is a Spring Boot application that acts as a middleware for the Philo
 
 ## Prerequisites
 
-- Java 17 or higher
+- Java 21 or higher
 - Maven (wrapper included)
 
 ## Configuration
@@ -33,17 +33,17 @@ The application is configured using environment variables. You can set these in 
 
 ## Running Locally
 
-To run the application locally using the Maven wrapper:
+Create `backend/secrets-local.properties` (gitignored) with your OAuth credentials:
 
-```bash
-./mvnw spring-boot:run
+```properties
+OAUTH_CONSUMER_KEY=<your key>
+OAUTH_CONSUMER_SECRET=<your secret>
 ```
 
-make sure to set the environment variables properly before running the command, e.g.:
+Then run from the `backend/` directory:
 
 ```bash
-export ALLOWED_ORIGINS=http://localhost:3000
-./mvnw spring-boot:run
+./mvnw spring-boot:run -Dspring-boot.run.profiles=dev
 ```
 
 ## Build

--- a/backend/README.md
+++ b/backend/README.md
@@ -46,6 +46,21 @@ Then run from the `backend/` directory:
 ./mvnw spring-boot:run -Dspring-boot.run.profiles=dev
 ```
 
+The `dev` profile pre-fills `WIKIBASE_*`/`SPARQL_*` with FactGrid defaults and sets `ALLOWED_ORIGINS=*`, so the backend listens on `localhost:8080` ready to use. To point the frontend at it, run `yarn dev:local` instead of `yarn dev` from `frontend/` (see `frontend/README.md`).
+
+To run it detached and keep the logs in a file (`dev.log` is gitignored):
+
+```bash
+nohup ./mvnw spring-boot:run -Dspring-boot.run.profiles=dev > dev.log 2>&1 &
+disown
+```
+
+Then follow the logs with:
+
+```bash
+tail -f dev.log
+```
+
 ## Build
 
 To build the executable JAR:

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -35,6 +35,18 @@
             <artifactId>spring-boot-starter-cache</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-jpa</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-validation</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+        </dependency>
+        <dependency>
             <groupId>com.github.scribejava</groupId>
             <artifactId>scribejava-apis</artifactId>
             <version>${scribejava.version}</version>

--- a/backend/src/main/java/io/github/philobiblon/backend/Application.java
+++ b/backend/src/main/java/io/github/philobiblon/backend/Application.java
@@ -2,8 +2,10 @@ package io.github.philobiblon.backend;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
+@EnableScheduling
 public class Application {
 
     public static void main(String[] args) {

--- a/backend/src/main/java/io/github/philobiblon/backend/config/H2ConsoleConfig.java
+++ b/backend/src/main/java/io/github/philobiblon/backend/config/H2ConsoleConfig.java
@@ -1,0 +1,20 @@
+package io.github.philobiblon.backend.config;
+
+import org.h2.server.web.JakartaWebServlet;
+import org.springframework.boot.web.servlet.ServletRegistrationBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+
+@Configuration
+@Profile("dev")
+public class H2ConsoleConfig {
+
+    @Bean
+    public ServletRegistrationBean<JakartaWebServlet> h2ConsoleServlet() {
+        ServletRegistrationBean<JakartaWebServlet> reg =
+                new ServletRegistrationBean<>(new JakartaWebServlet(), "/h2/*");
+        reg.addInitParameter("-webAllowOthers", "");
+        return reg;
+    }
+}

--- a/backend/src/main/java/io/github/philobiblon/backend/controller/SearchController.java
+++ b/backend/src/main/java/io/github/philobiblon/backend/controller/SearchController.java
@@ -1,6 +1,9 @@
 package io.github.philobiblon.backend.controller;
 
 import io.github.philobiblon.backend.representation.Option;
+import io.github.philobiblon.backend.representation.QuickSearchResponse;
+import jakarta.validation.constraints.NotBlank;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
 import java.io.IOException;
@@ -8,8 +11,12 @@ import java.util.List;
 
 @RestController
 @RequestMapping("/api/search")
+@Validated
 public interface SearchController {
 
     @PostMapping(consumes = "application/x-www-form-urlencoded")
     List<Option> search(@RequestParam String sparqlQuery, @RequestParam String q) throws IOException;
+
+    @GetMapping("/quick")
+    QuickSearchResponse quickSearch(@RequestParam @NotBlank String q, @RequestParam @NotBlank String lang);
 }

--- a/backend/src/main/java/io/github/philobiblon/backend/controller/impl/SearchControllerImpl.java
+++ b/backend/src/main/java/io/github/philobiblon/backend/controller/impl/SearchControllerImpl.java
@@ -2,6 +2,8 @@ package io.github.philobiblon.backend.controller.impl;
 
 import io.github.philobiblon.backend.controller.SearchController;
 import io.github.philobiblon.backend.representation.Option;
+import io.github.philobiblon.backend.representation.QuickSearchResponse;
+import io.github.philobiblon.backend.service.QuickSearchService;
 import io.github.philobiblon.backend.service.SearchService;
 import io.github.philobiblon.backend.service.SparqlService;
 import org.apache.jena.query.ResultSet;
@@ -16,15 +18,22 @@ public class SearchControllerImpl implements SearchController {
 
     private SearchService searchService;
     private SparqlService sparqlService;
+    private QuickSearchService quickSearchService;
 
     @Autowired
-    public SearchControllerImpl(SearchService searchService, SparqlService sparqlService) {
+    public SearchControllerImpl(SearchService searchService, SparqlService sparqlService,
+                                QuickSearchService quickSearchService) {
         this.searchService = searchService;
         this.sparqlService = sparqlService;
+        this.quickSearchService = quickSearchService;
     }
 
     public List<Option> search(String sparqlQuery, String q) throws IOException {
         ResultSet resultSet = sparqlService.getSparqlQueryResult(sparqlQuery);
         return searchService.search(resultSet, q);
+    }
+
+    public QuickSearchResponse quickSearch(String q, String lang) {
+        return quickSearchService.search(q, lang);
     }
 }

--- a/backend/src/main/java/io/github/philobiblon/backend/entity/SearchItem.java
+++ b/backend/src/main/java/io/github/philobiblon/backend/entity/SearchItem.java
@@ -38,7 +38,7 @@ public class SearchItem {
     @Column(length = 1000)
     private String label;
 
-    /** Normalized (lowercased, accent-stripped) label + aliases, used for LIKE matching. */
+    /** Normalized (lowercased, accent-stripped) label + aliases + qid + pbid, used for LIKE matching. */
     @Column(length = 10000)
     private String searchText;
 

--- a/backend/src/main/java/io/github/philobiblon/backend/entity/SearchItem.java
+++ b/backend/src/main/java/io/github/philobiblon/backend/entity/SearchItem.java
@@ -1,0 +1,96 @@
+package io.github.philobiblon.backend.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.Table;
+
+/**
+ * Materialized, searchable copy of a PhiloBiblon item label (per language).
+ * Populated periodically from Wikibase so the general search can be served
+ * locally without hitting the (slow) SPARQL endpoint on every keystroke.
+ */
+@Entity
+@Table(name = "search_item", indexes = {
+        @Index(name = "idx_search_item_lang_generation", columnList = "lang,generation")
+})
+public class SearchItem {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    /** Wikibase Q id (extracted from the ?item URI). */
+    @Column(length = 32)
+    private String qid;
+
+    /** PhiloBiblon id (P476 value) — used by the frontend to navigate to /item/{id}. */
+    @Column(length = 255)
+    private String pbid;
+
+    @Column(length = 8)
+    private String lang;
+
+    /** Human readable label shown in the autocomplete. */
+    @Column(length = 1000)
+    private String label;
+
+    /** Normalized (lowercased, accent-stripped) label + aliases, used for LIKE matching. */
+    @Column(length = 10000)
+    private String searchText;
+
+    /** Description shown below the label in the autocomplete, for disambiguation. */
+    @Column(length = 1000)
+    private String description;
+
+    /** Load batch identifier; allows atomic swap between refreshes. */
+    private long generation;
+
+    public SearchItem() {
+    }
+
+    public SearchItem(String qid, String pbid, String lang, String label, String searchText, String description, long generation) {
+        this.qid = qid;
+        this.pbid = pbid;
+        this.lang = lang;
+        this.label = label;
+        this.searchText = searchText;
+        this.description = description;
+        this.generation = generation;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getQid() {
+        return qid;
+    }
+
+    public String getPbid() {
+        return pbid;
+    }
+
+    public String getLang() {
+        return lang;
+    }
+
+    public String getLabel() {
+        return label;
+    }
+
+    public String getSearchText() {
+        return searchText;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public long getGeneration() {
+        return generation;
+    }
+}

--- a/backend/src/main/java/io/github/philobiblon/backend/repository/SearchItemRepository.java
+++ b/backend/src/main/java/io/github/philobiblon/backend/repository/SearchItemRepository.java
@@ -13,7 +13,7 @@ public interface SearchItemRepository extends JpaRepository<SearchItem, Long> {
 
     @Query("SELECT s FROM SearchItem s " +
             "WHERE s.lang = :lang AND s.generation = :generation " +
-            "AND s.searchText LIKE CONCAT('%', :term, '%') ESCAPE '\\\\' " +
+            "AND s.searchText LIKE CONCAT('%', :term, '%') ESCAPE '\\' " +
             "ORDER BY LOCATE(:term, s.searchText), LENGTH(s.label), s.label")
     List<SearchItem> search(@Param("lang") String lang,
                             @Param("generation") long generation,

--- a/backend/src/main/java/io/github/philobiblon/backend/repository/SearchItemRepository.java
+++ b/backend/src/main/java/io/github/philobiblon/backend/repository/SearchItemRepository.java
@@ -1,0 +1,28 @@
+package io.github.philobiblon.backend.repository;
+
+import io.github.philobiblon.backend.entity.SearchItem;
+import org.springframework.data.domain.Limit;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+public interface SearchItemRepository extends JpaRepository<SearchItem, Long> {
+
+    @Query("SELECT s FROM SearchItem s " +
+            "WHERE s.lang = :lang AND s.generation = :generation " +
+            "AND s.searchText LIKE CONCAT('%', :term, '%') ESCAPE '\\\\' " +
+            "ORDER BY LOCATE(:term, s.searchText), LENGTH(s.label), s.label")
+    List<SearchItem> search(@Param("lang") String lang,
+                            @Param("generation") long generation,
+                            @Param("term") String term,
+                            Limit limit);
+
+    @Query("SELECT MAX(s.generation) FROM SearchItem s")
+    Long findMaxGeneration();
+
+    @Transactional
+    long deleteByGenerationNot(long generation);
+}

--- a/backend/src/main/java/io/github/philobiblon/backend/representation/QuickResult.java
+++ b/backend/src/main/java/io/github/philobiblon/backend/representation/QuickResult.java
@@ -1,0 +1,29 @@
+package io.github.philobiblon.backend.representation;
+
+/**
+ * Lightweight result for the general (autocomplete) search.
+ * Shape matches what the frontend's customizeSearchData expects: { pbid, label, description }.
+ */
+public class QuickResult {
+    private String pbid;
+    private String label;
+    private String description;
+
+    public QuickResult(String pbid, String label, String description) {
+        this.pbid = pbid;
+        this.label = label;
+        this.description = description;
+    }
+
+    public String getPbid() {
+        return pbid;
+    }
+
+    public String getLabel() {
+        return label;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+}

--- a/backend/src/main/java/io/github/philobiblon/backend/representation/QuickSearchResponse.java
+++ b/backend/src/main/java/io/github/philobiblon/backend/representation/QuickSearchResponse.java
@@ -1,0 +1,21 @@
+package io.github.philobiblon.backend.representation;
+
+import java.util.List;
+
+public class QuickSearchResponse {
+    private boolean indexLoading;
+    private List<QuickResult> results;
+
+    public QuickSearchResponse(boolean indexLoading, List<QuickResult> results) {
+        this.indexLoading = indexLoading;
+        this.results = results;
+    }
+
+    public boolean isIndexLoading() {
+        return indexLoading;
+    }
+
+    public List<QuickResult> getResults() {
+        return results;
+    }
+}

--- a/backend/src/main/java/io/github/philobiblon/backend/service/QuickSearchService.java
+++ b/backend/src/main/java/io/github/philobiblon/backend/service/QuickSearchService.java
@@ -1,0 +1,17 @@
+package io.github.philobiblon.backend.service;
+
+import io.github.philobiblon.backend.representation.QuickSearchResponse;
+
+public interface QuickSearchService {
+
+    /**
+     * Searches the locally materialized index for items whose label/aliases/description
+     * contain the given (normalized) term, for the given language.
+     */
+    QuickSearchResponse search(String q, String lang);
+
+    /**
+     * Rebuilds the local search index from Wikibase and atomically swaps it in.
+     */
+    void refresh();
+}

--- a/backend/src/main/java/io/github/philobiblon/backend/service/impl/QuickSearchServiceImpl.java
+++ b/backend/src/main/java/io/github/philobiblon/backend/service/impl/QuickSearchServiceImpl.java
@@ -1,0 +1,243 @@
+package io.github.philobiblon.backend.service.impl;
+
+import io.github.philobiblon.backend.entity.SearchItem;
+import io.github.philobiblon.backend.representation.QuickResult;
+import io.github.philobiblon.backend.representation.QuickSearchResponse;
+import io.github.philobiblon.backend.repository.SearchItemRepository;
+import io.github.philobiblon.backend.service.QuickSearchService;
+import jakarta.annotation.PostConstruct;
+import org.apache.jena.query.Query;
+import org.apache.jena.query.QueryExecution;
+import org.apache.jena.query.QueryFactory;
+import org.apache.jena.query.QuerySolution;
+import org.apache.jena.query.ResultSet;
+import org.apache.jena.rdf.model.RDFNode;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.event.EventListener;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.data.domain.Limit;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StreamUtils;
+
+import java.io.IOException;
+import java.net.http.HttpClient;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+@Service
+public class QuickSearchServiceImpl implements QuickSearchService {
+
+    private static final Logger logger = LoggerFactory.getLogger(QuickSearchServiceImpl.class);
+
+    private static final int LABEL_MAX_LENGTH = 1000;
+    private static final int SEARCH_TEXT_MAX_LENGTH = 10000;
+
+    @Value("${sparql.endpoint}")
+    private String sparqlEndpoint;
+    @Value("${sparql.queryPrefix:}")
+    private String sparqlQueryPrefix;
+    @Value("${search.index.languages:ca,es,en,gl,pt}")
+    private String[] languages;
+    @Value("${search.index.candidateLimit:100}")
+    private int candidateLimit;
+    @Value("${search.index.resultLimit:20}")
+    private int resultLimit;
+
+    private final SearchItemRepository repository;
+
+    private volatile long currentGeneration;
+    private final AtomicBoolean refreshing = new AtomicBoolean(false);
+    private String loadQueryTemplate;
+    private final HttpClient http1Client = HttpClient.newBuilder()
+            .version(HttpClient.Version.HTTP_1_1)
+            .build();
+
+    public QuickSearchServiceImpl(SearchItemRepository repository) {
+        this.repository = repository;
+    }
+
+    @PostConstruct
+    void init() throws IOException {
+        try (var in = new ClassPathResource("sparql/load-search-items.rq").getInputStream()) {
+            loadQueryTemplate = StreamUtils.copyToString(in, StandardCharsets.UTF_8);
+        }
+        Long maxGeneration = repository.findMaxGeneration();
+        currentGeneration = maxGeneration != null ? maxGeneration : 0L;
+        logger.info("QuickSearch index initialized at generation {}", currentGeneration);
+    }
+
+    @Override
+    public QuickSearchResponse search(String q, String lang) {
+        if (currentGeneration == 0L) {
+            return new QuickSearchResponse(true, List.of());
+        }
+        String term = SearchServiceImpl.normalize(q);
+        if (term == null || term.isBlank()) {
+            return new QuickSearchResponse(false, List.of());
+        }
+
+        String escapedTerm = term.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_");
+        List<SearchItem> candidates = repository.search(lang, currentGeneration, escapedTerm, Limit.of(candidateLimit));
+        List<String> queryWords = Arrays.asList(term.split("\\s+"));
+
+        List<QuickResult> results = candidates.stream()
+                .filter(item -> SearchServiceImpl.rank(item.getLabel(), queryWords) < Integer.MAX_VALUE)
+                .limit(resultLimit)
+                .map(item -> new QuickResult(item.getPbid(), item.getLabel(), item.getDescription()))
+                .toList();
+        return new QuickSearchResponse(false, results);
+    }
+
+    /** Loads the index once the application is ready, without blocking startup. */
+    @EventListener(ApplicationReadyEvent.class)
+    void loadOnStartup() {
+        Thread thread = new Thread(this::refresh, "quick-search-initial-load");
+        thread.setDaemon(true);
+        thread.start();
+    }
+
+    @Override
+    @Scheduled(cron = "${search.index.refreshCron:0 0 3 * * *}")
+    public void refresh() {
+        if (!refreshing.compareAndSet(false, true)) {
+            logger.info("QuickSearch index refresh already in progress, skipping");
+            return;
+        }
+        long newGeneration = System.currentTimeMillis();
+        logger.info("Refreshing QuickSearch index (generation {})...", newGeneration);
+
+        try {
+            List<SearchItem> items = new ArrayList<>();
+            try {
+                for (String lang : languages) {
+                    items.addAll(loadLanguage(lang.trim(), newGeneration));
+                }
+            } catch (Exception e) {
+                logger.error("QuickSearch index refresh failed; keeping previous generation {}", currentGeneration, e);
+                return;
+            }
+
+            if (items.isEmpty()) {
+                logger.warn("QuickSearch index refresh produced no items; keeping previous generation {}", currentGeneration);
+                return;
+            }
+
+            repository.saveAll(items);
+            currentGeneration = newGeneration;
+            long removed = repository.deleteByGenerationNot(newGeneration);
+            logger.info("QuickSearch index refreshed: {} items, generation {}, {} stale rows removed",
+                    items.size(), newGeneration, removed);
+        } finally {
+            refreshing.set(false);
+        }
+    }
+
+    private List<SearchItem> loadLanguage(String lang, long generation) {
+        String sparqlQuery = addPrefixes(loadQueryTemplate.replace("${lang}", lang));
+        Query query = QueryFactory.create(sparqlQuery);
+
+        Map<String, Accumulator> byItem = new LinkedHashMap<>();
+        try (QueryExecution qexec = QueryExecution.service(sparqlEndpoint)
+                .query(query)
+                .httpClient(http1Client)
+                .build()) {
+            ResultSet resultSet = qexec.execSelect();
+            while (resultSet.hasNext()) {
+                QuerySolution solution = resultSet.next();
+                String qid = solution.contains("item") ? extractQid(solution.get("item")) : null;
+                String pbid = literal(solution, "pbid");
+                if (qid == null || pbid == null) {
+                    continue;
+                }
+                Accumulator acc = byItem.computeIfAbsent(qid, k -> new Accumulator(pbid));
+                String label = literal(solution, "label");
+                if (label != null) {
+                    acc.label = label;
+                }
+                addIfPresent(acc.aliases, literal(solution, "alias"));
+                if (acc.description == null) {
+                    acc.description = literal(solution, "desc");
+                }
+            }
+        }
+
+        List<SearchItem> items = new ArrayList<>(byItem.size());
+        for (Map.Entry<String, Accumulator> entry : byItem.entrySet()) {
+            Accumulator acc = entry.getValue();
+            String label = acc.label != null ? acc.label : acc.pbid;
+            StringBuilder searchSource = new StringBuilder(label);
+            for (String extra : acc.aliases) {
+                searchSource.append(' ').append(extra);
+            }
+            String searchText = SearchServiceImpl.normalize(searchSource.toString());
+            items.add(new SearchItem(
+                    entry.getKey(),
+                    acc.pbid,
+                    lang,
+                    truncate(label, LABEL_MAX_LENGTH),
+                    truncate(searchText, SEARCH_TEXT_MAX_LENGTH),
+                    truncate(acc.description, LABEL_MAX_LENGTH),
+                    generation));
+        }
+        logger.info("Loaded {} items for language '{}'", items.size(), lang);
+        return items;
+    }
+
+    private String addPrefixes(String query) {
+        if (sparqlQueryPrefix != null && !sparqlQueryPrefix.isBlank()) {
+            return sparqlQueryPrefix.replace("\\n", "\n") + "\n" + query;
+        }
+        return query;
+    }
+
+    private static void addIfPresent(Set<String> target, String value) {
+        if (value != null && !value.isBlank()) {
+            target.add(value);
+        }
+    }
+
+    private static String literal(QuerySolution solution, String var) {
+        if (!solution.contains(var)) {
+            return null;
+        }
+        RDFNode node = solution.get(var);
+        return node.isLiteral() ? node.asLiteral().getString() : node.toString();
+    }
+
+    private static String extractQid(RDFNode node) {
+        if (node == null || !node.isResource()) {
+            return null;
+        }
+        String uri = node.asResource().getURI();
+        return uri.substring(uri.lastIndexOf('/') + 1);
+    }
+
+    private static String truncate(String value, int max) {
+        if (value == null) {
+            return null;
+        }
+        return value.length() > max ? value.substring(0, max) : value;
+    }
+
+    private static final class Accumulator {
+        private final String pbid;
+        private String label;
+        private String description;
+        private final Set<String> aliases = new LinkedHashSet<>();
+
+        private Accumulator(String pbid) {
+            this.pbid = pbid;
+        }
+    }
+}

--- a/backend/src/main/java/io/github/philobiblon/backend/service/impl/QuickSearchServiceImpl.java
+++ b/backend/src/main/java/io/github/philobiblon/backend/service/impl/QuickSearchServiceImpl.java
@@ -165,6 +165,7 @@ public class QuickSearchServiceImpl implements QuickSearchService {
                     continue;
                 }
                 Accumulator acc = byItem.computeIfAbsent(qid, k -> new Accumulator(pbid));
+                acc.pbids.add(pbid);
                 String label = literal(solution, "label");
                 if (label != null) {
                     acc.label = label;
@@ -183,6 +184,10 @@ public class QuickSearchServiceImpl implements QuickSearchService {
             StringBuilder searchSource = new StringBuilder(label);
             for (String extra : acc.aliases) {
                 searchSource.append(' ').append(extra);
+            }
+            searchSource.append(' ').append(entry.getKey());
+            for (String pbid : acc.pbids) {
+                searchSource.append(' ').append(pbid);
             }
             String searchText = SearchServiceImpl.normalize(searchSource.toString());
             items.add(new SearchItem(
@@ -235,13 +240,17 @@ public class QuickSearchServiceImpl implements QuickSearchService {
     }
 
     private static final class Accumulator {
+        /** Canonical pbid (first one encountered), used for the item's stored/navigable id. */
         private final String pbid;
         private String label;
         private String description;
         private final Set<String> aliases = new LinkedHashSet<>();
+        /** All P476 values seen for this item (an item can have several, e.g. one per linked database). */
+        private final Set<String> pbids = new LinkedHashSet<>();
 
         private Accumulator(String pbid) {
             this.pbid = pbid;
+            this.pbids.add(pbid);
         }
     }
 }

--- a/backend/src/main/java/io/github/philobiblon/backend/service/impl/QuickSearchServiceImpl.java
+++ b/backend/src/main/java/io/github/philobiblon/backend/service/impl/QuickSearchServiceImpl.java
@@ -26,6 +26,7 @@ import org.springframework.util.StreamUtils;
 import java.io.IOException;
 import java.net.http.HttpClient;
 import java.nio.charset.StandardCharsets;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.LinkedHashMap;
@@ -33,6 +34,7 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 @Service
@@ -61,6 +63,7 @@ public class QuickSearchServiceImpl implements QuickSearchService {
     private String loadQueryTemplate;
     private final HttpClient http1Client = HttpClient.newBuilder()
             .version(HttpClient.Version.HTTP_1_1)
+            .connectTimeout(Duration.ofSeconds(30))
             .build();
 
     public QuickSearchServiceImpl(SearchItemRepository repository) {
@@ -92,7 +95,7 @@ public class QuickSearchServiceImpl implements QuickSearchService {
         List<String> queryWords = Arrays.asList(term.split("\\s+"));
 
         List<QuickResult> results = candidates.stream()
-                .filter(item -> SearchServiceImpl.rank(item.getLabel(), queryWords) < Integer.MAX_VALUE)
+                .filter(item -> SearchServiceImpl.rank(item.getSearchText(), queryWords) < Integer.MAX_VALUE)
                 .limit(resultLimit)
                 .map(item -> new QuickResult(item.getPbid(), item.getLabel(), item.getDescription()))
                 .toList();
@@ -151,6 +154,7 @@ public class QuickSearchServiceImpl implements QuickSearchService {
         try (QueryExecution qexec = QueryExecution.service(sparqlEndpoint)
                 .query(query)
                 .httpClient(http1Client)
+                .timeout(15, TimeUnit.MINUTES)
                 .build()) {
             ResultSet resultSet = qexec.execSelect();
             while (resultSet.hasNext()) {

--- a/backend/src/main/resources/application-dev.properties
+++ b/backend/src/main/resources/application-dev.properties
@@ -1,18 +1,18 @@
 allowed.origins=*
 
-# OAUTH_CONSUMER_KEY=3d6eb2f8bc763a3f564787cc80bbb7d4
-# OAUTH_CONSUMER_SECRET=cc274db007381442bd6b70c417eddfeffd55d90e
-# OAUTH_CALLBACK_URL=http://localhost:8080/oauth_callback
+# OAuth secrets are loaded from backend/secrets-local.properties (gitignored).
+# Copy backend/secrets-local.properties.template and fill in your values.
+spring.config.import=optional:file:secrets-local.properties
 
-OAUTH_CONSUMER_KEY=cb04538158d22e03b01fe9d5a93a3418
-OAUTH_CONSUMER_SECRET=6c64e0fb56ae8f963261965e8772be83ea95f0a1
 OAUTH_CALLBACK_URL=http://localhost:3000/oauth_callback
 
-WIKIBASE_BASE_URL=http://localhost
-WIKIBASE_API_URL=${WIKIBASE_BASE_URL}/w/api.php
-WIKIBASE_INDEX_URL=${WIKIBASE_BASE_URL}/w/index.php
-WIKIBASE_NICE_URL_BASE=${WIKIBASE_BASE_URL}/wiki/
+WIKIBASE_BASE_URL=https://database.factgrid.de
+WIKIBASE_API_URL=https://database.factgrid.de/w/api.php
+WIKIBASE_INDEX_URL=https://database.factgrid.de/w/index.php
+WIKIBASE_NICE_URL_BASE=https://database.factgrid.de/wiki/
 
-SPARQL_BASE_URL=http://localhost:8834
-SPARQL_ENDPOINT=${SPARQL_BASE_URL}/proxy/wdqs/bigdata/namespace/wdq/sparql
-SPARQL_QUERY_PREFIX=
+SPARQL_BASE_URL=https://database.factgrid.de/query
+SPARQL_ENDPOINT=https://database.factgrid.de/sparql/bigdata/namespace/wdq/sparql
+SPARQL_QUERY_PREFIX=PREFIX owl:<http://www.w3.org/2002/07/owl#>\nPREFIX schema:<http://schema.org/>\nPREFIX skos:<http://www.w3.org/2004/02/skos/core#>\nPREFIX rdfs:<http://www.w3.org/2000/01/rdf-schema#>\nPREFIX wd:<https://database.factgrid.de/entity/>\nPREFIX wdt:<https://database.factgrid.de/prop/direct/>\nPREFIX p:<https://database.factgrid.de/prop/>\nPREFIX pq:<https://database.factgrid.de/prop/qualifier/>
+
+spring.h2.console.enabled=true

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -16,4 +16,9 @@ wikibase.niceUrlBase=${WIKIBASE_NICE_URL_BASE}
 sparql.baseUrl=${SPARQL_BASE_URL}
 sparql.endpoint=${SPARQL_ENDPOINT}
 sparql.queryPrefix=${SPARQL_QUERY_PREFIX}
-sparql.cache.compressResults=${SPARQL_CACHE_COMPRESS_RESULTS}
+sparql.cache.compressResults=${SPARQL_CACHE_COMPRESS_RESULTS:false}
+
+# Local materialized index for the general (autocomplete) search
+spring.datasource.url=jdbc:h2:file:${SEARCH_DB_PATH:./data/searchcache}
+spring.jpa.hibernate.ddl-auto=update
+search.index.refreshCron=${SEARCH_INDEX_REFRESH_CRON:0 0 3 * * *}

--- a/backend/src/main/resources/sparql/load-search-items.rq
+++ b/backend/src/main/resources/sparql/load-search-items.rq
@@ -1,0 +1,9 @@
+SELECT ?item ?pbid ?label ?alias ?desc WHERE {
+  ?item wdt:P476 ?pbid .
+  FILTER (REGEX(?pbid, '(.*) bibid ') || REGEX(?pbid, '(.*) bioid ') || REGEX(?pbid, '(.*) geoid ')
+    || REGEX(?pbid, '(.*) insid ') || REGEX(?pbid, '(.*) libid ') || REGEX(?pbid, '(.*) manid ')
+    || REGEX(?pbid, '(.*) subid ') || REGEX(?pbid, '(.*) texid ')) .
+  OPTIONAL { ?item rdfs:label ?label FILTER langMatches(lang(?label), '${lang}') }
+  OPTIONAL { ?item skos:altLabel ?alias FILTER langMatches(lang(?alias), '${lang}') }
+  OPTIONAL { ?item schema:description ?desc FILTER langMatches(lang(?desc), '${lang}') }
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,7 +23,10 @@ services:
         restart: unless-stopped
         extra_hosts:
             - "host.docker.internal:host-gateway"
+        volumes:
+            - backend-data:/app/data
         environment:
+            - SEARCH_DB_PATH=/app/data/searchcache
             - WIKIBASE_BASE_URL=${WIKIBASE_BASE_URL}
             - WIKIBASE_API_URL=${WIKIBASE_API_URL}
             - WIKIBASE_INDEX_URL=${WIKIBASE_INDEX_URL}
@@ -35,3 +38,6 @@ services:
             - OAUTH_CONSUMER_SECRET=${OAUTH_CONSUMER_SECRET}
             - OAUTH_CALLBACK_URL=${OAUTH_CALLBACK_URL}
             - ALLOWED_ORIGINS=${ALLOWED_ORIGINS}
+
+volumes:
+    backend-data:

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -16,11 +16,15 @@ Requires Node 22+ and Yarn 4 with `nodeLinker: node-modules` (already configured
 # Dev server (uses staging backend at philobiblon.cog.berkeley.edu/ui-dev/)
 yarn dev
 
+# Dev server pointing to a backend running locally at localhost:8080
+# (see backend/README.md "Running Locally")
+yarn dev:local
+
 # Lint
 yarn lint
 ```
 
-The dev script sets `API_BASE_URL` to the staging backend automatically.
+The dev script sets `API_BASE_URL` to the staging backend automatically; `dev:local` overrides it to `http://localhost:8080/`.
 
 ## Production build
 

--- a/frontend/components/search/Simple.vue
+++ b/frontend/components/search/Simple.vue
@@ -5,7 +5,7 @@
       rounded
       variant="solo"
       density="compact"
-      :items="items"
+      :items="displayItems"
       item-value="id"
       item-title="title"
       class="search-bar"
@@ -16,6 +16,8 @@
       prepend-inner-icon="mdi-magnify"
       :placeholder="t('wiki.search.placeholder')"
       hide-no-data
+      :custom-filter="() => true"
+      :item-props="item => item.desc ? { subtitle: item.desc } : {}"
       @update:model-value="onItemSelected"
     />
   </div>
@@ -32,30 +34,55 @@ const router = useRouter()
 const route = useRoute()
 const localePath = useLocalePath()
 
+const DEBOUNCE_MS = 300
+
 const items = ref([])
 const search = ref('')
 const loading = ref(false)
+const indexLoading = ref(false)
+const debouncing = ref(false)
+let debounceTimer = null
+
+const LABEL_MAX_DISPLAY = 80
+const DESC_MAX_DISPLAY = 100
 
 const isWelcome = computed(() => route.path.includes('Welcome'))
 
-watch(search, (val) => {
-  if (val) {
-    searchItems(val)
+const displayItems = computed(() => {
+  if (!search.value || search.value.length < 2 || loading.value || debouncing.value) {
+    return []
   }
+  if (items.value.length === 0) {
+    const msg = indexLoading.value ? t('wiki.search.index_loading') : t('wiki.search.no_results')
+    return [{ id: null, title: msg, disabled: true }]
+  }
+  return items.value
+})
+
+watch(search, (val) => {
+  clearTimeout(debounceTimer)
+  if (!val) {
+    debouncing.value = false
+    return
+  }
+  debouncing.value = true
+  debounceTimer = setTimeout(() => searchItems(val), DEBOUNCE_MS)
 })
 
 async function searchItems (query) {
+  debouncing.value = false
   if (query.length < 2) {
     items.value = []
+    indexLoading.value = false
     return
   }
 
   loading.value = true
 
   try {
-    const sparqlQuery = $wikibase.$query.allItemsQuery(query, locale.value)
-    const res = await $wikibase.runSparqlQuery(sparqlQuery)
-    items.value = customizeSearchData(res)
+    const res = await $wikibase.quickSearch(query, locale.value)
+    indexLoading.value = res.indexLoading
+    items.value = res.indexLoading ? [] : customizeSearchData(res.results)
   } catch (error) {
     notifyError(error)
   } finally {
@@ -66,7 +93,12 @@ async function searchItems (query) {
 function customizeSearchData (res) {
   return res.map(item => ({
     id: item.pbid,
-    title: item.label
+    title: item.label.length > LABEL_MAX_DISPLAY
+      ? item.label.substring(0, LABEL_MAX_DISPLAY) + '…'
+      : item.label,
+    desc: item.description
+      ? (item.description.length > DESC_MAX_DISPLAY ? item.description.substring(0, DESC_MAX_DISPLAY) + '…' : item.description)
+      : null
   }))
 }
 
@@ -101,6 +133,10 @@ function onItemSelected (id) {
   display: none;
 }
 
+:deep(.v-autocomplete__menu-icon) {
+  display: none;
+}
+
 :deep(.search-bar .v-field) {
   border: 1px solid #dcdcdc;
   transition: border-color 0.3s, box-shadow 0.3s;
@@ -118,5 +154,11 @@ function onItemSelected (id) {
 
 :deep(.search-bar .v-field__overlay) {
   display: none;
+}
+
+:deep(.item-subtitle) {
+  font-weight: normal;
+  font-size: 0.8rem;
+  color: #666;
 }
 </style>

--- a/frontend/components/search/Simple.vue
+++ b/frontend/components/search/Simple.vue
@@ -42,6 +42,7 @@ const loading = ref(false)
 const indexLoading = ref(false)
 const debouncing = ref(false)
 let debounceTimer = null
+let lastRequestId = 0
 
 const LABEL_MAX_DISPLAY = 80
 const DESC_MAX_DISPLAY = 100
@@ -77,16 +78,18 @@ async function searchItems (query) {
     return
   }
 
+  const requestId = ++lastRequestId
   loading.value = true
 
   try {
     const res = await $wikibase.quickSearch(query, locale.value)
+    if (requestId !== lastRequestId) return
     indexLoading.value = res.indexLoading
     items.value = res.indexLoading ? [] : customizeSearchData(res.results)
   } catch (error) {
-    notifyError(error)
+    if (requestId === lastRequestId) notifyError(error)
   } finally {
-    loading.value = false
+    if (requestId === lastRequestId) loading.value = false
   }
 }
 

--- a/frontend/lang/ca.js
+++ b/frontend/lang/ca.js
@@ -608,7 +608,9 @@ export default {
   },
   wiki: {
     search: {
-      placeholder: 'Cercar en PhiloBiblon'
+      placeholder: 'Cercar en PhiloBiblon',
+      index_loading: 'L\'índex de cerca s\'està carregant, torneu-ho a provar d\'aquí a uns minuts.',
+      no_results: 'No s\'han trobat resultats.'
     }
   },
   footer: {

--- a/frontend/lang/en.js
+++ b/frontend/lang/en.js
@@ -610,7 +610,9 @@ export default {
   },
   wiki: {
     search: {
-      placeholder: 'Search in PhiloBiblon'
+      placeholder: 'Search in PhiloBiblon',
+      index_loading: 'The search index is still loading, please try again in a few minutes.',
+      no_results: 'No results found.'
     }
   },
   footer: {

--- a/frontend/lang/es.js
+++ b/frontend/lang/es.js
@@ -608,7 +608,9 @@ export default {
   },
   wiki: {
     search: {
-      placeholder: 'Buscar en PhiloBiblon'
+      placeholder: 'Buscar en PhiloBiblon',
+      index_loading: 'El índice de búsqueda se está cargando, inténtelo de nuevo en unos minutos.',
+      no_results: 'No se han encontrado resultados.'
     }
   },
   footer: {

--- a/frontend/lang/gl.js
+++ b/frontend/lang/gl.js
@@ -608,7 +608,9 @@ export default {
   },
   wiki: {
     search: {
-      placeholder: 'Busca en PhiloBiblon'
+      placeholder: 'Busca en PhiloBiblon',
+      index_loading: 'O índice de busca está a cargarse, téntao de novo en uns minutos.',
+      no_results: 'Non se atoparon resultados.'
     }
   },
   footer: {

--- a/frontend/lang/pt.js
+++ b/frontend/lang/pt.js
@@ -608,7 +608,9 @@ export default {
   },
   wiki: {
     search: {
-      placeholder: 'Pesquisar em PhiloBiblon'
+      placeholder: 'Pesquisar em PhiloBiblon',
+      index_loading: 'O índice de pesquisa ainda está a carregar, tente novamente em alguns minutos.',
+      no_results: 'Nenhum resultado encontrado.'
     }
   },
   footer: {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -6,6 +6,7 @@
   "packageManager": "yarn@4.12.0",
   "scripts": {
     "dev": "API_BASE_URL=https://philobiblon.cog.berkeley.edu/ui-local/ nuxt dev",
+    "dev:local": "API_BASE_URL=http://localhost:8080/ nuxt dev",
     "build": "nuxt build",
     "generate": "nuxt generate",
     "preview": "nuxt preview",

--- a/frontend/plugins/01.config.client.js
+++ b/frontend/plugins/01.config.client.js
@@ -4,7 +4,8 @@ export default defineNuxtPlugin(async () => {
 
   if (publicConfig.apiBaseUrl) {
     try {
-      const response = await fetch(`${publicConfig.apiBaseUrl}/api/config`)
+      const baseUrl = publicConfig.apiBaseUrl.replace(/\/$/, '')
+      const response = await fetch(`${baseUrl}/api/config`)
       const data = await response.json()
       Object.entries(data).forEach(([key, value]) => {
         // replace internal host, only for local development

--- a/frontend/service/wikibase.service.js
+++ b/frontend/service/wikibase.service.js
@@ -37,6 +37,16 @@ export class WikibaseService {
     this.$oauth = new OAuthService({ config })
     this.$notification = $notification
     this.sparqlBackendEndpoint = this.joinUrl(config.apiBaseUrl, 'api/sparql/query')
+    this.quickSearchEndpoint = this.joinUrl(config.apiBaseUrl, 'api/search/quick')
+  }
+
+  async quickSearch (text, lang) {
+    const url = `${this.quickSearchEndpoint}?q=${encodeURIComponent(text)}&lang=${encodeURIComponent(lang)}`
+    const response = await fetch(url)
+    if (response.status < 200 || response.status > 299) {
+      throw new Error(response.statusText)
+    }
+    return response.json()
   }
 
   getWbk () {
@@ -89,7 +99,6 @@ export class WikibaseService {
                   properties[currentProperty] = []
                 }
               } else {
-                 
                 console.error(`Invalid property ${currentProperty} in section ${sectionName}: ${line}`)
                 currentProperty = null
               }
@@ -101,15 +110,12 @@ export class WikibaseService {
                   properties[currentProperty].push(qualifier)
                 }
               } else {
-                 
                 console.error(`Invalid qualifier ${qualifier} for property ${currentProperty} in section ${sectionName}: ${line}`)
               }
             } else {
-               
               console.warn(`Ignored line: ${line}`)
             }
           } catch (error) {
-             
             console.error(`Error in line '${line}': ${error}`)
           }
         }
@@ -117,12 +123,10 @@ export class WikibaseService {
         result[sectionName] = properties
       }
     } catch (error) {
-       
       console.log(error)
     }
 
     if (process.env.debug) {
-       
       console.log('sorted properties', result)
     }
 
@@ -392,7 +396,8 @@ export class WikibaseService {
       true
     ).then((results) => {
       if (results && results.length > 0) {
-        return results[0]
+        const first = results[0]
+        return typeof first === 'string' ? first : (first.item ?? null)
       } else {
         return null
       }
@@ -723,7 +728,6 @@ export class WikibaseService {
 
       return csrfToken
     } catch (error) {
-       
       console.error('Failed to fetch CSRF token', error)
       return error
     }
@@ -757,7 +761,6 @@ export class WikibaseService {
 
       return await response
     } catch (error) {
-       
       console.error('Error updating discussion page:', error)
     }
   }


### PR DESCRIPTION
Closes #449

## Summary

- **New local search index** (`SearchItem` entity + H2/JPA): loaded from Wikibase on startup and refreshed nightly at 3:00 AM. Replaces per-keystroke SPARQL queries.
- **Relevant ordering**: by term position (leftmost first), then label length, then alphabetically.
- **Description in dropdown**: shown as a subtitle to disambiguate items with the same label.
- **Result limit**: increased from 10 to 20.
- **Navigation fix**: `getEntityFromPBID()` was returning an object instead of a string, causing an "Invalid entity id" error.
- **LIKE escaping**: `%`, `_` and `\` in search terms are now properly escaped.
- **Concurrency guard**: `AtomicBoolean` prevents two index refreshes from running in parallel.
- **Endpoint validation**: `@NotBlank` on `q` and `lang` parameters of `/api/search/quick`.
- **Loading message**: updated to reflect that loading may take a few minutes (all 5 languages).

## Test plan

- [ ] Start the backend and wait for the initial index load to complete (log: `QuickSearch index refreshed`)
- [ ] `GET /api/search/quick?q=ab&lang=en` → returns results with `description` populated
- [ ] Search "ab" in the frontend → dropdown appears with labels and grey subtitles
- [ ] Click a result → navigates correctly to `/item/{pbid}`
- [ ] Search "%" → does not return all results
- [ ] `GET /api/search/quick?q=&lang=en` → returns HTTP 400

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added instant “quick search” autocomplete powered by a locally built search index.
  * Added automatic background index refresh on a configurable schedule.
  * Shows index-loading status while the search index initializes.
* **Improvements**
  * Updated autocomplete behavior with debounced/race-safe requests and improved empty-state handling (“no results”).
  * Search results are now sourced from the quick-search backend endpoint.
* **Localization**
  * Added new search status messages (index loading + no results) for Catalan, English, Spanish, Galician, and Portuguese.
* **Documentation / Setup**
  * Improved local development guidance and enabled access to the H2 console in the dev profile.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->