### PR TITLE
docs: add CONTRIBUTING.md, review-queue skill, and Ui_ControlledVocabulary fix

### DIFF
--- a/.claude/skills/review-queue/SKILL.md
+++ b/.claude/skills/review-queue/SKILL.md
@@ -14,9 +14,11 @@ The repo is resolved automatically from `git remote -v`, same as `docs/agents/is
 GitHub's search syntax doesn't support a clean OR between `review-requested` and `assignee`, so run two separate queries:
 
 ```
-gh pr list --state open --search "review-requested:@me" --json number,title,url,author,updatedAt,mergeStateStatus,isDraft,headRefName,reviewDecision,statusCheckRollup
-gh pr list --state open --assignee "@me" --json number,title,url,author,updatedAt,mergeStateStatus,isDraft,headRefName,reviewDecision,statusCheckRollup
+gh pr list --state open --search "review-requested:@me" --limit 200 --json number,title,url,author,updatedAt,mergeStateStatus,isDraft,headRefName,headRepositoryOwner,reviewDecision,statusCheckRollup
+gh pr list --state open --assignee "@me" --limit 200 --json number,title,url,author,updatedAt,mergeStateStatus,isDraft,headRefName,headRepositoryOwner,reviewDecision,statusCheckRollup
 ```
+
+`--limit 200` avoids the default 30-result cap silently truncating a larger queue.
 
 ### 2. Merge and dedupe
 
@@ -55,6 +57,8 @@ Don't rely on `mergeStateStatus` for this — `BLOCKED` doesn't tell you if the 
 ```
 gh api "repos/<owner>/<repo>/compare/master...<headRefName>" --jq '{ahead_by, behind_by}'
 ```
+
+If the PR's `headRepositoryOwner.login` (fetched in step 1) differs from `<owner>` — i.e. the PR comes from a fork — prefix the head ref with that owner instead: `master...<headRepositoryOwner>:<headRefName>`. Using bare `headRefName` for a forked PR compares against a same-named branch in the base repo (or 404s) instead of the fork's actual branch.
 
 URL-encode the branch name (e.g. `#` → `%23`, non-ASCII characters) or the API returns a `404`. `behind_by: 0` means the branch is rebased/up to date with master; `behind_by > 0` means it needs a rebase or merge — report the count.
 

