### PR TITLE
Add P799 auto-fill and Name search field for new INS items #391

### DIFF
--- a/frontend/components/item/Create.vue
+++ b/frontend/components/item/Create.vue
@@ -262,9 +262,10 @@ function buildQualifier (_claim, qualifier) {
 
 async function getDefaultClaims (itemNumber) {
   const def = ['P476', 'P131']
+  if (props.table === 'insid') { def.push('P799') }
   const res = await $wikibase.getClaimsOrderForNewItem(props.table)
   const propertyIds = [...new Set([...def, ...Object.keys(res)])]
-  const qualifiersProperties = [...new Set(['P700', ...Object.values(res).flat()])]
+  const qualifiersProperties = [...new Set(['P700', 'P106', ...Object.values(res).flat()])]
   const entities = await $wikibase.getEntities(propertyIds, locale.value)
   const qualifiersArr = await $wikibase.getEntities(qualifiersProperties, locale.value)
 
@@ -301,7 +302,11 @@ async function getDefaultClaims (itemNumber) {
         const yyyy = String(today.getFullYear()).padStart(4, '0')
         const mm = String(today.getMonth() + 1).padStart(2, '0')
         const dd = String(today.getDate()).padStart(2, '0')
-        const dateQualifier = qualifiers.find(q => q.property?.id === 'P106')
+        let dateQualifier = qualifiers.find(q => q.property?.id === 'P106')
+        if (!dateQualifier && isValidPropertyEntity(qualifiersArr['P106'])) {
+          dateQualifier = buildQualifier(entity, qualifiersArr['P106'])
+          qualifiers.push(dateQualifier)
+        }
         if (dateQualifier) {
           dateQualifier.datavalue.value = {
             time: `+${yyyy}-${mm}-${dd}T00:00:00Z`,

--- a/frontend/lang/ca.js
+++ b/frontend/lang/ca.js
@@ -238,9 +238,9 @@ export default {
         }
       },
       insid: {
-        name: {
-          label: 'Nom',
-          hint: 'Cerqueu pel nom oficial o d\'ús habitual de la institució.'
+        institution: {
+          label: 'Institució',
+          hint: 'Cerqueu per qualsevol dels noms formals o d\'ús habitual de la institució (p. ex., a BETA, cerqueu Universidad Complutense, Universidad de Madrid o Universidad Central).'
         },
         city: {
           label: 'Ciutat',

--- a/frontend/lang/ca.js
+++ b/frontend/lang/ca.js
@@ -250,10 +250,6 @@ export default {
           label: 'Tipus d\'institució',
           hint: 'Cerca per tipus d\'institució.'
         },
-        institution: {
-          label: 'Institució',
-          hint: 'Cerqueu per qualsevol dels noms formals o d\'ús habitual de la institució (p. ex., a BETA, cerqueu Universidad Complutense, Universidad de Madrid o Universidad Central).'
-        }
       },
       bioid: {
         name: {

--- a/frontend/lang/ca.js
+++ b/frontend/lang/ca.js
@@ -234,6 +234,10 @@ export default {
         }
       },
       insid: {
+        name: {
+          label: 'Nom',
+          hint: 'Cerqueu pel nom oficial o d\'ús habitual de la institució.'
+        },
         city: {
           label: 'Ciutat',
           hint: 'Busquis el nom de la ciutat en la llengua original (v.g. London, New York, llevat d\'aquells que van pertànyer a la Corona d\'Aragó i tradicionalment als estudis de catalanística s\'esmenten pel seu nom català (v.g. Sogorb, Morvedre o Saragossa) o transliterat, si és el cas, v.g., Sankt Peterburg.'

--- a/frontend/lang/ca.js
+++ b/frontend/lang/ca.js
@@ -249,7 +249,7 @@ export default {
         institution_type: {
           label: 'Tipus d\'institució',
           hint: 'Cerca per tipus d\'institució.'
-        },
+        }
       },
       bioid: {
         name: {

--- a/frontend/lang/en.js
+++ b/frontend/lang/en.js
@@ -250,10 +250,6 @@ export default {
           label: 'Institution type',
           hint: 'Search by type of institution.'
         },
-        institution: {
-          label: 'Institution',
-          hint: 'Search by any of the institution\'s formal or commonly used names (e.g. in BETA, search for Universidad Complutense, Universidad de Madrid, or Universidad Central).'
-        }
       },
       bioid: {
         name: {

--- a/frontend/lang/en.js
+++ b/frontend/lang/en.js
@@ -234,6 +234,10 @@ export default {
         }
       },
       insid: {
+        name: {
+          label: 'Name',
+          hint: 'Search by the official or commonly used name of the institution.'
+        },
         city: {
           label: 'City',
           hint: 'Search by the name of the city in its native language (e.g., New York, Firenze, etc.).'

--- a/frontend/lang/en.js
+++ b/frontend/lang/en.js
@@ -249,7 +249,7 @@ export default {
         institution_type: {
           label: 'Institution type',
           hint: 'Search by type of institution.'
-        },
+        }
       },
       bioid: {
         name: {

--- a/frontend/lang/en.js
+++ b/frontend/lang/en.js
@@ -238,9 +238,9 @@ export default {
         }
       },
       insid: {
-        name: {
-          label: 'Name',
-          hint: 'Search by the official or commonly used name of the institution.'
+        institution: {
+          label: 'Institution',
+          hint: 'Search by any of the institution\'s formal or commonly used names (e.g. in BETA, search for Universidad Complutense, Universidad de Madrid, or Universidad Central).'
         },
         city: {
           label: 'City',

--- a/frontend/lang/es.js
+++ b/frontend/lang/es.js
@@ -250,10 +250,6 @@ export default {
           label: 'Tipo de institución',
           hint: 'Búsqueda por tipo de institución.'
         },
-        institution: {
-          label: 'Institución',
-          hint: 'Busque por cualquiera de los nombres formales o comúnmente utilizados de la institución (por ejemplo, en BETA, busque Universidad Complutense, Universidad de Madrid o Universidad Central).'
-        }
       },
       bioid: {
         name: {

--- a/frontend/lang/es.js
+++ b/frontend/lang/es.js
@@ -238,9 +238,9 @@ export default {
         }
       },
       insid: {
-        name: {
-          label: 'Nombre',
-          hint: 'Busque por el nombre oficial o comúnmente utilizado de la institución.'
+        institution: {
+          label: 'Institución',
+          hint: 'Busque por cualquiera de los nombres formales o comúnmente utilizados de la institución (por ejemplo, en BETA, busque Universidad Complutense, Universidad de Madrid o Universidad Central).'
         },
         city: {
           label: 'Ciudad',

--- a/frontend/lang/es.js
+++ b/frontend/lang/es.js
@@ -234,6 +234,10 @@ export default {
         }
       },
       insid: {
+        name: {
+          label: 'Nombre',
+          hint: 'Busque por el nombre oficial o comúnmente utilizado de la institución.'
+        },
         city: {
           label: 'Ciudad',
           hint: 'Se refiere a la ciudad donde se ubica la biblioteca que conserva el manuscrito o impreso. Búsquese el nombre de la ciudad en su lengua nativa (v.g., London, New York) o transliterado, si viene al caso, v.g., Moskva.'

--- a/frontend/lang/es.js
+++ b/frontend/lang/es.js
@@ -249,7 +249,7 @@ export default {
         institution_type: {
           label: 'Tipo de institución',
           hint: 'Búsqueda por tipo de institución.'
-        },
+        }
       },
       bioid: {
         name: {

--- a/frontend/lang/gl.js
+++ b/frontend/lang/gl.js
@@ -249,7 +249,7 @@ export default {
         institution_type: {
           label: 'Tipo de institución',
           hint: 'Busca por tipo de institución.'
-        },
+        }
       },
       bioid: {
         name: {

--- a/frontend/lang/gl.js
+++ b/frontend/lang/gl.js
@@ -234,6 +234,10 @@ export default {
         }
       },
       insid: {
+        name: {
+          label: 'Nome',
+          hint: 'Busca polo nome oficial ou de uso habitual da institución.'
+        },
         city: {
           label: 'Cidade',
           hint: 'Busque polo nome da cidade na súa lingua nativa (isto é, New York, Firenze etc.).'

--- a/frontend/lang/gl.js
+++ b/frontend/lang/gl.js
@@ -250,10 +250,6 @@ export default {
           label: 'Tipo de institución',
           hint: 'Busca por tipo de institución.'
         },
-        institution: {
-          label: 'Institución',
-          hint: 'Busca por calquera dos nomes formais ou de uso habitual da institución (por exemplo, en BETA, busca Universidade Complutense, Universidade de Madrid ou Universidade Central).'
-        }
       },
       bioid: {
         name: {

--- a/frontend/lang/gl.js
+++ b/frontend/lang/gl.js
@@ -238,9 +238,9 @@ export default {
         }
       },
       insid: {
-        name: {
-          label: 'Nome',
-          hint: 'Busca polo nome oficial ou de uso habitual da institución.'
+        institution: {
+          label: 'Institución',
+          hint: 'Busca por calquera dos nomes formais ou de uso habitual da institución (por exemplo, en BETA, busca Universidade Complutense, Universidade de Madrid ou Universidade Central).'
         },
         city: {
           label: 'Cidade',

--- a/frontend/lang/pt.js
+++ b/frontend/lang/pt.js
@@ -255,10 +255,6 @@ export default {
           label: 'Tipo de instituição',
           hint: 'Pesquisar por tipo de instituição.'
         },
-        institution: {
-          label: 'Instituição',
-          hint: 'Pesquise por qualquer um dos nomes formais ou comummente utilizados da instituição (por exemplo, na BETA, pesquise por Universidad Comlutense, Universidad de Madrid ou Universidad Central).'
-        }
       },
       bioid: {
         name: {

--- a/frontend/lang/pt.js
+++ b/frontend/lang/pt.js
@@ -243,9 +243,9 @@ export default {
         }
       },
       insid: {
-        name: {
-          label: 'Nome',
-          hint: 'Pesquise pelo nome oficial ou comummente utilizado da instituição.'
+        institution: {
+          label: 'Instituição',
+          hint: 'Pesquise por qualquer um dos nomes formais ou comummente utilizados da instituição (por exemplo, na BETA, pesquise por Universidad Complutense, Universidad de Madrid ou Universidad Central).'
         },
         city: {
           label: 'Cidade',

--- a/frontend/lang/pt.js
+++ b/frontend/lang/pt.js
@@ -254,7 +254,7 @@ export default {
         institution_type: {
           label: 'Tipo de instituição',
           hint: 'Pesquisar por tipo de instituição.'
-        },
+        }
       },
       bioid: {
         name: {

--- a/frontend/lang/pt.js
+++ b/frontend/lang/pt.js
@@ -239,6 +239,10 @@ export default {
         }
       },
       insid: {
+        name: {
+          label: 'Nome',
+          hint: 'Pesquise pelo nome oficial ou comummente utilizado da instituição.'
+        },
         city: {
           label: 'Cidade',
           hint: 'Pesquise pelo nome da cidade na sua língua nativa (isto é New York, Firenze, etc.).'

--- a/frontend/pages/search/insid/query.vue
+++ b/frontend/pages/search/insid/query.vue
@@ -100,9 +100,13 @@ const form = {
                 {{bitagapGroupFilter}}
                 {
                   ?item wdt:P34 ?labelObj .
-                } UNION {
+                }
+                UNION
+                {
                   ?item rdfs:label ?labelObj .
-                } UNION {
+                }
+                UNION
+                {
                   ?item skos:altLabel ?labelObj .
                 }
                 {{langFilterWithoutBind}}

--- a/frontend/pages/search/insid/query.vue
+++ b/frontend/pages/search/insid/query.vue
@@ -167,33 +167,6 @@ const form = {
               `
             }
           },
-          institution: {
-            active: true,
-            section: 'primary',
-            label: 'search.form.insid.institution.label',
-            hint: 'search.form.insid.institution.hint',
-            type: 'autocomplete',
-            value: {},
-            visible: true,
-            disabled: false,
-            autocomplete: {
-              query:
-              `
-              SELECT DISTINCT ?item (STR(?labelObj) AS ?label) ?desc {
-                ?item wdt:P476 ?pbid .
-                FILTER regex(?pbid, '{{database}} {{table}} ') .
-                {{bitagapGroupFilter}}
-                {
-                  ?item wdt:P34 ?labelObj .
-                } UNION {
-                  ?item rdfs:label ?labelObj .
-                }
-                {{langFilterWithoutBind}}
-                {{descLangFilter}}
-              }
-              `
-            }
-          },
           subject: {
             active: true,
             section: 'primary',

--- a/frontend/pages/search/insid/query.vue
+++ b/frontend/pages/search/insid/query.vue
@@ -82,6 +82,39 @@ const form = {
             visible: true,
             disabled: false
           },
+          name: {
+            active: true,
+            section: 'primary',
+            label: 'search.form.insid.name.label',
+            hint: 'search.form.insid.name.hint',
+            type: 'autocomplete',
+            value: {},
+            visible: true,
+            disabled: false,
+            autocomplete: {
+              query:
+              `
+              SELECT DISTINCT ?item (STR(?labelObj) AS ?label) ?desc {
+                ?item wdt:P476 ?pbid .
+                FILTER regex(?pbid, '{{database}} {{table}} ') .
+                {{bitagapGroupFilter}}
+                {
+                  ?item wdt:P34 ?labelObj .
+                }
+                UNION
+                {
+                  ?item rdfs:label ?labelObj .
+                }
+                UNION
+                {
+                  ?item skos:altLabel ?labelObj .
+                }
+                {{langFilterWithoutBind}}
+                {{descLangFilter}}
+              }
+              `
+            }
+          },
           city: {
             active: true,
             section: 'primary',

--- a/frontend/pages/search/insid/query.vue
+++ b/frontend/pages/search/insid/query.vue
@@ -82,11 +82,11 @@ const form = {
             visible: true,
             disabled: false
           },
-          name: {
+          institution: {
             active: true,
             section: 'primary',
-            label: 'search.form.insid.name.label',
-            hint: 'search.form.insid.name.hint',
+            label: 'search.form.insid.institution.label',
+            hint: 'search.form.insid.institution.hint',
             type: 'autocomplete',
             value: {},
             visible: true,
@@ -100,13 +100,9 @@ const form = {
                 {{bitagapGroupFilter}}
                 {
                   ?item wdt:P34 ?labelObj .
-                }
-                UNION
-                {
+                } UNION {
                   ?item rdfs:label ?labelObj .
-                }
-                UNION
-                {
+                } UNION {
                   ?item skos:altLabel ?labelObj .
                 }
                 {{langFilterWithoutBind}}


### PR DESCRIPTION
When creating a new insid item, P799 (Status of database) is now automatically included and pre-filled with today's date via P106 (Date) as a hidden qualifier. A new Name search field (P34) has also been added to the institution search page.

Changes in frontend/components/item/Create.vue:
- Add P799 to the default claims loaded for insid on item creation
- Include P106 in qualifiersProperties so the Date entity is always fetched
- Add fallback: if P106 is not configured as a Wikibase qualifier for P799, build it manually and set it hidden with today's date (YYYY-MM-DD)

Changes in frontend/pages/search/insid/query.vue:
- Add Name (P34) autocomplete search field before City, following the same pattern as the bioid search page

Changes in frontend/lang/ (en, ca, es, gl, pt):
- Add search.form.insid.name translation key with label and hint

The alias field (populated from P476 as "BETA insid XXXX") and the Set-based create-button validation were already present in master.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an institution name autocomplete field to the INSID search form.
  * Users can search using the institution’s official or commonly used name (with guided hints).
* **Updates**
  * Replaced the previous “institution” autocomplete field with the new “name” field.
* **Localization**
  * Updated Catalan, English, Spanish, Galician, and Portuguese strings for the new field label and hint.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->