### PR TITLE
#468 warn before session expiry and preserve in-progress item

### DIFF
--- a/frontend/components/create/Base.vue
+++ b/frontend/components/create/Base.vue
@@ -55,7 +55,7 @@ watch(() => route.query.database, (val) => {
   if (groups.includes(val)) {
     database.value = val
     showGroups.value = false
-  } else {
+  } else if (val == null || val === '') {
     // No database in the URL (e.g. returning from an OAuth re-login): recover it
     // from a saved draft so the create form remounts in the same context.
     const savedDatabase = draft.load()?.database
@@ -65,6 +65,9 @@ watch(() => route.query.database, (val) => {
     } else {
       showGroups.value = true
     }
+  } else {
+    // Explicit but invalid database value: show the selector, never a stale draft.
+    showGroups.value = true
   }
 }, { immediate: true })
 

--- a/frontend/components/create/Base.vue
+++ b/frontend/components/create/Base.vue
@@ -49,12 +49,22 @@ const database = ref('BETA')
 const showGroups = ref(false)
 const groups = ['BETA', 'BITAGAP', 'BITECA']
 
+const draft = useItemDraft(props.table)
+
 watch(() => route.query.database, (val) => {
   if (groups.includes(val)) {
     database.value = val
     showGroups.value = false
   } else {
-    showGroups.value = true
+    // No database in the URL (e.g. returning from an OAuth re-login): recover it
+    // from a saved draft so the create form remounts in the same context.
+    const savedDatabase = draft.load()?.database
+    if (groups.includes(savedDatabase)) {
+      database.value = savedDatabase
+      showGroups.value = false
+    } else {
+      showGroups.value = true
+    }
   }
 }, { immediate: true })
 

--- a/frontend/components/item/Create.vue
+++ b/frontend/components/item/Create.vue
@@ -2,7 +2,7 @@
   <div class="all-width">
     <v-container>
       <v-row class="back">
-        <a class="link" @click="router.go(-1)">
+        <a class="link" @click="cancel">
           <v-tooltip location="right">
             <template #activator="{ props: tooltipProps }">
               <v-icon color="primary" size="large" v-bind="tooltipProps">
@@ -13,7 +13,20 @@
           </v-tooltip>
         </a>
       </v-row>
-      <template v-if="isUserLogged">
+      <v-alert
+        v-if="!isUserLogged && initialClaimsLoaded"
+        type="warning"
+        class="mb-4"
+        variant="tonal"
+      >
+        <div class="d-flex align-center justify-space-between flex-wrap ga-2">
+          <span>{{ t('auth.session.expired') }}</span>
+          <v-btn color="primary" variant="flat" @click="loginAgain">
+            {{ t('auth.login.label') }}
+          </v-btn>
+        </div>
+      </v-alert>
+      <template v-if="isUserLogged || initialClaimsLoaded">
         <v-row>
           <v-col>
             <v-form ref="form">
@@ -55,7 +68,7 @@
           <v-btn
             class="mt-4 mr-4"
             elevation="2"
-            @click="router.go(-1)"
+            @click="cancel"
           >
             {{ t('common.cancel') }}
           </v-btn>
@@ -65,7 +78,7 @@
                 <v-btn
                   class="mt-4"
                   elevation="2"
-                  :disabled="isCreateDisabled"
+                  :disabled="isCreateDisabled || !isUserLogged"
                   @click="create"
                 >
                   {{ t('common.create') }}
@@ -83,7 +96,7 @@
 </template>
 
 <script setup>
-import { computed, nextTick, onMounted, ref } from 'vue'
+import { computed, nextTick, onMounted, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useAuthStore } from '~/stores/auth'
 
@@ -95,9 +108,12 @@ const props = defineProps({
 const { $notification, $wikibase } = useNuxtApp()
 const { t, locale } = useI18n()
 const router = useRouter()
+const route = useRoute()
 const localePath = useLocalePath()
 const authStore = useAuthStore()
 const { notifyError } = useNotifyError()
+const draft = useItemDraft(props.table)
+const previousPathCookie = useCookie('previous-path', { path: '/', maxAge: 5 * 60 })
 
 const label = ref('')
 const initialClaimsLoaded = ref(false)
@@ -120,11 +136,47 @@ onMounted(() => {
   nextTick(() => {
     if (!isUserLogged.value || !props.database) {
       return router.push(localePath('/'))
+    }
+    const savedDraft = draft.load()
+    if (savedDraft && savedDraft.database === props.database) {
+      restoreDraft(savedDraft)
     } else {
       loadInitialClaims()
     }
   })
 })
+
+function restoreDraft (savedDraft) {
+  label.value = savedDraft.label || ''
+  description.value = savedDraft.description || ''
+  initialClaims.value = savedDraft.initialClaims || []
+  claims.value = generateClaimsData(initialClaims.value)
+  initialClaimsLoaded.value = true
+}
+
+// Persist the in-progress form so it survives a session expiry + OAuth re-login.
+function persistDraft () {
+  if (!initialClaimsLoaded.value) return
+  draft.save({
+    database: props.database,
+    label: label.value,
+    description: description.value,
+    initialClaims: initialClaims.value
+  })
+}
+
+watch([label, description], persistDraft)
+
+function loginAgain () {
+  persistDraft()
+  previousPathCookie.value = route.path
+  $wikibase.$oauth.step1()
+}
+
+function cancel () {
+  draft.clear()
+  router.go(-1)
+}
 
 function getCreateDisabledReason () {
   if (!label.value) {
@@ -301,6 +353,7 @@ function updateClaims (data) {
   initialClaims.value = data
   claims.value = generateClaimsData(data)
   generateLabelFromClaims()
+  persistDraft()
 }
 
 function generateClaimsData (data) {
@@ -395,6 +448,7 @@ async function create () {
       const response = await $wikibase.getWbEdit().entity.create(data, authStore.requestConfig)
 
       if (response.success) {
+        draft.clear()
         await router.push(localePath('/item/' + response.entity.id))
       } else {
         throw response

--- a/frontend/composables/useItemDraft.js
+++ b/frontend/composables/useItemDraft.js
@@ -1,0 +1,36 @@
+// Persists an in-progress "create item" form to sessionStorage so the user's
+// work survives a session expiry + OAuth re-login round-trip (issue #468).
+// sessionStorage is per-tab and survives the cross-origin OAuth navigation,
+// but is cleared when the tab closes — appropriate for a transient draft.
+const PREFIX = 'pb-draft-'
+
+export function useItemDraft (table) {
+  const key = PREFIX + table
+
+  function save (data) {
+    if (!import.meta.client) return
+    try {
+      sessionStorage.setItem(key, JSON.stringify(data))
+    } catch (e) {
+      console.error('Could not save draft', e)
+    }
+  }
+
+  function load () {
+    if (!import.meta.client) return null
+    try {
+      const raw = sessionStorage.getItem(key)
+      return raw ? JSON.parse(raw) : null
+    } catch (e) {
+      console.error('Could not read draft', e)
+      return null
+    }
+  }
+
+  function clear () {
+    if (!import.meta.client) return
+    sessionStorage.removeItem(key)
+  }
+
+  return { save, load, clear }
+}

--- a/frontend/composables/useSessionTimer.js
+++ b/frontend/composables/useSessionTimer.js
@@ -29,6 +29,14 @@ export function useSessionTimer () {
     $notification.error(t('auth.session.expired'))
   }
 
+  function warn (expiresAt) {
+    // Re-check the live session: a throttled timer may fire after expiry or
+    // after a manual logout.
+    if (!authStore.isLogged || Date.now() >= expiresAt) return
+    const minutes = Math.max(1, Math.round((expiresAt - Date.now()) / 60000))
+    $notification.warning(t('auth.session.expiring_soon', { minutes }))
+  }
+
   function schedule (expiresAt) {
     clearTimers()
     if (!expiresAt) return
@@ -41,10 +49,10 @@ export function useSessionTimer () {
 
     const msToWarning = msToExpiry - WARNING_LEAD_MS
     if (msToWarning > 0) {
-      warnTimer = setTimeout(() => {
-        const minutes = Math.max(1, Math.round((expiresAt - Date.now()) / 60000))
-        $notification.warning(t('auth.session.expiring_soon', { minutes }))
-      }, msToWarning)
+      warnTimer = setTimeout(() => warn(expiresAt), msToWarning)
+    } else {
+      // Session restored already inside the warning window: warn right away.
+      warn(expiresAt)
     }
 
     expiryTimer = setTimeout(handleExpiry, msToExpiry)

--- a/frontend/composables/useSessionTimer.js
+++ b/frontend/composables/useSessionTimer.js
@@ -1,0 +1,56 @@
+import { onBeforeUnmount, watch } from 'vue'
+import { useAuthStore } from '~/stores/auth'
+
+// How long before expiry the user is warned.
+const WARNING_LEAD_MS = 5 * 60 * 1000
+
+// Watches the authenticated session and proactively reacts to its expiry:
+// warns the user shortly before the session ends and, once it expires, logs
+// out and notifies — without waiting for a failed write to reveal it.
+export function useSessionTimer () {
+  const { $notification } = useNuxtApp()
+  const { t } = useI18n()
+  const authStore = useAuthStore()
+  const oauthCookie = useCookie('oauth')
+
+  let warnTimer = null
+  let expiryTimer = null
+
+  function clearTimers () {
+    if (warnTimer) { clearTimeout(warnTimer); warnTimer = null }
+    if (expiryTimer) { clearTimeout(expiryTimer); expiryTimer = null }
+  }
+
+  function handleExpiry () {
+    clearTimers()
+    if (!authStore.isLogged) return
+    authStore.logout()
+    oauthCookie.value = null
+    $notification.error(t('auth.session.expired'))
+  }
+
+  function schedule (expiresAt) {
+    clearTimers()
+    if (!expiresAt) return
+
+    const msToExpiry = expiresAt - Date.now()
+    if (msToExpiry <= 0) {
+      handleExpiry()
+      return
+    }
+
+    const msToWarning = msToExpiry - WARNING_LEAD_MS
+    if (msToWarning > 0) {
+      warnTimer = setTimeout(() => {
+        const minutes = Math.max(1, Math.round((expiresAt - Date.now()) / 60000))
+        $notification.warning(t('auth.session.expiring_soon', { minutes }))
+      }, msToWarning)
+    }
+
+    expiryTimer = setTimeout(handleExpiry, msToExpiry)
+  }
+
+  watch(() => authStore.expiresAt, schedule, { immediate: true })
+
+  onBeforeUnmount(clearTimers)
+}

--- a/frontend/lang/ca.js
+++ b/frontend/lang/ca.js
@@ -113,6 +113,10 @@ export default {
     logout: {
       label: 'Tancar sessió',
       success: 'Fins la propera!'
+    },
+    session: {
+      expiring_soon: 'La teva sessió caducarà en {minutes} minuts. Desa la teva feina o torna a iniciar sessió per continuar connectat.',
+      expired: 'La teva sessió ha caducat. Torna a iniciar sessió per continuar.'
     }
   },
   welcome: {

--- a/frontend/lang/en.js
+++ b/frontend/lang/en.js
@@ -113,6 +113,10 @@ export default {
     logout: {
       label: 'Logout',
       success: 'See you next time!'
+    },
+    session: {
+      expiring_soon: 'Your session will expire in {minutes} minutes. Save your work or log in again to stay connected.',
+      expired: 'Your session has expired. Log in again to continue.'
     }
   },
   welcome: {

--- a/frontend/lang/es.js
+++ b/frontend/lang/es.js
@@ -113,6 +113,10 @@ export default {
     logout: {
       label: 'Cerrar sesión',
       success: '¡Hasta la próxima!'
+    },
+    session: {
+      expiring_soon: 'Tu sesión caducará en {minutes} minutos. Guarda tu trabajo o vuelve a iniciar sesión para seguir conectado.',
+      expired: 'Tu sesión ha caducado. Inicia sesión de nuevo para continuar.'
     }
   },
   welcome: {

--- a/frontend/lang/gl.js
+++ b/frontend/lang/gl.js
@@ -113,6 +113,10 @@ export default {
     logout: {
       label: 'Pechar sesión',
       success: 'Ata a próxima vez!'
+    },
+    session: {
+      expiring_soon: 'A túa sesión caducará en {minutes} minutos. Garda o teu traballo ou volve iniciar sesión para seguir conectado.',
+      expired: 'A túa sesión caducou. Inicia sesión de novo para continuar.'
     }
   },
   welcome: {

--- a/frontend/lang/pt.js
+++ b/frontend/lang/pt.js
@@ -114,6 +114,10 @@ export default {
     logout: {
       label: 'Sair',
       success: 'Até a próxima!'
+    },
+    session: {
+      expiring_soon: 'A sua sessão expirará em {minutes} minutos. Guarde o seu trabalho ou inicie sessão novamente para continuar conectado.',
+      expired: 'A sua sessão expirou. Inicie sessão novamente para continuar.'
     }
   },
   welcome: {

--- a/frontend/layouts/default.vue
+++ b/frontend/layouts/default.vue
@@ -116,6 +116,8 @@ const { mdAndDown } = useDisplay()
 const authStore = useAuthStore()
 const breadcrumbStore = useBreadcrumbStore()
 
+useSessionTimer()
+
 const previousPathCookie = useCookie('previous-path', { path: '/', maxAge: 5 * 60 })
 const oauthCookie = useCookie('oauth')
 

--- a/frontend/service/notification.service.js
+++ b/frontend/service/notification.service.js
@@ -18,6 +18,10 @@ export class NotificationService {
     this.$notify({ title: message, type: 'info', duration: DURATION })
   }
 
+  warning (message) {
+    this.$notify({ title: message, type: 'warn', duration: ERROR_DURATION })
+  }
+
   notify (message) {
     this.$notify({ title: message, duration: DURATION })
   }

--- a/frontend/service/oauth.service.js
+++ b/frontend/service/oauth.service.js
@@ -1,4 +1,4 @@
-import { useAuthStore } from '~/stores/auth'
+import { SESSION_TTL_MS, useAuthStore } from '~/stores/auth'
 
 const b64url = s => btoa(unescape(encodeURIComponent(s))).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '')
 const b64urlDecode = s => decodeURIComponent(escape(atob(s.replace(/-/g, '+').replace(/_/g, '/'))))
@@ -52,10 +52,12 @@ export class OAuthService {
     if (response.status === 0) {
       const accessToken = response.accessToken
       const username = await this.getUsername(accessToken)
-      useAuthStore().login({ username, accessToken })
+      const expiresAt = Date.now() + SESSION_TTL_MS
+      useAuthStore().login({ username, accessToken, expiresAt })
       const oauth = {
         username,
-        accessToken
+        accessToken,
+        expiresAt
       }
       this.oauthCookie.value = signToken(oauth)
     }
@@ -68,8 +70,8 @@ export class OAuthService {
     try {
       const decoded = decodeToken(token)
       if (!decoded?.username || !decoded?.accessToken) return
-      const { username, accessToken } = decoded
-      useAuthStore().login({ username, accessToken })
+      const { username, accessToken, expiresAt } = decoded
+      useAuthStore().login({ username, accessToken, expiresAt })
     } catch (err) {
        
       console.error(err)

--- a/frontend/service/oauth.service.js
+++ b/frontend/service/oauth.service.js
@@ -69,7 +69,12 @@ export class OAuthService {
     if (!token) return
     try {
       const decoded = decodeToken(token)
-      if (!decoded?.username || !decoded?.accessToken) return
+      // Reject pre-rollout cookies without an expiry, otherwise login() would
+      // synthesize a fresh TTL and extend an already-expired session.
+      if (!decoded?.username || !decoded?.accessToken || !decoded?.expiresAt) {
+        this.oauthCookie.value = null
+        return
+      }
       const { username, accessToken, expiresAt } = decoded
       useAuthStore().login({ username, accessToken, expiresAt })
     } catch (err) {

--- a/frontend/stores/auth.js
+++ b/frontend/stores/auth.js
@@ -1,20 +1,29 @@
 import { defineStore } from 'pinia'
 import { computed, ref } from 'vue'
 
+// Session lifetime in ms. Must stay aligned with the backend access-token TTL
+// (TimedMap of 60 minutes in WikibaseOAuthServiceImpl). The backend renews its
+// token on every write; this frontend value is counted from login time, so it
+// is intentionally conservative (it may warn slightly early, never late).
+export const SESSION_TTL_MS = 60 * 60 * 1000
+
 export const useAuthStore = defineStore('auth', () => {
   const isLogged = ref(false)
   const username = ref(null)
   const accessToken = ref(null)
+  const expiresAt = ref(null)
 
-  function login ({ username: u, accessToken: t }) {
+  function login ({ username: u, accessToken: t, expiresAt: e }) {
     username.value = u
     accessToken.value = t
+    expiresAt.value = e ?? Date.now() + SESSION_TTL_MS
     isLogged.value = true
   }
 
   function logout () {
     username.value = null
     accessToken.value = null
+    expiresAt.value = null
     isLogged.value = false
   }
 
@@ -34,6 +43,7 @@ export const useAuthStore = defineStore('auth', () => {
     isLogged,
     username,
     accessToken,
+    expiresAt,
     login,
     logout,
     requestConfig,


### PR DESCRIPTION
Closes #468

## Problema

La sesión de PBUI caduca a los **60 minutos** (TTL del access token OAuth en el backend; la cookie del frontend dura lo mismo). Hasta ahora el frontend solo se enteraba de la caducidad **al fallar una escritura**: en ese momento `notifyError` hacía logout y, como el formulario de creación estaba envuelto en `v-if="isUserLogged"`, **se desmontaba y se perdían todas las declaraciones** introducidas.

## Solución (solo frontend)

### No se pierde el trabajo
- El formulario de creación ya **no se desmonta** al perder la sesión. En su lugar aparece un banner "sesión expirada" con botón *Iniciar sesión*.
- El borrador en curso (label, descripción y claims) se **persiste en `sessionStorage`** (`useItemDraft`), sobrevive al viaje de re-login OAuth y se **restaura** al volver a la página de creación.
- `create/Base.vue` recupera la base de datos del borrador al volver sin `?database` en la URL, para remontar el formulario en el mismo contexto.
- El borrador se limpia al crear con éxito o al cancelar.

### Aviso proactivo de caducidad
- `useSessionTimer` avisa **5 min antes** de caducar y, al expirar, hace logout + notifica **sin esperar a una escritura fallida**. El botón de cabecera pasa a "iniciar sesión" automáticamente.
- Se guarda `expiresAt` en el store de auth y en la cookie `oauth` (para conocer el tiempo restante tras recargar).
- Nuevo nivel `warning` en el servicio de notificaciones y claves i18n `auth.session.*` en los 5 idiomas.

## Notas
- **Sin cambios de backend.** El TTL del frontend (`SESSION_TTL_MS`, 60 min) se cuenta desde el login y debe mantenerse alineado con el `TimedMap` del backend (queda documentado en el código). El backend renueva su token en cada escritura, por lo que el aviso puede adelantarse al vencimiento real — conservador, nunca tardío.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added session-expiry warnings and automatic sign-out handling.
  * Improved create-item flows with draft saving, restore on return, and relogin support after session expiry.
  * Restored the previously selected database when available, reducing repeated setup.

* **Bug Fixes**
  * Create forms now preserve entered details if the session expires or the page is revisited.
  * Session-expiration messages are now available in multiple languages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->