--- a/.claude/skills/review-queue/SKILL.md
+++ b/.claude/skills/review-queue/SKILL.md
@@ -1,0 +1,76 @@
+---
+name: review-queue
+description: List open PRs in philobiblon-ui where the user is requested as a reviewer or is the assignee, showing whether each branch is up to date with master or needs a rebase. Read-only — does not review anything itself. Use when the user asks what they need to review or wants to check their review queue.
+---
+
+Lists the PRs waiting on the current user, so they can decide what to review and in what order. This skill is purely informational: it never reviews anything itself. Once the user picks a PR, run the `review` skill against it manually.
+
+## Process
+
+### 1. Fetch both PR sets
+
+The repo is resolved automatically from `git remote -v`, same as `docs/agents/issue-tracker.md`.
+
+GitHub's search syntax doesn't support a clean OR between `review-requested` and `assignee`, so run two separate queries:
+
+```
+gh pr list --state open --search "review-requested:@me" --json number,title,url,author,updatedAt,mergeStateStatus,isDraft,headRefName,reviewDecision,statusCheckRollup
+gh pr list --state open --assignee "@me" --json number,title,url,author,updatedAt,mergeStateStatus,isDraft,headRefName,reviewDecision,statusCheckRollup
+```
+
+### 2. Merge and dedupe
+
+Combine both result sets by PR `number`. For each PR, track why it showed up: `Review requested`, `Assignee`, or `Both` if it appeared in both lists.
+
+### 3. Empty case
+
+If the merged list is empty, report "no PRs pending" and stop — don't produce an empty table.
+
+### 4. Interpret `mergeStateStatus`
+
+Map each PR's `mergeStateStatus` to a short branch-status label:
+
+- `CLEAN` → up to date with master, ready to review.
+- `BEHIND` → needs a rebase/merge with master before reviewing.
+- `DIRTY` → conflicts.
+- `UNSTABLE` → CI/checks failing.
+- `BLOCKED` → blocked — see step 4b for the specific reason.
+- Anything else → show the raw value as-is.
+
+`mergeStateStatus` only ever holds one value, so a `BLOCKED` PR can *also* be behind master — that fact is hidden unless you check separately (step 4c).
+
+### 4b. Diagnose the `BLOCKED` reason
+
+For any PR whose `mergeStateStatus` is `BLOCKED`, use `reviewDecision` and `statusCheckRollup` (already fetched in step 1) to say why:
+
+- `reviewDecision: REVIEW_REQUIRED` and all `statusCheckRollup` entries `SUCCESS` → "awaiting review"
+- `reviewDecision: CHANGES_REQUESTED` → "changes requested"
+- Any `statusCheckRollup` entry with state other than `SUCCESS` (e.g. `PENDING`, `FAILURE`, `ERROR`) → "checks pending/failing" (name the check if only one is non-passing)
+- If both apply, mention both, e.g. "awaiting review; 1 check pending"
+
+### 4c. Check whether the branch is actually rebased
+
+Don't rely on `mergeStateStatus` for this — `BLOCKED` doesn't tell you if the branch is also behind master. For each PR, compare its `headRefName` against `master` directly:
+
+```
+gh api "repos/<owner>/<repo>/compare/master...<headRefName>" --jq '{ahead_by, behind_by}'
+```
+
+URL-encode the branch name (e.g. `#` → `%23`, non-ASCII characters) or the API returns a `404`. `behind_by: 0` means the branch is rebased/up to date with master; `behind_by > 0` means it needs a rebase or merge — report the count.
+
+### 4d. Surface the CodeRabbit check state
+
+CodeRabbit doesn't leave a formal PR review (`reviews` stays empty) — it posts an automated summary as an issue comment and reports its own progress as a check in `statusCheckRollup` (entry with `context: "CodeRabbit"`). Pull that entry out separately from the generic blocked-reason bucket in step 4b:
+
+- No entry with `context: "CodeRabbit"` → "not run"
+- `state: SUCCESS` → "done"
+- `state: PENDING`/`IN_PROGRESS` → "in progress"
+- `state: FAILURE`/`ERROR` → "failed"
+
+### 5. Present the table
+
+Sort by `updatedAt` ascending (oldest first — these have usually been waiting longest). Columns: PR number, title, author, reason (Review requested / Assignee / Both), days since last update, branch status (from step 4), blocked reason (from step 4b, blank if not blocked), rebased? (from step 4c), CodeRabbit (from step 4d).
+
+### 6. Stop there
+
+Don't call the `review` skill automatically for any PR — the user picks which one to review and does that themselves.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,10 +52,15 @@ Two modules behind an nginx reverse proxy:
 
 ### UI configuration via wiki pages
 
