### PR TITLE
fix #386 add new ANA item improvements

### DIFF
--- a/frontend/components/item/Create.vue
+++ b/frontend/components/item/Create.vue
@@ -29,6 +29,12 @@
                 class="text-subtitle-1"
                 :label="t('item.description')"
               />
+              <v-text-field
+                v-model="alias"
+                type="text"
+                class="text-subtitle-1"
+                :label="t('item.alias')"
+              />
             </v-form>
           </v-col>
         </v-row>
@@ -74,7 +80,7 @@
 </template>
 
 <script setup>
-import { computed, nextTick, onMounted, ref } from 'vue'
+import { computed, nextTick, onMounted, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useAuthStore } from '~/stores/auth'
 
@@ -95,12 +101,19 @@ const initialClaimsLoaded = ref(false)
 const initialClaims = ref([])
 const claims = ref([])
 const description = ref('')
+const alias = ref('')
 
 const isUserLogged = computed(() => authStore.isLogged)
 const isCreateDisabled = computed(() => !!getCreateDisabledReason())
 const pbid = computed(() => initialClaims.value.find(
   item => item.property.id === $wikibase.constructor.PROPERTY_PBID
 )?.value)
+
+watch(pbid, (newPbid) => {
+  if (newPbid && !alias.value) {
+    alias.value = newPbid
+  }
+})
 
 onMounted(() => {
   nextTick(() => {
@@ -121,18 +134,15 @@ function getCreateDisabledReason () {
     return t('messages.error.inputs.initial_claims')
   }
 
-  const claimsEntries = Object.entries(claims.value)
-
-  for (let propIndex = 0; propIndex < claimsEntries.length; propIndex++) {
-    const [, claimArray] = claimsEntries[propIndex]
-    const initialClaim = initialClaims.value[propIndex]
+  for (const [propertyId, claimArray] of Object.entries(claims.value)) {
+    const initialClaim = initialClaims.value.find(ic => ic.property?.id === propertyId)
     const propertyLabel = initialClaim?.property?.label
 
     if (
-      initialClaim?.property?.id === 'P2' ||
-      initialClaim?.property?.id === 'P476' ||
-      (props.table === 'cnum' && initialClaim?.property?.id === 'P590') ||
-      (props.table === 'copid' && initialClaim?.property?.id === 'P839')
+      propertyId === 'P2' ||
+      propertyId === 'P476' ||
+      (props.table === 'cnum' && propertyId === 'P590') ||
+      (props.table === 'copid' && propertyId === 'P839')
     ) {
       for (const item of claimArray) {
         if (item?.value == null || item?.value === '') {
@@ -151,9 +161,28 @@ function getCreateDisabledReason () {
         }
       }
     }
+
+    if (propertyId === 'P799') {
+      for (const item of claimArray) {
+        const dateQualifier = item?.qualifiers?.P106
+        if (dateQualifier != null && !isCompleteDate(dateQualifier)) {
+          return t('messages.error.inputs.incomplete_date', { propertyLabel })
+        }
+      }
+    }
   }
 
   return null
+}
+
+function isCompleteDate (value) {
+  if (typeof value === 'object' && value !== null) {
+    return value.precision === 11
+  }
+  if (typeof value === 'string') {
+    return /^[+-]?\d{4}-\d{2}-\d{2}/.test(value)
+  }
+  return false
 }
 
 async function loadInitialClaims () {
@@ -161,10 +190,25 @@ async function loadInitialClaims () {
     const res = await $wikibase.getTableLastItem(props.database, props.table)
     if (res?.length && res[0]) {
       await getDefaultClaims(res[0].item_number)
+      setDefaultDescription()
       initialClaimsLoaded.value = true
     }
   } catch (error) {
     notifyError(error)
+  }
+}
+
+const cnumDefaultDescriptions = {
+  en: 'textual witness',
+  es: 'testimonio textual',
+  ca: 'testimoni textual',
+  pt: 'testemunho textual',
+  gl: 'testemuño textual'
+}
+
+function setDefaultDescription () {
+  if (props.table === 'cnum' && !description.value) {
+    description.value = cnumDefaultDescriptions[locale.value] || ''
   }
 }
 
@@ -369,6 +413,9 @@ async function create () {
         descriptions: {
           [locale.value]: description.value || ' '
         },
+        aliases: {
+          [locale.value]: alias.value ? [alias.value] : []
+        },
         claims: {
           ...cleanedClaims
         }
@@ -449,7 +496,8 @@ function generateLabelFromClaims () {
       const work = getClaimValue('P590')
       const partOf = getClaimValue('P8')
       if (work && partOf) {
-        generatedLabel = `Witness of ${work}, part of ${partOf}`
+        const workTerminated = /[.!?]\s*$/.test(work) ? work.trimEnd() : `${work}.`
+        generatedLabel = `${workTerminated} ${partOf}`
       }
       break
     }

--- a/frontend/components/item/Create.vue
+++ b/frontend/components/item/Create.vue
@@ -107,7 +107,7 @@ const isUserLogged = computed(() => authStore.isLogged)
 const isCreateDisabled = computed(() => !!getCreateDisabledReason())
 const pbid = computed(() => initialClaims.value.find(
   item => item.property.id === $wikibase.constructor.PROPERTY_PBID
-)?.value)
+)?.value?.datavalue?.value)
 
 watch(pbid, (newPbid) => {
   if (newPbid && !alias.value) {
@@ -164,8 +164,11 @@ function getCreateDisabledReason () {
 
     if (propertyId === 'P799') {
       for (const item of claimArray) {
+        if (item?.value == null || item?.value === '') {
+          continue
+        }
         const dateQualifier = item?.qualifiers?.P106
-        if (dateQualifier != null && !isCompleteDate(dateQualifier)) {
+        if (dateQualifier == null || !isCompleteDate(dateQualifier)) {
           return t('messages.error.inputs.incomplete_date', { propertyLabel })
         }
       }
@@ -413,11 +416,14 @@ async function create () {
         descriptions: {
           [locale.value]: description.value || ' '
         },
-        aliases: {
-          [locale.value]: alias.value ? [alias.value] : []
-        },
         claims: {
           ...cleanedClaims
+        }
+      }
+
+      if (alias.value) {
+        data.aliases = {
+          [locale.value]: [alias.value]
         }
       }
 

--- a/frontend/components/item/Create.vue
+++ b/frontend/components/item/Create.vue
@@ -201,17 +201,9 @@ async function loadInitialClaims () {
   }
 }
 
-const cnumDefaultDescriptions = {
-  en: 'textual witness',
-  es: 'testimonio textual',
-  ca: 'testimoni textual',
-  pt: 'testemunho textual',
-  gl: 'testemuño textual'
-}
-
 function setDefaultDescription () {
   if (props.table === 'cnum' && !description.value) {
-    description.value = cnumDefaultDescriptions[locale.value] || ''
+    description.value = t('item.cnum_description')
   }
 }
 

--- a/frontend/lang/ca.js
+++ b/frontend/lang/ca.js
@@ -456,6 +456,7 @@ export default {
     title: 'Títol',
     description: 'Descripció',
     alias: 'Àlies',
+    cnum_description: 'testimoni textual',
     back: 'Torna',
     identifiers: 'Identificadors',
     related_items: 'Elements relacionats',

--- a/frontend/lang/ca.js
+++ b/frontend/lang/ca.js
@@ -455,6 +455,7 @@ export default {
     label: 'Item',
     title: 'Títol',
     description: 'Descripció',
+    alias: 'Àlies',
     back: 'Torna',
     identifiers: 'Identificadors',
     related_items: 'Elements relacionats',
@@ -604,7 +605,8 @@ export default {
         initial_claims: 'Les afirmacions s\'estan carregant',
         claim_value_missing: 'Si us plau, ompliu el valor de l\'afirmació per a "{propertyLabel}"',
         qualifier_key_missing: 'Falta una propietat de qualificador a l\'afirmació "{claimLabel}" per a "{propertyLabel}"',
-        qualifier_value_missing: 'Falta el valor d\'algun qualificador a l\'afirmació "{claimLabel}" per a "{propertyLabel}"'
+        qualifier_value_missing: 'Falta el valor d\'algun qualificador a l\'afirmació "{claimLabel}" per a "{propertyLabel}"',
+        incomplete_date: 'Si us plau, ompliu una data completa (any, mes i dia) per al qualificador "{propertyLabel}"'
       },
       creation: {
         pbid_already_exists: 'El PhiloBiblon ID "{pbid}" ja existeix en {item}.'

--- a/frontend/lang/en.js
+++ b/frontend/lang/en.js
@@ -458,6 +458,7 @@ export default {
     title: 'Title',
     description: 'Description',
     alias: 'Alias',
+    cnum_description: 'textual witness',
     back: 'Go back',
     identifiers: 'Identifiers',
     related_items: 'Related items',

--- a/frontend/lang/en.js
+++ b/frontend/lang/en.js
@@ -457,6 +457,7 @@ export default {
     label: 'Item',
     title: 'Title',
     description: 'Description',
+    alias: 'Alias',
     back: 'Go back',
     identifiers: 'Identifiers',
     related_items: 'Related items',
@@ -606,7 +607,8 @@ export default {
         initial_claims: 'Claims are still loading',
         claim_value_missing: 'Please fill in the claim value for "{propertyLabel}"',
         qualifier_key_missing: 'A qualifier property is missing in the claim "{claimLabel}" for "{propertyLabel}"',
-        qualifier_value_missing: 'Some qualifier(s) value are missing in the claim "{claimLabel}" for "{propertyLabel}"'
+        qualifier_value_missing: 'Some qualifier(s) value are missing in the claim "{claimLabel}" for "{propertyLabel}"',
+        incomplete_date: 'Please fill in a complete date (year, month and day) for the "{propertyLabel}" qualifier'
       },
       creation: {
         pbid_already_exists: 'PhiloBiblon ID "{pbid}" already exists in {item}.'

--- a/frontend/lang/es.js
+++ b/frontend/lang/es.js
@@ -455,6 +455,7 @@ export default {
     label: 'Artículo',
     title: 'Título',
     description: 'Descripción',
+    alias: 'Alias',
     back: 'Ir atrás',
     identifiers: 'Identificadores',
     related_items: 'Elementos relacionados',
@@ -604,7 +605,8 @@ export default {
         initial_claims: 'Los enunciados todavía se están cargando',
         claim_value_missing: 'Por favor, rellena el valor del enunciado para "{propertyLabel}"',
         qualifier_key_missing: 'Falta una propiedad calificadora en el enunciado "{claimLabel}" para "{propertyLabel}"',
-        qualifier_value_missing: 'Falta el valor de algún calificador en el enunciado "{claimLabel}" para "{propertyLabel}"'
+        qualifier_value_missing: 'Falta el valor de algún calificador en el enunciado "{claimLabel}" para "{propertyLabel}"',
+        incomplete_date: 'Por favor, introduce una fecha completa (año, mes y día) para el calificador "{propertyLabel}"'
       },
       creation: {
         pbid_already_exists: 'El PhiloBiblon ID "{pbid}" ya existe en {item}.'

--- a/frontend/lang/es.js
+++ b/frontend/lang/es.js
@@ -456,6 +456,7 @@ export default {
     title: 'Título',
     description: 'Descripción',
     alias: 'Alias',
+    cnum_description: 'testimonio textual',
     back: 'Ir atrás',
     identifiers: 'Identificadores',
     related_items: 'Elementos relacionados',

--- a/frontend/lang/gl.js
+++ b/frontend/lang/gl.js
@@ -455,6 +455,7 @@ export default {
     label: 'Elemento',
     title: 'Título',
     description: 'Descrición',
+    alias: 'Alcume',
     back: 'Volve',
     identifiers: 'Identificadores',
     related_items: 'Elementos relacionados',
@@ -604,7 +605,8 @@ export default {
         initial_claims: 'Os enunciados aínda se están cargando',
         claim_value_missing: 'Por favor, enche o valor do enunciado para "{propertyLabel}"',
         qualifier_key_missing: 'Falta unha propiedade cualificadora no enunciado "{claimLabel}" para "{propertyLabel}"',
-        qualifier_value_missing: 'Falta o valor dalgún cualificador no enunciado "{claimLabel}" para "{propertyLabel}"'
+        qualifier_value_missing: 'Falta o valor dalgún cualificador no enunciado "{claimLabel}" para "{propertyLabel}"',
+        incomplete_date: 'Por favor, enche unha data completa (ano, mes e día) para o cualificador "{propertyLabel}"'
       },
       creation: {
         pbid_already_exists: 'O PhiloBiblon ID "{pbid}" xa existe en {item}.'

--- a/frontend/lang/gl.js
+++ b/frontend/lang/gl.js
@@ -456,6 +456,7 @@ export default {
     title: 'Título',
     description: 'Descrición',
     alias: 'Alcume',
+    cnum_description: 'testemuño textual',
     back: 'Volve',
     identifiers: 'Identificadores',
     related_items: 'Elementos relacionados',

--- a/frontend/lang/pt.js
+++ b/frontend/lang/pt.js
@@ -455,6 +455,7 @@ export default {
     label: 'Artigo',
     title: 'Título',
     description: 'Descrição',
+    alias: 'Alias',
     back: 'Volte',
     identifiers: 'Identificadores',
     related_items: 'Itens relacionados',
@@ -604,7 +605,8 @@ export default {
         initial_claims: 'Os enunciados ainda estão a carregar',
         claim_value_missing: 'Por favor, preencha o valor do enunciado para "{propertyLabel}"',
         qualifier_key_missing: 'Falta uma propriedade qualificadora no enunciado "{claimLabel}" para "{propertyLabel}"',
-        qualifier_value_missing: 'Falta o valor de algum qualificador no enunciado "{claimLabel}" para "{propertyLabel}"'
+        qualifier_value_missing: 'Falta o valor de algum qualificador no enunciado "{claimLabel}" para "{propertyLabel}"',
+        incomplete_date: 'Por favor, preencha uma data completa (ano, mês e dia) para o qualificador "{propertyLabel}"'
       },
       creation: {
         pbid_already_exists: 'O PhiloBiblon ID "{pbid}" já existe em {item}.'

--- a/frontend/lang/pt.js
+++ b/frontend/lang/pt.js
@@ -456,6 +456,7 @@ export default {
     title: 'Título',
     description: 'Descrição',
     alias: 'Alias',
+    cnum_description: 'testemunho textual',
     back: 'Volte',
     identifiers: 'Identificadores',
     related_items: 'Itens relacionados',


### PR DESCRIPTION
## Summary
- Format the auto-generated label for `cnum` (ANA) item creation as `${P590}. ${P8}` (no "Witness of"/"part of" prefixes, terminal period after P590).
- Prefill a default Description for `cnum` items based on the active locale (en/es/ca/pt/gl).
- Add a generic **Alias** field to item creation, defaulted to the generated PhiloBiblon ID and sent as a Wikibase alias on create — also closes #384.
- Require a complete date (year, month, day) on the P106 qualifier when filling P799 (Status of database).
- Fix `getCreateDisabledReason()` to match initial claims by property id instead of array index, which was fragile once claim rows no longer aligned 1:1 with the claims map.

Closes #386, closes #384.

## Test plan
- [x] `yarn lint` passes (verified locally, 0 errors)
- [ ] Manually create a new `cnum` (ANA) item in each locale and confirm label/description defaults
- [ ] Confirm the Alias field is populated with the PBID and persists as a Wikibase alias after creation
- [ ] Confirm P799 creation is blocked with an error until P106 has a complete date
- [ ] Confirm adding extra statements beyond P590/P8 no longer blocks creation (please re-verify against staging — could not be reproduced/confirmed against a live OAuth-gated Wikibase from this environment)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced validation for claim items to require complete qualifier dates (year, month, day), including property-specific checks.
  * Improved item creation defaults by auto-filling CNUM descriptions when missing.
  * Adjusted generated CNUM labels for cleaner punctuation handling.
* **Bug Fixes**
  * Updated the PBID “already exists” error to report the correct alias value.
* **Localization**
  * Added translations for CNUM description, alias label, and the new “incomplete date” validation message in Catalan, English, Spanish, Galician, and Portuguese.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->