### PR TITLE
add default description for new cnum items

### DIFF
--- a/frontend/components/item/Create.vue
+++ b/frontend/components/item/Create.vue
@@ -108,6 +108,9 @@ onMounted(() => {
       return router.push(localePath('/'))
     } else {
       loadInitialClaims()
+      if (props.table === 'cnum') {
+        description.value = t('item.create.cnum.default_description')
+      }
     }
   })
 })

--- a/frontend/lang/ca.js
+++ b/frontend/lang/ca.js
@@ -469,7 +469,10 @@ export default {
         text: 'Crear element',
         enabled: 'Crea un element nou'
       },
-      calculating_new_pbid: 'Calculant nou PhiloBiblon ID ..'
+      calculating_new_pbid: 'Calculant nou PhiloBiblon ID ..',
+      cnum: {
+        default_description: 'Testimoni textual'
+      }
     },
     related: {
       manid: {

--- a/frontend/lang/en.js
+++ b/frontend/lang/en.js
@@ -471,7 +471,10 @@ export default {
         text: 'Create item',
         enabled: 'Create a new item'
       },
-      calculating_new_pbid: 'Calculating new PhiloBiblon ID ..'
+      calculating_new_pbid: 'Calculating new PhiloBiblon ID ..',
+      cnum: {
+        default_description: 'Textual testimony'
+      }
     },
     related: {
       manid: {

--- a/frontend/lang/es.js
+++ b/frontend/lang/es.js
@@ -469,7 +469,10 @@ export default {
         text: 'Crear elemento',
         enabled: 'Crea un elemento nevo'
       },
-      calculating_new_pbid: 'Calculando nuevo PhiloBiblon ID ..'
+      calculating_new_pbid: 'Calculando nuevo PhiloBiblon ID ..',
+      cnum: {
+        default_description: 'Testimonio textual'
+      }
     },
     related: {
       manid: {

--- a/frontend/lang/gl.js
+++ b/frontend/lang/gl.js
@@ -469,7 +469,10 @@ export default {
         text: 'Crear elemento',
         enabled: 'Crea un novo elemento'
       },
-      calculating_new_pbid: 'Calculando o novo ID de PhiloBiblon ..'
+      calculating_new_pbid: 'Calculando o novo ID de PhiloBiblon ..',
+      cnum: {
+        default_description: 'Testemuño textual'
+      }
     },
     related: {
       manid: {

--- a/frontend/lang/pt.js
+++ b/frontend/lang/pt.js
@@ -469,7 +469,10 @@ export default {
         text: 'Criar elemento',
         enabled: 'Criar um novo item'
       },
-      calculating_new_pbid: 'Calculando o novo ID PhiloBiblon ..'
+      calculating_new_pbid: 'Calculando o novo ID PhiloBiblon ..',
+      cnum: {
+        default_description: 'Testemunho textual'
+      }
     },
     related: {
       manid: {


### PR DESCRIPTION
Al crear un nuevo ítem de tipo cnum (testimonio textual), el campo Description se rellena automáticamente con el texto correspondiente al idioma activo del usuario. Añadida la clave item.create.cnum.default_description en los 5 ficheros de idioma (en, es, ca, gl, pt).