### PR TITLE
add P799 to default claims and ensure P106 date qualifier is built

### DIFF
--- a/frontend/components/item/Create.vue
+++ b/frontend/components/item/Create.vue
@@ -229,9 +229,10 @@ function buildQualifier (_claim, qualifier) {
 
 async function getDefaultClaims (itemNumber) {
   const def = ['P476', 'P131']
+  if (props.table === 'bibid') { def.push('P799') }
   const res = await $wikibase.getClaimsOrderForNewItem(props.table)
   const propertyIds = [...new Set([...def, ...Object.keys(res)])]
-  const qualifiersProperties = [...new Set(['P700', ...Object.values(res).flat()])]
+  const qualifiersProperties = [...new Set(['P700', 'P106', ...Object.values(res).flat()])]
   const entities = await $wikibase.getEntities(propertyIds, locale.value)
   const qualifiersArr = await $wikibase.getEntities(qualifiersProperties, locale.value)
 
@@ -268,7 +269,11 @@ async function getDefaultClaims (itemNumber) {
         const yyyy = String(today.getFullYear()).padStart(4, '0')
         const mm = String(today.getMonth() + 1).padStart(2, '0')
         const dd = String(today.getDate()).padStart(2, '0')
-        const dateQualifier = qualifiers.find(q => q.property?.id === 'P106')
+        let dateQualifier = qualifiers.find(q => q.property?.id === 'P106')
+        if (!dateQualifier && isValidPropertyEntity(qualifiersArr['P106'])) {
+          dateQualifier = buildQualifier(entity, qualifiersArr['P106'])
+          qualifiers.push(dateQualifier)
+        }
         if (dateQualifier) {
           dateQualifier.datavalue.value = {
             time: `+${yyyy}-${mm}-${dd}T00:00:00Z`,


### PR DESCRIPTION
- Add P799 (Status of database) to the default claims loaded for bibid items
- Include P106 in qualifiersProperties so the Date entity is fetched from Wikibase
- Add fallback in P799 block: if P106 is not present in Wikibase config qualifiers, build it manually via buildQualifier so the creation date is always set and hidden
- Note: partial date formats (YYYY, YYYY-MM) in P222 already supported by Time.vue via toWikibaseTime() — issue #306 was already resolved in the component

issue Add new BIB item #387

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved default claim setup for new items so required properties are included more reliably.
  * Expanded qualifier loading to capture all needed qualifier properties for new item creation.
  * Fixed date qualifier handling so missing `P106` qualifiers are now added automatically when available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->