-The frontend reads special Wikibase wiki pages to drive UI behaviour:
-- `Ui_SortedProperties` — display order of claims per table type
-- `Ui_SortedProperties_NewItem` — claim order for new items
-- `Ui_ControlledVocabulary` — autocomplete queries and default values per field
+The frontend reads special Wikibase wiki pages to drive UI behaviour. All three are parsed in `frontend/service/wikibase.service.js` and fetched via `getWikibasePage(pageName)`.
+
+- **`Ui_SortedProperties`** — display order of claims per table type, on existing items. Consumed via `getClaimsOrder(table)`.
+- **`Ui_SortedProperties_NewItem`** — which claims/qualifiers get pre-filled by default when creating a new item of a given table, and in what order. Consumed via `getClaimsOrderForNewItem(table)`, which delegates to `getClaimsOrder(table, pageName)` with the page name overridden. The page name itself is configurable per environment via the `WIKIBASE_NEW_ITEM_PAGE` build arg (defaults to `Ui_SortedProperties_NewItem`, see below and `nuxt.config.ts`).
+- **`Ui_ControlledVocabulary`** — autocomplete queries and default values per field, per table and per bibliography (BETA/BITECA/BITAGAP). Consumed via `getControlledVocabularyConfig(table, bibliography)`.
+
+Both `Ui_SortedProperties` and `Ui_SortedProperties_NewItem` share the same wikitext format, parsed by `parseSortedPropertiesConfig`: one `====<table>====` section per item table, with `* Pxxx` lines listing properties in order and `:: qualifier Pxxx` sub-lines listing that property's qualifier order. `Ui_ControlledVocabulary` uses a different, table-based wikitext format (`==== <table> (...) ====` sections with `| property || bibliographies || default_value || query` rows), parsed by `parseControlledVocabularySections`.
+
+**Implication for new-item defaults:** when a new claim/qualifier needs to be forced onto item creation for a specific table (e.g. adding P799 as a default claim for one table), the correct place to express that is a `====<table>====` entry in `Ui_SortedProperties_NewItem` — not a hardcoded `if (props.table === 'x') { ... }` branch in `frontend/components/item/Create.vue`. Hardcoding per-table property IDs in `getDefaultClaims`/`getCreateDisabledReason` bypasses the wiki-driven config, is easy to get wrong during merges (see the P799/P106 gating regression across PRs #475/#476/#478, where per-table `if` guards were dropped during a merge and silently became unconditional for every table), and requires a code deploy instead of a wiki edit for what should be config-only changes.
 
 ### Item types
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,16 +10,16 @@ We use a lightweight GitHub Flow:
 2. **Open a Pull Request** against `master` as soon as your change is ready for feedback.
 3. **CodeRabbit runs automatically** on every PR as an automated first-pass review. Address its comments.
 4. **At least one approved human review is required** before a PR can be merged — branch protection blocks merging otherwise.
-5. **Merge via squash-merge.** All commits on your branch are squashed into a single commit on `master`, titled after the PR title (e.g. `add P799 with P106 date and comma separator for UNI items (#475)`). Individual commits on your branch don't need to be perfect, but **write your PR title as a good Conventional Commit message** (see below) — squash-merge makes it the permanent history on `master`.
+5. **Merge via squash-merge.** All commits on your branch are squashed into a single commit on `master`, titled after the PR title (e.g. `feat(frontend): add P799 with P106 date and comma separator for UNI items`). Individual commits on your branch don't need to be perfect, but **write your PR title as a good Conventional Commit message** (see below) — squash-merge makes it the permanent history on `master`.
 
 What happens after merge (staging deploy, second review, production tagging) is documented in [docs/README.md's Development Workflow section](docs/README.md#development-workflow) — this file only covers getting your PR merged.
 
 ## Branch naming
 
-Use a short, descriptive branch name prefixed with the type of change, mirroring the Conventional Commit types below:
+Use a short, descriptive branch name prefixed with a short category (for example `feature/`, `fix/`, `chore/`, or `docs/`):
 
 ```
-type/short-description
+category/short-description
 ```
 
 Examples: `feature/date-filter`, `fix/manid-item-creation`, `chore/update-dependencies`, `docs/contributing-guide`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,64 @@
+# Contributing to PhiloBiblon UI
+
+Thanks for contributing. This document covers the git workflow, branch naming, and commit message conventions used in this repo. For environment setup, architecture, and the full CI/CD pipeline, see the links at the bottom — this file only covers the contribution process itself.
+
+## Workflow
+
+We use a lightweight GitHub Flow:
+
+1. **Branch off `master`.** `master` is always deployable — every merge auto-deploys to staging (see [docs/README.md](docs/README.md#development-workflow)), so keep it clean.
+2. **Open a Pull Request** against `master` as soon as your change is ready for feedback.
+3. **CodeRabbit runs automatically** on every PR as an automated first-pass review. Address its comments.
+4. **At least one approved human review is required** before a PR can be merged — branch protection blocks merging otherwise.
+5. **Merge via squash-merge.** All commits on your branch are squashed into a single commit on `master`, titled after the PR title (e.g. `add P799 with P106 date and comma separator for UNI items (#475)`). Individual commits on your branch don't need to be perfect, but **write your PR title as a good Conventional Commit message** (see below) — squash-merge makes it the permanent history on `master`.
+
+What happens after merge (staging deploy, second review, production tagging) is documented in [docs/README.md's Development Workflow section](docs/README.md#development-workflow) — this file only covers getting your PR merged.
+
+## Branch naming
+
+Use a short, descriptive branch name prefixed with the type of change, mirroring the Conventional Commit types below:
+
+```
+type/short-description
+```
+
+Examples: `feature/date-filter`, `fix/manid-item-creation`, `chore/update-dependencies`, `docs/contributing-guide`.
+
+This is a recommended convention going forward, not something currently enforced by tooling.
+
+## Commit messages: Conventional Commits
+
+We're adopting [Conventional Commits](https://www.conventionalcommits.org/) for new commit messages and PR titles. This is a **new convention** — existing history on `master` is a mix of conforming and non-conforming messages — but please follow it going forward, especially for your **PR title**, since squash-merge makes it the permanent commit message on `master`.
+
+Format: `type(scope): short summary`
+
+| Type | Use for |
+|---|---|
+| `feat` | A new feature |
+| `fix` | A bug fix |
+| `docs` | Documentation only changes |
+| `style` | Formatting, whitespace, etc. (no code behavior change) |
+| `refactor` | Code change that neither fixes a bug nor adds a feature |
+| `perf` | Performance improvement |
+| `test` | Adding or correcting tests |
+| `build` | Build system or dependency changes |
+| `ci` | CI/CD configuration changes |
+| `chore` | Other changes that don't modify src or test files |
+
+Scope is typically `frontend` or `backend` (omit it if the change spans both or is repo-wide).
+
+Examples:
+
+```
+feat(frontend): add date range filter to manuscript search
+fix(backend): correct OAuth token refresh timing
+docs: add CONTRIBUTING.md with git workflow and commit conventions
+```
+
+## Setup and technical documentation
+
+- [docs/README.md](docs/README.md) — documentation index, architecture overview, and full development-to-production pipeline
+- [docs/frontend/setup.md](docs/frontend/setup.md) — frontend setup
+- [docs/backend/setup.md](docs/backend/setup.md) — backend setup
+- [docs/cicd.md](docs/cicd.md) — CI/CD workflows and deployment
+- [AGENTS.md](AGENTS.md) — deeper technical/architecture reference (written for AI coding agents, but useful background for any contributor)

--- a/docs/README.md
+++ b/docs/README.md
@@ -160,6 +160,8 @@ cd backend
 
 ## Development Workflow
 
+> Branch naming and commit message conventions are documented in [CONTRIBUTING.md](../CONTRIBUTING.md).
+
 ```mermaid
 flowchart LR
     A[🧑‍💻 Code changes] --> B[🤖 Automated review\nCodeRabbit]

--- a/frontend/service/wikibase.service.js
+++ b/frontend/service/wikibase.service.js
@@ -229,6 +229,10 @@ export class WikibaseService {
                 if (!result[sectionName][biblio]) {
                   result[sectionName][biblio] = {}
                 }
+                if (result[sectionName][biblio][property]) {
+
+                  console.error(`Duplicate entry for property ${property} and bibliography ${biblio} in section ${sectionName}: ${rowMatch}`)
+                }
                 result[sectionName][biblio][property] = {
                   default_value: defaultValue,
                   query


### PR DESCRIPTION
## Summary
- Adds `CONTRIBUTING.md` documenting the git workflow (branch off master, PR, required review + CodeRabbit, squash-merge), branch naming, and the new Conventional Commits convention for commit messages/PR titles.
- Expands `AGENTS.md`'s "UI configuration via wiki pages" section with the wikitext format for `Ui_SortedProperties`/`_NewItem` and `Ui_ControlledVocabulary`, plus a note that new-item claim defaults belong in wiki config, not hardcoded per-table branches in `Create.vue` (see the P799/P106 gating regression across #475/#476/#478).
- Adds a `review-queue` Claude Code skill to list PRs pending review, with branch rebase status, blocked reason, and CodeRabbit check state.
- Fixes `parseControlledVocabularySections` in `frontend/service/wikibase.service.js`: it silently overwrote an entry when the same property+bibliography pair appeared twice within a section (e.g. a section split across multiple wikitables). Now logs a `console.error`, matching the existing error-logging pattern already used for invalid rows in the same function.

## Test plan
- [x] Render `CONTRIBUTING.md` and `docs/README.md` to confirm the cross-links resolve
- [x] Confirm the `review-queue` skill lists PRs as expected via `/review-queue`
- [x] Manually construct a `Ui_ControlledVocabulary`-style wikitext with a duplicated property+bibliography pair across two tables in the same section and confirm the new `console.error` fires

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added contributor guidance for branching, pull requests, review handling, and commit message conventions, plus workflow references.
  * Expanded wiki-driven UI configuration documentation, including parsing guidance for sorted properties and controlled vocabulary pages.
  * Added a new reference describing the review-queue workflow behavior.

* **Bug Fixes**
  * Prevented duplicate controlled-vocabulary entries from silently overwriting existing values; duplicates are now reported.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->