### PR TITLE
Add required fields for label generation on new item creation #344

### DIFF
--- a/frontend/components/item/Create.vue
+++ b/frontend/components/item/Create.vue
@@ -137,8 +137,11 @@ function getCreateDisabledReason () {
 
   const requiredPropertyIds = new Set(['P2', 'P476'])
   if (props.table === 'manid') requiredPropertyIds.add('P329')
-  if (props.table === 'cnum') requiredPropertyIds.add('P590')
+  if (props.table === 'cnum') { requiredPropertyIds.add('P590'); requiredPropertyIds.add('P8') }
   if (props.table === 'copid') { requiredPropertyIds.add('P839'); requiredPropertyIds.add('P329') }
+  if (props.table === 'bioid' || props.table === 'geoid' || props.table === 'insid') requiredPropertyIds.add('P34')
+  if (props.table === 'texid') { requiredPropertyIds.add('P21'); requiredPropertyIds.add('P11') }
+  if (props.table === 'bibid') { requiredPropertyIds.add('P1134'); requiredPropertyIds.add('P11') }
 
   for (const propKey of requiredPropertyIds) {
     const claimArray = claims.value[propKey]

--- a/frontend/components/item/Create.vue
+++ b/frontend/components/item/Create.vue
@@ -140,6 +140,8 @@ function getCreateDisabledReason () {
   if (props.table === 'cnum') { requiredPropertyIds.add('P590'); requiredPropertyIds.add('P8') }
   if (props.table === 'copid') { requiredPropertyIds.add('P839'); requiredPropertyIds.add('P329') }
   if (props.table === 'geoid' || props.table === 'insid') { requiredPropertyIds.add('P34'); requiredPropertyIds.add('P297') }
+  if (props.table === 'libid') { requiredPropertyIds.add('P34'); requiredPropertyIds.add('P47') }
+  if (props.table === 'subid') requiredPropertyIds.add('P34')
   if (props.table === 'texid') { requiredPropertyIds.add('P21'); requiredPropertyIds.add('P11') }
 
   if (props.table === 'bioid') {
@@ -148,8 +150,8 @@ function getCreateDisabledReason () {
       return Array.isArray(arr) && arr.length > 0 && arr[0]?.value != null && arr[0]?.value !== ''
     })
     if (!hasName) {
-      const label = initialClaims.value.find(c => c.property?.id === 'P34')?.property?.label || 'P34'
-      return t('messages.error.inputs.claim_value_missing', { propertyLabel: label })
+      const propertyLabel = initialClaims.value.find(c => c.property?.id === 'P34')?.property?.label || 'P34'
+      return t('messages.error.inputs.claim_value_missing', { propertyLabel })
     }
   }
 
@@ -159,8 +161,8 @@ function getCreateDisabledReason () {
       return Array.isArray(arr) && arr.length > 0 && arr[0]?.value != null && arr[0]?.value !== ''
     })
     if (!hasName) {
-      const label = initialClaims.value.find(c => c.property?.id === 'P1134')?.property?.label || 'P1134'
-      return t('messages.error.inputs.claim_value_missing', { propertyLabel: label })
+      const propertyLabel = initialClaims.value.find(c => c.property?.id === 'P247')?.property?.label || 'P247'
+      return t('messages.error.inputs.claim_value_missing', { propertyLabel })
     }
     requiredPropertyIds.add('P11')
   }

--- a/frontend/components/item/Create.vue
+++ b/frontend/components/item/Create.vue
@@ -139,9 +139,31 @@ function getCreateDisabledReason () {
   if (props.table === 'manid') requiredPropertyIds.add('P329')
   if (props.table === 'cnum') { requiredPropertyIds.add('P590'); requiredPropertyIds.add('P8') }
   if (props.table === 'copid') { requiredPropertyIds.add('P839'); requiredPropertyIds.add('P329') }
-  if (props.table === 'bioid' || props.table === 'geoid' || props.table === 'insid') requiredPropertyIds.add('P34')
+  if (props.table === 'geoid' || props.table === 'insid') { requiredPropertyIds.add('P34'); requiredPropertyIds.add('P297') }
   if (props.table === 'texid') { requiredPropertyIds.add('P21'); requiredPropertyIds.add('P11') }
-  if (props.table === 'bibid') { requiredPropertyIds.add('P1134'); requiredPropertyIds.add('P11') }
+
+  if (props.table === 'bioid') {
+    const hasName = ['P34', 'P77', 'P173', 'P291', 'P165', 'P746'].some(p => {
+      const arr = claims.value[p]
+      return Array.isArray(arr) && arr.length > 0 && arr[0]?.value != null && arr[0]?.value !== ''
+    })
+    if (!hasName) {
+      const label = initialClaims.value.find(c => c.property?.id === 'P34')?.property?.label || 'P34'
+      return t('messages.error.inputs.claim_value_missing', { propertyLabel: label })
+    }
+  }
+
+  if (props.table === 'bibid') {
+    const hasName = ['P247', 'P21', 'P1134'].some(p => {
+      const arr = claims.value[p]
+      return Array.isArray(arr) && arr.length > 0 && arr[0]?.value != null && arr[0]?.value !== ''
+    })
+    if (!hasName) {
+      const label = initialClaims.value.find(c => c.property?.id === 'P1134')?.property?.label || 'P1134'
+      return t('messages.error.inputs.claim_value_missing', { propertyLabel: label })
+    }
+    requiredPropertyIds.add('P11')
+  }
 
   for (const propKey of requiredPropertyIds) {
     const claimArray = claims.value[propKey]


### PR DESCRIPTION
Enforce required properties per table type in getCreateDisabledReason so the CREATE button stays disabled until the fields needed to auto-generate the label are filled in.

Changes in frontend/components/item/Create.vue:
- bioid, geoid, insid: require P34 (Naming)
- texid: require P21 (Author) and P11 (Title)
- bibid: require P1134 (Creator) and P11 (Title)
- cnum: add P8 (Part of) alongside the existing P590 (Identified Work)

Label generation logic (generateLabelFromClaims) was already complete in master. Tables manid, cnum (P590), copid, libid, and subid were already handled.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved create-form validation so the correct required properties are enforced for more item types.
  * Updated required fields for several table types, including `cnum`, `copid`, `geoid`, `insid`, `texid`, `bioid`, and `bibid`.
  * Added stricter “name present” checks for `bioid`/`bibid`, with clearer missing-property messaging and continued existing `copid` requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->