### PR TITLE
fix(frontend): #167 fix date sort in search results

### DIFF
--- a/frontend/components/search/Results.vue
+++ b/frontend/components/search/Results.vue
@@ -137,6 +137,7 @@ import { useI18n } from 'vue-i18n'
 import { useQueryStatusStore } from '~/stores/queryStatus'
 
 const props = defineProps({
+  table: { type: String, default: null },
   sparqlQuery: { type: String, default: null },
   results: { type: Array, default: null },
   totalResults: { type: Number, default: 0 },
@@ -149,6 +150,7 @@ const props = defineProps({
 const emit = defineEmits(['on-sort-by-id', 'on-sort-descending', 'on-pagination', 'go-to-item'])
 
 const { t } = useI18n()
+const { $wikibase } = useNuxtApp()
 const config = useRuntimeConfig().public
 const localePath = useLocalePath()
 const queryStatusStore = useQueryStatusStore()
@@ -166,11 +168,16 @@ const subjectLink = computed(() => props.subject?.qid
 
 const currentTab = ref('results')
 const selectedItem = ref([])
-const sortItems = [
-  { text: t('search.results.sort_option.id'), value: 'id' },
-  { text: t('search.results.sort_option.name'), value: 'name' },
-  { text: t('search.results.sort_option.date'), value: 'date' }
-]
+const sortItems = computed(() => {
+  const items = [
+    { text: t('search.results.sort_option.id'), value: 'id' },
+    { text: t('search.results.sort_option.name'), value: 'name' }
+  ]
+  if ($wikibase.$query.supportsDateSort(props.table)) {
+    items.push({ text: t('search.results.sort_option.date'), value: 'date' })
+  }
+  return items
+})
 const sortBy = ref(null)
 const currentPage = ref(null)
 

--- a/frontend/service/query.service.js
+++ b/frontend/service/query.service.js
@@ -5,6 +5,16 @@ const CARTAS_TEXT = '[Cartas de]'
 const BITAGAP_GROUP_CARTAS = 'CARTAS'
 const BITAGAP_GROUP_ORIGINAL = 'ORIG'
 export class QueryService {
+  static DATE_SORT_PATTERNS = {
+    bibid: 'OPTIONAL { ?item wdt:P49 ?date_raw }',
+    texid: 'OPTIONAL { ?item wdt:P412 ?date_raw }',
+    manid: 'OPTIONAL { ?item wdt:P536 ?date_raw }',
+    bioid: `OPTIONAL {
+          ?item p:P137 ?history_sort .
+          ?history_sort pq:P49 ?date_raw .
+        }`
+  }
+
   constructor ({ config }) {
     this.$config = config
   }
@@ -1124,12 +1134,13 @@ export class QueryService {
         return queryStatus.isSortDescending ? `DESC(${idExpr})` : idExpr
       }
       case 'date': {
+        const tieBreak = queryStatus.isSortDescending ? `DESC(${nameSort})` : nameSort
         if (!hasDateBinding) {
-          return queryStatus.isSortDescending ? `DESC(${nameSort})` : nameSort
+          return tieBreak
         }
         const dateExpr = 'xsd:dateTime(?date)'
         const primary = queryStatus.isSortDescending ? `DESC(${dateExpr})` : dateExpr
-        return `${primary} ${nameSort}`
+        return `${primary} ${tieBreak}`
       }
       case 'name':
       default:
@@ -1140,21 +1151,11 @@ export class QueryService {
   getDateSortPattern (table) {
     const queryStatus = useQueryStatusStore()
     if (queryStatus.sortBy !== 'date') { return '' }
-    switch (table) {
-      case 'bibid':
-        return 'OPTIONAL { ?item wdt:P49 ?date_raw }'
-      case 'texid':
-        return 'OPTIONAL { ?item wdt:P412 ?date_raw }'
-      case 'manid':
-        return 'OPTIONAL { ?item wdt:P536 ?date_raw }'
-      case 'bioid':
-        return `OPTIONAL {
-          ?item p:P137 ?history_sort .
-          ?history_sort pq:P49 ?date_raw .
-        }`
-      default:
-        return ''
-    }
+    return this.constructor.DATE_SORT_PATTERNS[table] || ''
+  }
+
+  supportsDateSort (table) {
+    return table in this.constructor.DATE_SORT_PATTERNS
   }
 
   itemsQuery (table, form, lang, resultsPerPage) {

--- a/frontend/service/query.service.js
+++ b/frontend/service/query.service.js
@@ -1115,21 +1115,26 @@ export class QueryService {
     return this.generateQuery(table, COUNT_QUERY, form)
   }
 
-  getSortClause () {
+  getSortClause (hasDateBinding) {
     const queryStatus = useQueryStatusStore()
-    let sortBy
+    const nameSort = this.replaceDiacritics('xsd:string(?label)')
     switch (queryStatus.sortBy) {
-      case 'id':
-        sortBy = 'xsd:integer(?pbidn)'
-        break
-      case 'date':
-        sortBy = 'xsd:dateTime(?date)'
-        break
+      case 'id': {
+        const idExpr = 'xsd:integer(?pbidn)'
+        return queryStatus.isSortDescending ? `DESC(${idExpr})` : idExpr
+      }
+      case 'date': {
+        if (!hasDateBinding) {
+          return queryStatus.isSortDescending ? `DESC(${nameSort})` : nameSort
+        }
+        const dateExpr = 'xsd:dateTime(?date)'
+        const primary = queryStatus.isSortDescending ? `DESC(${dateExpr})` : dateExpr
+        return `${primary} ${nameSort}`
+      }
       case 'name':
       default:
-        sortBy = this.replaceDiacritics('xsd:string(?label)')
+        return queryStatus.isSortDescending ? `DESC(${nameSort})` : nameSort
     }
-    return queryStatus.isSortDescending ? `DESC(${sortBy})` : sortBy
   }
 
   getDateSortPattern (table) {
@@ -1169,7 +1174,7 @@ export class QueryService {
         ${this.generateLangFilters(lang)}
         ${this.generateDescLangFilters('item', lang)}
       }
-      ORDER BY ${this.getSortClause()}
+      ORDER BY ${this.getSortClause(!!dateSortPattern)}
       OFFSET ${(useQueryStatusStore().currentPage - 1) * resultsPerPage}
       LIMIT ${resultsPerPage}`
     return this.generateQuery(table, SEARCH_QUERY, form, lang)


### PR DESCRIPTION
## Summary

- **Fixes #167** — Sorting search results by date produced indeterminate order because the SPARQL query referenced `?date` in `ORDER BY` without ever binding it.
- Added `getDateSortPattern(table)` method that returns the correct `OPTIONAL` SPARQL pattern to fetch dates per table type: `bibid`→P49, `texid`→P412, `manid`→P536, `bioid`→P137/P49.
- The date is aggregated with `MIN(?date_raw)` in the inner subquery to avoid row duplication when items have multiple date values.
- The OPTIONAL pattern is only included when the user selects "Date" sort — no performance impact for Name/ID sorting.

## Test plan

- [x] Search References (bibid) by author "Askins", sort by Date ASC → results should be in chronological order (1968, 1973, 1974, …, 2023)
- [x] Toggle to Date DESC → results should be in reverse chronological order (2023, …, 1968)
- [x] Items without a date value appear at the beginning (ASC) or end (DESC) of results
- [x] Sort by Name and ID still work as before (no regression)
- [x] Test date sort on other table types: Works (texid), MsEd (manid), Persons (bioid)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved search result sorting behavior for date ordering across supported content types.
  * Date sort is now offered only when date sorting is available, and ordering updates correctly based on whether date data is present.
  * Sorting by date now uses more accurate date values to produce the expected item order.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->