### PR TITLE
LIB item creation fixes and improvements #392

### DIFF
--- a/frontend/components/item/Create.vue
+++ b/frontend/components/item/Create.vue
@@ -178,7 +178,8 @@ async function loadInitialClaims () {
 }
 
 function buildClaim (entity, qualifiers = [], value = null, removable = true) {
-  const lbl = $wikibase.getValueByLang(entity.labels, locale.value)?.value || entity.id
+  const altLabel = $wikibase.getAlternativeLabel(props.table, entity, locale.value)
+  const lbl = (altLabel ?? $wikibase.getValueByLang(entity.labels, locale.value))?.value || entity.id
   return {
     default: true,
     removable,
@@ -204,7 +205,8 @@ function buildClaim (entity, qualifiers = [], value = null, removable = true) {
 }
 
 function buildQualifier (_claim, qualifier) {
-  const lbl = $wikibase.getValueByLang(qualifier.labels, locale.value)?.value || qualifier.id
+  const altLabel = $wikibase.getAlternativeLabel(props.table, qualifier, locale.value)
+  const lbl = (altLabel ?? $wikibase.getValueByLang(qualifier.labels, locale.value))?.value || qualifier.id
   return {
     default: true,
     property: {
@@ -263,7 +265,11 @@ async function getDefaultClaims (itemNumber) {
         const yyyy = String(today.getFullYear()).padStart(4, '0')
         const mm = String(today.getMonth() + 1).padStart(2, '0')
         const dd = String(today.getDate()).padStart(2, '0')
-        const dateQualifier = qualifiers.find(q => q.property?.id === 'P106')
+        let dateQualifier = qualifiers.find(q => q.property?.id === 'P106')
+        if (!dateQualifier && isValidPropertyEntity(qualifiersArr['P106'])) {
+          dateQualifier = buildQualifier(entity, qualifiersArr['P106'])
+          qualifiers.push(dateQualifier)
+        }
         if (dateQualifier) {
           dateQualifier.datavalue.value = {
             time: `+${yyyy}-${mm}-${dd}T00:00:00Z`,

--- a/frontend/components/item/Create.vue
+++ b/frontend/components/item/Create.vue
@@ -29,6 +29,12 @@
                 class="text-subtitle-1"
                 :label="t('item.description')"
               />
+              <v-text-field
+                v-model="alias"
+                type="text"
+                class="text-subtitle-1"
+                :label="t('item.alias')"
+              />
             </v-form>
           </v-col>
         </v-row>
@@ -95,6 +101,7 @@ const initialClaimsLoaded = ref(false)
 const initialClaims = ref([])
 const claims = ref([])
 const description = ref('')
+const alias = ref('')
 
 const isUserLogged = computed(() => authStore.isLogged)
 const isCreateDisabled = computed(() => !!getCreateDisabledReason())
@@ -123,9 +130,8 @@ function getCreateDisabledReason () {
 
   const claimsEntries = Object.entries(claims.value)
 
-  for (let propIndex = 0; propIndex < claimsEntries.length; propIndex++) {
-    const [, claimArray] = claimsEntries[propIndex]
-    const initialClaim = initialClaims.value[propIndex]
+  for (const [propId, claimArray] of claimsEntries) {
+    const initialClaim = initialClaims.value.find(c => c.property?.id === propId)
     const propertyLabel = initialClaim?.property?.label
 
     if (
@@ -141,14 +147,17 @@ function getCreateDisabledReason () {
 
         const claimLabel = initialClaim?.value?.datavalue?.value?.label || propertyLabel
 
-        for (const [qualifierKey, qualifierVal] of Object.entries(item.qualifiers || {})) {
-          if (!qualifierKey || qualifierKey === 'null') {
-            return t('messages.error.inputs.qualifier_key_missing', { claimLabel, propertyLabel })
-          }
-          if (!qualifierVal || qualifierVal === 'null') {
-            return t('messages.error.inputs.qualifier_value_missing', { claimLabel, propertyLabel })
-          }
+        if (initialClaim?.property?.id !== 'P2') {
+          for (const [qualifierKey, qualifierVal] of Object.entries(item.qualifiers || {})) {
+              if (!qualifierKey || qualifierKey === 'null') {
+                return t('messages.error.inputs.qualifier_key_missing', { claimLabel, propertyLabel })
+              }
+              if (!qualifierVal || qualifierVal === 'null') {
+                return t('messages.error.inputs.qualifier_value_missing', { claimLabel, propertyLabel })
+              }
+            }
         }
+       
       }
     }
   }
@@ -212,9 +221,12 @@ function buildQualifier (_claim, qualifier) {
 
 async function getDefaultClaims (itemNumber) {
   const def = ['P476', 'P131']
+  if (props.table === 'libid') {
+    def.push('P799')
+  }
   const res = await $wikibase.getClaimsOrderForNewItem(props.table)
   const propertyIds = [...new Set([...def, ...Object.keys(res)])]
-  const qualifiersProperties = [...new Set(['P700', ...Object.values(res).flat()])]
+  const qualifiersProperties = [...new Set(['P700', 'P106', ...Object.values(res).flat()])]
   const entities = await $wikibase.getEntities(propertyIds, locale.value)
   const qualifiersArr = await $wikibase.getEntities(qualifiersProperties, locale.value)
 
@@ -284,6 +296,10 @@ function updateClaims (data) {
   initialClaims.value = data
   claims.value = generateClaimsData(data)
   generateLabelFromClaims()
+  const pbidValue = getClaimValue('P476')
+  if (pbidValue && !alias.value) {
+    alias.value = pbidValue
+  }
 }
 
 function generateClaimsData (data) {
@@ -367,6 +383,7 @@ async function create () {
         descriptions: {
           [locale.value]: description.value || ' '
         },
+        ...(alias.value && {aliases: {en: [alias.value]}}),
         claims: {
           ...cleanedClaims
         }

--- a/frontend/lang/ca.js
+++ b/frontend/lang/ca.js
@@ -455,6 +455,7 @@ export default {
     label: 'Item',
     title: 'Títol',
     description: 'Descripció',
+    alias: 'Alias',
     back: 'Torna',
     identifiers: 'Identificadors',
     related_items: 'Elements relacionats',

--- a/frontend/lang/en.js
+++ b/frontend/lang/en.js
@@ -457,6 +457,7 @@ export default {
     label: 'Item',
     title: 'Title',
     description: 'Description',
+    alias: 'Alias',
     back: 'Go back',
     identifiers: 'Identifiers',
     related_items: 'Related items',

--- a/frontend/lang/es.js
+++ b/frontend/lang/es.js
@@ -455,6 +455,7 @@ export default {
     label: 'Artículo',
     title: 'Título',
     description: 'Descripción',
+    alias: 'Alias',
     back: 'Ir atrás',
     identifiers: 'Identificadores',
     related_items: 'Elementos relacionados',

--- a/frontend/lang/gl.js
+++ b/frontend/lang/gl.js
@@ -455,6 +455,7 @@ export default {
     label: 'Elemento',
     title: 'Título',
     description: 'Descrición',
+    alias: 'Alias',
     back: 'Volve',
     identifiers: 'Identificadores',
     related_items: 'Elementos relacionados',

--- a/frontend/lang/pt.js
+++ b/frontend/lang/pt.js
@@ -455,6 +455,7 @@ export default {
     label: 'Artigo',
     title: 'Título',
     description: 'Descrição',
+    alias: 'Alias',
     back: 'Volte',
     identifiers: 'Identificadores',
     related_items: 'Itens relacionados',


### PR DESCRIPTION
Se elimina el requisito de qualifier para P2 (Instance of) que bloqueaba el botón CREATE. Se corrige el bug de índices en la validación que impedía crear ítems con statements extra. Se añade campo Alias auto-rellenado con el PhiloBiblon ID. Se añade P799 (Status of database) con la fecha de hoy pre-rellenada en el qualifier P106.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional “Alias” field to the item creation form, auto-filled from the P476 claim when empty.
  * Alias values are included in the create request when provided.
* **Bug Fixes**
  * Improved claim matching during validation by aligning edits to the correct claim properties.
  * Refined qualifier validation and default qualifier handling for more reliable submissions.
  * Improved label selection by preferring alternative labels when available.
* **Documentation**
  * Added the “Alias” label to supported UI languages (English, Spanish, Catalan, Galician, Portuguese).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->