### PR TITLE
Fix CREATE button and add P799 auto-fill for new LIB items #392

### DIFF
--- a/frontend/components/item/Create.vue
+++ b/frontend/components/item/Create.vue
@@ -156,12 +156,14 @@ function getCreateDisabledReason () {
 
       const claimLabel = initialClaim?.value?.datavalue?.value?.label || propertyLabel
 
-      for (const [qualifierKey, qualifierVal] of Object.entries(item.qualifiers || {})) {
-        if (!qualifierKey || qualifierKey === 'null') {
-          return t('messages.error.inputs.qualifier_key_missing', { claimLabel, propertyLabel })
-        }
-        if (!qualifierVal || qualifierVal === 'null') {
-          return t('messages.error.inputs.qualifier_value_missing', { claimLabel, propertyLabel })
+      if (propKey !== 'P2') {
+        for (const [qualifierKey, qualifierVal] of Object.entries(item.qualifiers || {})) {
+          if (!qualifierKey || qualifierKey === 'null') {
+            return t('messages.error.inputs.qualifier_key_missing', { claimLabel, propertyLabel })
+          }
+          if (!qualifierVal || qualifierVal === 'null') {
+            return t('messages.error.inputs.qualifier_value_missing', { claimLabel, propertyLabel })
+          }
         }
       }
     }
@@ -262,9 +264,10 @@ function buildQualifier (_claim, qualifier) {
 
 async function getDefaultClaims (itemNumber) {
   const def = ['P476', 'P131']
+  if (props.table === 'libid') { def.push('P799') }
   const res = await $wikibase.getClaimsOrderForNewItem(props.table)
   const propertyIds = [...new Set([...def, ...Object.keys(res)])]
-  const qualifiersProperties = [...new Set(['P700', ...Object.values(res).flat()])]
+  const qualifiersProperties = [...new Set(['P700', 'P106', ...Object.values(res).flat()])]
   const entities = await $wikibase.getEntities(propertyIds, locale.value)
   const qualifiersArr = await $wikibase.getEntities(qualifiersProperties, locale.value)
 
@@ -301,7 +304,11 @@ async function getDefaultClaims (itemNumber) {
         const yyyy = String(today.getFullYear()).padStart(4, '0')
         const mm = String(today.getMonth() + 1).padStart(2, '0')
         const dd = String(today.getDate()).padStart(2, '0')
-        const dateQualifier = qualifiers.find(q => q.property?.id === 'P106')
+        let dateQualifier = qualifiers.find(q => q.property?.id === 'P106')
+        if (!dateQualifier && isValidPropertyEntity(qualifiersArr['P106'])) {
+          dateQualifier = buildQualifier(entity, qualifiersArr['P106'])
+          qualifiers.push(dateQualifier)
+        }
         if (dateQualifier) {
           dateQualifier.datavalue.value = {
             time: `+${yyyy}-${mm}-${dd}T00:00:00Z`,


### PR DESCRIPTION
When creating a new libid item, the CREATE button was blocked if P2 (Instance of) had a qualifier configured in Wikibase, even when the qualifier was not required.

Changes in frontend/components/item/Create.vue:
- Skip qualifier validation for P2 (Instance of) in getCreateDisabledReason, so only the value itself is required, not its qualifiers
- Add P799 to the default claims loaded for libid on item creation
- Include P106 in qualifiersProperties so the Date entity is always fetched
- Add fallback: if P106 is not configured as a Wikibase qualifier for P799, build it manually and set it hidden with today's date (YYYY-MM-DD)

The alias field (populated from P476 as "BETA libid XXXX") was already present in master.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed item creation so claims with required property **P2** no longer fail qualifier validation when qualifiers are missing.
  * Improved default claim setup for **libid** item creation by including the expected additional property.
  * Ensured date qualifiers are added automatically when needed, so newly created claims can include the current date without manual entry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->