### PR TITLE
fix(frontend): #183 apply alternative property labels to qualifiers and references

### DIFF
--- a/frontend/components/item/Claims.vue
+++ b/frontend/components/item/Claims.vue
@@ -9,7 +9,7 @@
       @delete-claim="deleteClaim"
       @create-claim="addValueToClaim"
     />
-    <item-claim-create v-if="isUserLogged" :item="item" @update-claims="updateClaims" />
+    <item-claim-create v-if="isUserLogged" :item="item" :table="table" @update-claims="updateClaims" />
   </div>
 </template>
 

--- a/frontend/components/item/Create.vue
+++ b/frontend/components/item/Create.vue
@@ -169,7 +169,8 @@ async function loadInitialClaims () {
 }
 
 function buildClaim (entity, qualifiers = [], value = null, removable = true) {
-  const lbl = $wikibase.getValueByLang(entity.labels, locale.value)?.value || entity.id
+  const altLabel = $wikibase.getAlternativeLabel(props.table, entity, locale.value)
+  const lbl = (altLabel ?? $wikibase.getValueByLang(entity.labels, locale.value))?.value || entity.id
   return {
     default: true,
     removable,
@@ -195,7 +196,8 @@ function buildClaim (entity, qualifiers = [], value = null, removable = true) {
 }
 
 function buildQualifier (_claim, qualifier) {
-  const lbl = $wikibase.getValueByLang(qualifier.labels, locale.value)?.value || qualifier.id
+  const altLabel = $wikibase.getAlternativeLabel(props.table, qualifier, locale.value)
+  const lbl = (altLabel ?? $wikibase.getValueByLang(qualifier.labels, locale.value))?.value || qualifier.id
   return {
     default: true,
     property: {

--- a/frontend/components/item/claim/Base.vue
+++ b/frontend/components/item/claim/Base.vue
@@ -6,7 +6,7 @@
       </div>
     </v-row>
     <v-container class="claim-values">
-      <item-claim-values :claim="claim" @delete-claim="emit('delete-claim', $event)" />
+      <item-claim-values :claim="claim" :table="table" @delete-claim="emit('delete-claim', $event)" />
       <item-claim-add-value
         v-if="isUserLogged && isAllowedAddValue"
         :key="claim.values.length"

--- a/frontend/components/item/claim/Create.vue
+++ b/frontend/components/item/claim/Create.vue
@@ -75,6 +75,7 @@
           :key="claim?.property?.id"
           :claim="claim"
           :for-create="forCreate"
+          :table="table"
           :initial-qualifiers="claim.qualifiers"
           @update-qualifiers="updateQualifiers($event, key)"
         />
@@ -111,7 +112,8 @@ import { WikibaseService } from '~/service/wikibase.service'
 const props = defineProps({
   item: { type: Object, default: null },
   initialClaims: { type: Array, default: null },
-  forCreate: { type: Boolean, default: false }
+  forCreate: { type: Boolean, default: false },
+  table: { type: String, default: null }
 })
 
 const emit = defineEmits(['update-claims'])
@@ -139,8 +141,13 @@ watch(claims, (newValue) => {
   }
 }, { deep: true })
 
-function onChangeProperty (property, claim) {
-  claim.property = property ?? null
+async function onChangeProperty (property, claim) {
+  if (property) {
+    const altLabel = await $wikibase.getEntityLabel(props.table, property.id, locale.value)
+    claim.property = { ...property, label: altLabel?.value ?? property.label }
+  } else {
+    claim.property = null
+  }
   claim.value.datavalue.value = null
   claim.value.property = property?.id ?? null
   claim.mainsnak.property = property?.id ?? null

--- a/frontend/components/item/claim/Values.vue
+++ b/frontend/components/item/claim/Values.vue
@@ -40,7 +40,7 @@
       </tr>
       <tr v-if="isUserLogged || item.references" class="table-row-edit">
         <td :colspan="formattedHeaders.length">
-          <item-reference-base :claim="item" />
+          <item-reference-base :claim="item" :table="table" />
         </td>
       </tr>
     </template>
@@ -53,7 +53,8 @@ import { useI18n } from 'vue-i18n'
 import { useAuthStore } from '~/stores/auth'
 
 const props = defineProps({
-  claim: { type: Object, default: () => ({ values: [] }) }
+  claim: { type: Object, default: () => ({ values: [] }) },
+  table: { type: String, default: null }
 })
 
 const emit = defineEmits(['delete-claim'])
@@ -99,10 +100,9 @@ async function getHeaders () {
     return props.claim.qualifiersOrder ? props.claim.qualifiersOrder.indexOf(a) - props.claim.qualifiersOrder.indexOf(b) : -1
   })
   const headerPromises = qualifiersKeysOrdered.map(async (property) => {
-    const entity = await $wikibase.getEntity(property, locale.value)
     return {
       property,
-      label: $wikibase.getValueByLang(entity.labels, locale.value)
+      label: await $wikibase.getEntityLabel(props.table, property, locale.value)
     }
   })
   headers.value = await Promise.all(headerPromises)

--- a/frontend/components/item/qualifier/Create.vue
+++ b/frontend/components/item/qualifier/Create.vue
@@ -103,7 +103,8 @@ import { WikibaseService } from '~/service/wikibase.service'
 const props = defineProps({
   claim: { type: Object, default: null },
   initialQualifiers: { type: Array, default: null },
-  forCreate: { type: Boolean, default: false }
+  forCreate: { type: Boolean, default: false },
+  table: { type: String, default: null }
 })
 
 const emit = defineEmits(['update-qualifiers', 'create-qualifier'])
@@ -146,9 +147,14 @@ function onNewValue (event, qualifier) {
   qualifier.datavalue.value = event
 }
 
-function onChangeProperty (event, index) {
+async function onChangeProperty (event, index) {
   const qualifier = qualifiers[index]
-  qualifier.property = event ? { id: event.id, label: event.label, datatype: event.datatype } : null
+  if (event) {
+    const altLabel = await $wikibase.getEntityLabel(props.table, event.id, locale.value)
+    qualifier.property = { id: event.id, label: altLabel?.value ?? event.label, datatype: event.datatype }
+  } else {
+    qualifier.property = null
+  }
   qualifier.datatype = event?.datatype
   qualifier.datavalue = { value: null }
 }

--- a/frontend/components/item/reference/Base.vue
+++ b/frontend/components/item/reference/Base.vue
@@ -19,6 +19,7 @@
           v-if="isUserLogged"
           class="mt-5"
           :claim="claim"
+          :table="table"
           @create-reference="createReference($event)"
         />
       </v-expansion-panel-text>

--- a/frontend/components/item/reference/Base.vue
+++ b/frontend/components/item/reference/Base.vue
@@ -12,6 +12,7 @@
           :key="`${reference.hash}-${references.length}`"
           :claim="claim"
           :value="reference"
+          :table="table"
           @delete-reference="deleteReference($event)"
         />
         <item-reference-create
@@ -30,7 +31,8 @@ import { computed, onMounted, ref } from 'vue'
 import { useAuthStore } from '~/stores/auth'
 
 const props = defineProps({
-  claim: { type: Object, required: true }
+  claim: { type: Object, required: true },
+  table: { type: String, default: null }
 })
 
 const authStore = useAuthStore()

--- a/frontend/components/item/reference/Create.vue
+++ b/frontend/components/item/reference/Create.vue
@@ -97,7 +97,8 @@ import { useAuthStore } from '~/stores/auth'
 
 const props = defineProps({
   claim: { type: Object, required: true },
-  value: { type: Object, default: null }
+  value: { type: Object, default: null },
+  table: { type: String, default: null }
 })
 
 const emit = defineEmits(['update-references', 'create-reference'])
@@ -121,9 +122,14 @@ function onNewValue (event, reference) {
   reference.datavalue.value = event
 }
 
-function onChangeProperty (event, index) {
+async function onChangeProperty (event, index) {
   const reference = references[index]
-  reference.property = event
+  if (event) {
+    const altLabel = await $wikibase.getEntityLabel(props.table, event.id, locale.value)
+    reference.property = { ...event, label: altLabel?.value ?? event.label }
+  } else {
+    reference.property = null
+  }
   reference.datatype = event?.datatype
   reference.datavalue = { value: null }
 }

--- a/frontend/components/item/reference/List.vue
+++ b/frontend/components/item/reference/List.vue
@@ -49,7 +49,8 @@ import { useAuthStore } from '~/stores/auth'
 
 const props = defineProps({
   claim: { type: Object, required: true },
-  value: { type: Object, required: true }
+  value: { type: Object, required: true },
+  table: { type: String, default: null }
 })
 
 const emit = defineEmits(['delete-reference'])
@@ -87,10 +88,9 @@ async function getProperties () {
     return valueToView.value['snaks-order'] ? valueToView.value['snaks-order'].indexOf(a) - valueToView.value['snaks-order'].indexOf(b) : -1
   })
   const headerPromises = referenceKeysOrdered.map(async (property) => {
-    const entity = await $wikibase.getEntity(property, locale.value)
     return {
       property,
-      label: $wikibase.getValueByLang(entity.labels, locale.value)
+      label: await $wikibase.getEntityLabel(props.table, property, locale.value)
     }
   })
   properties.value = await Promise.all(headerPromises)

--- a/frontend/components/item/reference/List.vue
+++ b/frontend/components/item/reference/List.vue
@@ -34,6 +34,7 @@
             class="mt-5"
             :claim="claim"
             :value="valueToView"
+            :table="table"
             @create-reference="updateReference($event)"
           />
         </td>

--- a/frontend/service/wikibase.service.js
+++ b/frontend/service/wikibase.service.js
@@ -322,7 +322,7 @@ export class WikibaseService {
             )
           }
           itemCache.addEntry({
-            key: this.getLabelCacheKey(),
+            key: this.getLabelCacheKey(id, lang),
             value: propertyLabel
           })
           return propertyLabel

--- a/frontend/service/wikibase.service.js
+++ b/frontend/service/wikibase.service.js
@@ -308,7 +308,7 @@ export class WikibaseService {
 
   getEntityLabel (table, id, lang) {
     const itemCache = useItemCacheStore()
-    const cachedValue = itemCache.cache[this.getLabelCacheKey(id, lang)]
+    const cachedValue = itemCache.cache[this.getLabelCacheKey(table, id, lang)]
     if (cachedValue) {
       return cachedValue
     } else {
@@ -322,7 +322,7 @@ export class WikibaseService {
             )
           }
           itemCache.addEntry({
-            key: this.getLabelCacheKey(id, lang),
+            key: this.getLabelCacheKey(table, id, lang),
             value: propertyLabel
           })
           return propertyLabel
@@ -330,8 +330,8 @@ export class WikibaseService {
     }
   }
 
-  getLabelCacheKey (id, lang) {
-    return id + '_' + lang
+  getLabelCacheKey (table, id, lang) {
+    return table ? `${id}_${lang}_${table}` : `${id}_${lang}`
   }
 
   getAlternativeLabel (table, entity, lang) {


### PR DESCRIPTION
## Summary

Fixes #183 (partially — extends the existing `getAlternativeLabel` implementation to cover qualifier and reference property headers, which were previously skipped).

- Propagate the `table` prop through `claim/Values`, `reference/Base` and `reference/List` so qualifier and reference property headers resolve via `getEntityLabel` (which calls `getAlternativeLabel`) instead of calling `getEntity` + `getValueByLang` directly.
- Fix a cache key bug in `getEntityLabel` where `getLabelCacheKey()` was called without arguments, storing every alternative label under the same `undefined_undefined` key.

## Root cause

`claim/Base.vue` already passed `table` to `getEntityLabel` for the statement-level property label. However, `claim/Values.vue` (qualifier column headers) and `reference/List.vue` (reference property labels) fetched labels with `getEntity` + `getValueByLang` directly, bypassing `getAlternativeLabel` entirely and ignoring the current table context.

## Test plan

- [x] Open an item in a table that has alternative property labels defined (e.g. a `manid` item with property P543 — should show "Size" instead of "Segmentation")
- [x] Verify the qualifier column header shows the alternative label for the current table
- [x] Verify reference property labels also show the alternative label
- [x] Verify items in tables without alternative labels defined still show the standard FactGrid label (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved label resolution and display for claim, qualifier, and reference properties so names render more consistently across claim/reference tables.
  * Fixed label caching to account for different table contexts, reducing cases where the wrong label text could appear after switching views.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->