### PR TITLE
fix #306 don't pre-fill date fields with today's date on creation

### DIFF
--- a/frontend/components/item/util/EditDatePickerField.vue
+++ b/frontend/components/item/util/EditDatePickerField.vue
@@ -136,14 +136,18 @@ watch(currentText, (newVal, oldVal) => {
 })
 
 onMounted(() => {
-  const isCreatingWithNoValue = props.mode === 'creation' && props.value === null
-  const initialValue = isCreatingWithNoValue ? today.value : props.value
+  // Only the calendar-based qualifier (P106 Date of P799 Dataset status)
+  // defaults to today's date, since the user normally wants the creation date.
+  // Every other date field stays empty so the gray placeholder
+  // (YYYY, YYYY-MM-DD, …) is shown for manual partial-date entry.
+  const shouldDefaultToToday = props.mode === 'creation' && props.value === null && props.useCalendar
+  const initialValue = shouldDefaultToToday ? today.value : props.value
   currentText.value = initialValue
   consolidatedText.value = initialValue
   if (props.useCalendar) {
     pickerDate.value = parseDate(initialValue)
   }
-  if (isCreatingWithNoValue) {
+  if (shouldDefaultToToday) {
     emit('new-value', initialValue)
   }
 })


### PR DESCRIPTION
## Problem

Issue #306: on the item-creation form, **every** date field was pre-filled with today's date. It should instead show the gray placeholder template (`YYYY, YYYY-MM, YYYY-MM-DD, MM-DD, or DD`) so the user can type a partial date manually — most PhiloBiblon dates fall between 1200 and 1700, so defaulting to the current year is unhelpful.

The exception is **P106 (Date)** as a qualifier of **P799 (Dataset status)**, which uses the calendar popup and *should* default to today, since the user normally wants the creation date.

## Cause

In `frontend/components/item/util/EditDatePickerField.vue`, the `onMounted` hook defaulted to `today.value` for *any* date field in creation mode with no value (`isCreatingWithNoValue`), regardless of the field.

## Fix

Gate the "default to today" behaviour on `props.useCalendar`, which is only `true` for the P106-of-P799 qualifier (see `Time.vue` `useCalendar`). All other date fields stay empty and show the gray placeholder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Date fields now only auto-fill with today’s date in creation mode when the calendar picker is enabled and no value is set.
  * Calendar-based date inputs now initialize to the selected date more reliably, improving the starting view when editing or creating items.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->