### PR TITLE
Add P799 status date auto-fill for new SUB items #395

### DIFF
--- a/frontend/components/item/Create.vue
+++ b/frontend/components/item/Create.vue
@@ -262,9 +262,10 @@ function buildQualifier (_claim, qualifier) {
 
 async function getDefaultClaims (itemNumber) {
   const def = ['P476', 'P131']
+  if (props.table === 'subid') { def.push('P799') }
   const res = await $wikibase.getClaimsOrderForNewItem(props.table)
   const propertyIds = [...new Set([...def, ...Object.keys(res)])]
-  const qualifiersProperties = [...new Set(['P700', ...Object.values(res).flat()])]
+  const qualifiersProperties = [...new Set(['P700', 'P106', ...Object.values(res).flat()])]
   const entities = await $wikibase.getEntities(propertyIds, locale.value)
   const qualifiersArr = await $wikibase.getEntities(qualifiersProperties, locale.value)
 
@@ -301,7 +302,11 @@ async function getDefaultClaims (itemNumber) {
         const yyyy = String(today.getFullYear()).padStart(4, '0')
         const mm = String(today.getMonth() + 1).padStart(2, '0')
         const dd = String(today.getDate()).padStart(2, '0')
-        const dateQualifier = qualifiers.find(q => q.property?.id === 'P106')
+        let dateQualifier = qualifiers.find(q => q.property?.id === 'P106')
+        if (!dateQualifier && isValidPropertyEntity(qualifiersArr['P106'])) {
+          dateQualifier = buildQualifier(entity, qualifiersArr['P106'])
+          qualifiers.push(dateQualifier)
+        }
         if (dateQualifier) {
           dateQualifier.datavalue.value = {
             time: `+${yyyy}-${mm}-${dd}T00:00:00Z`,


### PR DESCRIPTION
When creating a new subid item, P799 (Status of database) is now automatically included and pre-filled with today's date via P106 (Date) as a hidden qualifier.

Changes in frontend/components/item/Create.vue:
- Add P799 to the default claims loaded for subid on item creation
- Include P106 in qualifiersProperties so the Date entity is always fetched
- Add fallback: if P106 is not configured as a Wikibase qualifier for P799, build it manually and set it hidden with today's date (YYYY-MM-DD)

The alias field (populated from P476 as "BETA subid XXXX") and the Set-based create-button validation were already present in master.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved default property setup so `P799` is included consistently across supported item creation flows.
  * Enhanced claim construction to reliably include the date qualifier (`P106`), even when it isn’t present in the initial generated qualifiers.
  * Fixed cases where date-related details could be missing, helping prevent incomplete or partially populated entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->