### PR TITLE
Fix label generation and add P799 auto-fill for new GEO items #390

### DIFF
--- a/frontend/components/item/Create.vue
+++ b/frontend/components/item/Create.vue
@@ -574,7 +574,14 @@ function generateLabelFromClaims () {
       }
       break
     }
-    case 'geoid':
+    case 'geoid': {
+      const name = getClaimValue('P34')
+      const region = getClaimValue('P297')
+      if (name) {
+        generatedLabel = region ? `${name}, ${region}` : name
+      }
+      break
+    }
     case 'insid': {
       const name = getClaimValue('P34')
       const region = getClaimValue('P297')


### PR DESCRIPTION
When creating a new geoid item, P34 (Naming) is now sufficient to generate
the label. P297 (Territorial localisation) becomes optional: if filled in,
it is appended as ", region" — but it no longer blocks label generation or
the CREATE button.

Changes in frontend/components/item/Create.vue:
- Split the shared geoid/insid case in generateLabelFromClaims so each
  table has independent label logic
- geoid: generate label from P34 alone; append P297 if present
- insid: unchanged — still requires both P34 and P297 for the label

P799 (Status of database) with P106 (Date) as hidden qualifier, the alias
field (populated from P476 as "BETA geoid XXXX"), and the Set-based
create-button validation were already present in this branch.
