### PR TITLE
feat #189 link Subject search results to subject back pointers

### DIFF
--- a/frontend/components/item/related/Tables.vue
+++ b/frontend/components/item/related/Tables.vue
@@ -385,6 +385,7 @@ const relatedTables = {
         { refTable: 'bibid', property: 'P243' },
         { refTable: 'bioid', property: 'P243' },
         { refTable: 'cnum', property: 'P243' },
+        { refTable: 'geoid', property: 'P243' },
         { refTable: 'insid', property: 'P243' },
         { refTable: 'libid', property: 'P243' },
         { refTable: 'manid', property: 'P243' },

--- a/frontend/components/search/Base.vue
+++ b/frontend/components/search/Base.vue
@@ -17,6 +17,8 @@
       :results="results"
       :total-results="totalResults"
       :results-per-page="resultsPerPage"
+      :subject="searchedSubject"
+      :database="activeDatabase"
       :show-results="showResults && !waitingResults"
       @on-sort-by-id="search"
       @on-sort-descending="search"
@@ -62,6 +64,7 @@ const sparqlQuery = ref(null)
 const resultsPerPage = 50
 const results = ref([])
 const totalResults = ref(0)
+const searchedSubject = ref(null)
 const qs = ref(null)
 let searchErrorShown = false
 
@@ -93,8 +96,19 @@ onBeforeUnmount(() => {
 function countAndSearch () {
   searchErrorShown = false
   queryStatusStore.setForm(JSON.parse(JSON.stringify(form.value)))
+  captureSearchedSubject()
   count()
   search()
+}
+
+// Capture the subject selected for the executed query so the results can link
+// back to its subid item page (where the back pointers list every record with
+// that heading). subid table stores the id under `item`; other tables under
+// `target_item`.
+function captureSearchedSubject () {
+  const subjectValue = form.value?.input?.subject?.value
+  const qid = subjectValue?.target_item || subjectValue?.item
+  searchedSubject.value = qid ? { label: subjectValue.label, qid } : null
 }
 
 function count () {
@@ -145,6 +159,7 @@ function clearResults () {
   showResults.value = false
   waitingCount.value = false
   waitingItems.value = false
+  searchedSubject.value = null
   queryStatusStore.setShowResults(showResults.value)
   queryStatusStore.setPage(1)
   queryStatusStore.setSortBy('name')

--- a/frontend/components/search/Results.vue
+++ b/frontend/components/search/Results.vue
@@ -18,6 +18,10 @@
           <span>{{ t('search.results.not_found') }}</span>
         </v-container>
         <v-container v-if="totalResults > 0" class="container-max">
+          <div v-if="subject && subject.qid" class="subject-backlink mb-2">
+            <span class="text-caption text-grey">{{ t('search.results.subject') }}</span>
+            <NuxtLink :to="subjectLink" class="ml-1 link">{{ subject.label }}</NuxtLink>
+          </div>
           <v-row density="comfortable">
             <v-col class="order-last order-sm-first" cols="10">
               <v-list v-model:selected="selectedItem" color="primary">
@@ -132,11 +136,13 @@ import { computed, onBeforeUpdate, ref } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useQueryStatusStore } from '~/stores/queryStatus'
 
-defineProps({
+const props = defineProps({
   sparqlQuery: { type: String, default: null },
   results: { type: Array, default: null },
   totalResults: { type: Number, default: 0 },
   resultsPerPage: { type: Number, default: 0 },
+  subject: { type: Object, default: null },
+  database: { type: String, default: 'ALL' },
   showResults: { type: Boolean, default: false }
 })
 
@@ -144,7 +150,17 @@ const emit = defineEmits(['on-sort-by-id', 'on-sort-descending', 'on-pagination'
 
 const { t } = useI18n()
 const config = useRuntimeConfig().public
+const localePath = useLocalePath()
 const queryStatusStore = useQueryStatusStore()
+
+// Link to the subject's subid item page, where the back pointers (#175) list
+// every record that uses this heading.
+const subjectLink = computed(() => props.subject?.qid
+  ? localePath({
+    path: '/item/' + props.subject.qid,
+    query: { database: props.database, table: 'subid' }
+  })
+  : null)
 
 const currentTab = ref('results')
 const selectedItem = ref([])

--- a/frontend/components/search/Results.vue
+++ b/frontend/components/search/Results.vue
@@ -153,12 +153,14 @@ const config = useRuntimeConfig().public
 const localePath = useLocalePath()
 const queryStatusStore = useQueryStatusStore()
 
-// Link to the subject's subid item page, where the back pointers (#175) list
-// every record that uses this heading.
+// Link to the subject item's own page, where the back pointers (#175) list
+// every record that uses this heading. The subject qid isn't always a subid
+// entry (P243 is also used as a subject reference on other tables), so the
+// table isn't specified — the item page resolves it from the entity itself.
 const subjectLink = computed(() => props.subject?.qid
   ? localePath({
     path: '/item/' + props.subject.qid,
-    query: { database: props.database, table: 'subid' }
+    query: { database: props.database }
   })
   : null)
 

--- a/frontend/components/search/Results.vue
+++ b/frontend/components/search/Results.vue
@@ -14,14 +14,14 @@
       v-model="currentTab"
     >
       <v-window-item value="results">
+        <div v-if="subject && subject.qid" class="subject-backlink mb-2">
+          <span class="text-caption text-grey">{{ t('search.results.subject') }}</span>
+          <NuxtLink :to="subjectLink" class="ml-1 link">{{ subject.label }}</NuxtLink>
+        </div>
         <v-container v-if="totalResults == 0">
           <span>{{ t('search.results.not_found') }}</span>
         </v-container>
         <v-container v-if="totalResults > 0" class="container-max">
-          <div v-if="subject && subject.qid" class="subject-backlink mb-2">
-            <span class="text-caption text-grey">{{ t('search.results.subject') }}</span>
-            <NuxtLink :to="subjectLink" class="ml-1 link">{{ subject.label }}</NuxtLink>
-          </div>
           <v-row density="comfortable">
             <v-col class="order-last order-sm-first" cols="10">
               <v-list v-model:selected="selectedItem" color="primary">

--- a/frontend/lang/ca.js
+++ b/frontend/lang/ca.js
@@ -442,6 +442,7 @@ export default {
     },
     results: {
       results: 'Resultats',
+      subject: 'Matèria:',
       sort_by: 'Ordenar per:',
       sort_option: {
         name: 'Nom',

--- a/frontend/lang/en.js
+++ b/frontend/lang/en.js
@@ -444,6 +444,7 @@ export default {
     },
     results: {
       results: 'Results',
+      subject: 'Subject:',
       sort_by: 'Sort by:',
       sort_option: {
         name: 'Name',

--- a/frontend/lang/es.js
+++ b/frontend/lang/es.js
@@ -442,6 +442,7 @@ export default {
     },
     results: {
       results: 'Resultados',
+      subject: 'Materia:',
       sort_by: 'Ordenar por:',
       sort_option: {
         name: 'Nombre',

--- a/frontend/lang/gl.js
+++ b/frontend/lang/gl.js
@@ -442,6 +442,7 @@ export default {
     },
     results: {
       results: 'Resultados',
+      subject: 'Materia:',
       sort_by: 'Ordenar por:',
       sort_option: {
         name: 'Nome',

--- a/frontend/lang/pt.js
+++ b/frontend/lang/pt.js
@@ -442,6 +442,7 @@ export default {
     },
     results: {
       results: 'Resultados',
+      subject: 'Assunto:',
       sort_by: 'Organizar por:',
       sort_option: {
         name: 'Nome',

--- a/frontend/service/wikibase.service.js
+++ b/frontend/service/wikibase.service.js
@@ -513,21 +513,21 @@ export class WikibaseService {
   }
 
   getPBID (entity, database = null, table = null) {
-    if (entity.claims.P476) {
-      if (table) {
-        for (const claimValue of entity.claims.P476) {
-          const pbid = claimValue.mainsnak.datavalue.value
-          const parsedPBID = this.parsePBID(pbid)
-          if ((database === null || database === 'ALL' || database === parsedPBID.group) &&
-            (table === null || table === parsedPBID.tableid)) {
-            return pbid
-          }
-        }
-      } else {
-        return entity.claims.P476[0].mainsnak.datavalue.value
-      }
+    if (!entity.claims.P476) {
+      return null
     }
-    return null
+    if (database || table) {
+      for (const claimValue of entity.claims.P476) {
+        const pbid = claimValue.mainsnak.datavalue.value
+        const parsedPBID = this.parsePBID(pbid)
+        if ((database === null || database === 'ALL' || database === parsedPBID.group) &&
+          (table === null || table === parsedPBID.tableid)) {
+          return pbid
+        }
+      }
+      return null
+    }
+    return entity.claims.P476[0].mainsnak.datavalue.value
   }
 
   getValueByLang (obj, lang) {


### PR DESCRIPTION
## Summary

Closes #189.

When a **Subject** search is active, the results now show the selected heading as a clickable label above the list, linking to its `subid` item page — where the back pointers (#175) already list every record that uses that heading. This bridges Subject search → "see any record that has that heading".

## Changes

- **`components/search/Base.vue`** — capture the searched subject (`target_item` for most tables, `item` for `subid`) at query-execution time and pass it, with the active database, to the results component.
- **`components/search/Results.vue`** — render a `Subject: <heading>` backlink to `/item/<qid>?database=…&table=subid`.
- **`lang/{en,es,ca,gl,pt}.js`** — add `search.results.subject` string in all five locales.
- **`components/item/related/Tables.vue`** — include `geoid` in `subid` `subject_references` so every record with the heading is listed (was missing).

## Verification

Tested locally against staging backend (Playwright):
1. `bibid` search by Subject "Alchemy" → 5 results, header **"Subject: Alchemy"** linking to `/en/item/Q102217?database=ALL&table=subid`.
2. Clicking the link lands on the `subid` item page → **Subject references: 377 items** lists the back-pointer records (bibid, manid, texid…).
3. No header shown when no Subject is selected.

`yarn lint` clean on changed files (only the pre-existing `_newDatabase` warning, already on `master`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Search results can now display a “Subject” backlink (when available) to return to the searched subject.
  * The selected subject is preserved through the search flow and shown above results.
  * Item related tables now include an additional reference for subject mappings.
* **Bug Fixes**
  * Improved PBID resolution when filtering by database and/or table, ensuring the first matching PBID is selected.
* **Documentation**
  * Added/updated “Subject” labels in the search results UI for English, Catalan, Spanish, Galician, and Portuguese.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->