### PR TITLE
Add Textual Witness (cnum) search page and left-hand menu entry #381

### DIFF
--- a/frontend/lang/ca.js
+++ b/frontend/lang/ca.js
@@ -61,7 +61,7 @@ export default {
             label: 'Assumpte'
           },
           cnum: {
-            label: 'cnum'
+            label: 'Testimoni textual'
           },
           copid: {
             label: 'copid'
@@ -431,6 +431,16 @@ export default {
         subject: {
           label: 'Matèria',
           hint: ''
+        }
+      },
+      cnum: {
+        witness_of: {
+          label: 'Testimoni de',
+          hint: 'Cerqueu per l\'obra (texid) de la qual aquest és un testimoni textual.'
+        },
+        part_of: {
+          label: 'Part de',
+          hint: 'Cerqueu pel manuscrit o l\'edició (manid) que conté aquest testimoni textual.'
         }
       }
     },

--- a/frontend/lang/en.js
+++ b/frontend/lang/en.js
@@ -61,7 +61,7 @@ export default {
             label: 'Subject'
           },
           cnum: {
-            label: 'cnum'
+            label: 'Textual Witness'
           },
           copid: {
             label: 'copid'
@@ -433,6 +433,16 @@ export default {
         subject: {
           label: 'Subject',
           hint: ''
+        }
+      },
+      cnum: {
+        witness_of: {
+          label: 'Witness of',
+          hint: 'Search by the work (texid) of which this is a textual witness.'
+        },
+        part_of: {
+          label: 'Part of',
+          hint: 'Search by the manuscript or edition (manid) that contains this textual witness.'
         }
       }
     },

--- a/frontend/lang/es.js
+++ b/frontend/lang/es.js
@@ -61,7 +61,7 @@ export default {
             label: 'Asunto'
           },
           cnum: {
-            label: 'cnum'
+            label: 'Testimonio textual'
           },
           copid: {
             label: 'copid'
@@ -431,6 +431,16 @@ export default {
         subject: {
           label: 'Materia',
           hint: ''
+        }
+      },
+      cnum: {
+        witness_of: {
+          label: 'Testimonio de',
+          hint: 'Busque por la obra (texid) de la que este es un testimonio textual.'
+        },
+        part_of: {
+          label: 'Parte de',
+          hint: 'Busque por el manuscrito o la edición (manid) que contiene este testimonio textual.'
         }
       }
     },

--- a/frontend/lang/gl.js
+++ b/frontend/lang/gl.js
@@ -61,7 +61,7 @@ export default {
             label: 'Asunto'
           },
           cnum: {
-            label: 'cnum'
+            label: 'Testemuño textual'
           },
           copid: {
             label: 'copid'
@@ -431,6 +431,16 @@ export default {
         subject: {
           label: 'Materia',
           hint: ''
+        }
+      },
+      cnum: {
+        witness_of: {
+          label: 'Testemuño de',
+          hint: 'Busca pola obra (texid) da que este é un testemuño textual.'
+        },
+        part_of: {
+          label: 'Parte de',
+          hint: 'Busca polo manuscrito ou a edición (manid) que contén este testemuño textual.'
         }
       }
     },

--- a/frontend/lang/pt.js
+++ b/frontend/lang/pt.js
@@ -62,7 +62,7 @@ export default {
             label: 'Assunto'
           },
           cnum: {
-            label: 'cnum'
+            label: 'Testemunha textual'
           },
           copid: {
             label: 'copid'
@@ -431,6 +431,16 @@ export default {
         subject: {
           label: 'Assuntos',
           hint: ''
+        }
+      },
+      cnum: {
+        witness_of: {
+          label: 'Testemunha de',
+          hint: 'Pesquise pela obra (texid) da qual esta é uma testemunha textual.'
+        },
+        part_of: {
+          label: 'Parte de',
+          hint: 'Pesquise pelo manuscrito ou edição (manid) que contém esta testemunha textual.'
         }
       }
     },

--- a/frontend/layouts/default.vue
+++ b/frontend/layouts/default.vue
@@ -133,7 +133,8 @@ const searchItems = [
   { path: '/search/bibid/query', label: 'menu.item.search.item.bibid.label' },
   { path: '/search/manid/query', label: 'menu.item.search.item.manid.label' },
   { path: '/search/geoid/query', label: 'menu.item.search.item.geoid.label' },
-  { path: '/search/subid/query', label: 'menu.item.search.item.subid.label' }
+  { path: '/search/subid/query', label: 'menu.item.search.item.subid.label' },
+  { path: '/search/cnum/query', label: 'menu.item.search.item.cnum.label' }
 ]
 const createItems = [
   { path: '/item/texid/create', label: 'menu.item.create.item.texid.label' },

--- a/frontend/pages/search/cnum/query.vue
+++ b/frontend/pages/search/cnum/query.vue
@@ -1,0 +1,392 @@
+<template>
+  <search-base
+    table="cnum"
+    :form-definition="form"
+    :breadcrumb-items="breadcrumb_items"
+  />
+</template>
+
+<script setup>
+import { useI18n } from 'vue-i18n'
+
+const { t } = useI18n()
+
+const breadcrumb_items = [
+  { title: t('menu.item.search.label'), disabled: true },
+  { title: t('menu.item.search.item.cnum.label'), disabled: true }
+]
+
+const form = {
+        section: [
+          'primary',
+          'advanced'
+        ],
+        input: {
+          group: {
+            permanent: true,
+            value: 'ALL',
+            disabled: false
+          },
+          bitagap_group: {
+            permanent: true,
+            value: 'ALL',
+            disabled: false
+          },
+          simple_search: {
+            active: true,
+            section: 'primary',
+            label: 'search.form.common.simple_search.label',
+            hint: 'search.form.common.simple_search.hint',
+            type: 'autocomplete',
+            value: {},
+            visible: true,
+            disabled: false,
+            autocomplete: {
+              query:
+              `
+              SELECT DISTINCT ?item ?label ?desc
+              WHERE {
+                ?item wdt:P476 ?pbid .
+                FILTER regex(?pbid, '{{database}} {{table}} ') .
+                {{bitagapGroupFilter}}
+                {
+                  ?item rdfs:label ?labelObj .
+                  {{langFilter}}
+                }
+                UNION
+                {
+                  ?item skos:altLabel ?labelObj .
+                  {{langFilter}}
+                }
+                {{descLangFilter}}
+              }
+              `,
+              allowFreeText: true
+            }
+          },
+          q_number: {
+            active: true,
+            section: 'primary',
+            label: 'search.form.common.q_number.label',
+            hint: 'search.form.common.q_number.hint',
+            type: 'text',
+            value: '',
+            visible: true,
+            disabled: false
+          },
+          philobiblon_id: {
+            active: true,
+            section: 'primary',
+            label: 'search.form.common.philobiblon_id.label',
+            hint: 'search.form.common.philobiblon_id.hint',
+            type: 'text',
+            value: '',
+            visible: true,
+            disabled: false
+          },
+          witness_of: {
+            active: true,
+            section: 'primary',
+            label: 'search.form.cnum.witness_of.label',
+            hint: 'search.form.cnum.witness_of.hint',
+            type: 'autocomplete',
+            value: {},
+            visible: true,
+            disabled: false,
+            autocomplete: {
+              query:
+              `
+              SELECT DISTINCT ?target_item ?label ?desc WHERE {
+                {
+                  SELECT DISTINCT ?target_item WHERE {
+                    ?item wdt:P476 ?pbid .
+                    FILTER regex(?pbid, '{{database}} {{table}} ') .
+                    {{bitagapGroupFilter}}
+                    ?item wdt:P590 ?target_item .
+                    ?target_item wdt:P476 ?target_pbid .
+                    FILTER regex(?target_pbid, '(.*) texid ') .
+                  }
+                }
+                {{targetItemLangGroupPattern}}
+              }
+              `
+            }
+          },
+          part_of: {
+            active: true,
+            section: 'primary',
+            label: 'search.form.cnum.part_of.label',
+            hint: 'search.form.cnum.part_of.hint',
+            type: 'autocomplete',
+            value: {},
+            visible: true,
+            disabled: false,
+            autocomplete: {
+              query:
+              `
+              SELECT DISTINCT ?target_item ?label ?desc WHERE {
+                {
+                  SELECT DISTINCT ?target_item WHERE {
+                    ?item wdt:P476 ?pbid .
+                    FILTER regex(?pbid, '{{database}} {{table}} ') .
+                    {{bitagapGroupFilter}}
+                    ?item wdt:P8 ?target_item .
+                    ?target_item wdt:P476 ?target_pbid .
+                    FILTER regex(?target_pbid, '(.*) manid ') .
+                  }
+                }
+                {{targetItemLangGroupPattern}}
+              }
+              `
+            }
+          },
+          author: {
+            active: true,
+            section: 'primary',
+            label: 'search.form.texid.author.label',
+            hint: 'search.form.texid.author.hint',
+            type: 'autocomplete',
+            value: {},
+            visible: true,
+            disabled: false,
+            autocomplete: {
+              query:
+              `
+              SELECT DISTINCT ?target_item ?label ?desc {
+                {
+                  SELECT DISTINCT ?target_item {
+                    ?item wdt:P476 ?pbid .
+                    FILTER regex(?pbid, '{{database}} {{table}} ') .
+                    {{bitagapGroupFilter}}
+                    ?item wdt:P21 ?target_item .
+                  }
+                }
+                {{targetItemLangGroupPattern}}
+              }
+              `
+            }
+          },
+          incipit: {
+            active: true,
+            section: 'primary',
+            label: 'search.form.texid.incipit.label',
+            hint: 'search.form.texid.incipit.hint',
+            type: 'autocomplete',
+            value: {},
+            visible: true,
+            disabled: false,
+            autocomplete: {
+              query:
+              `
+              SELECT DISTINCT ?label {
+                ?item wdt:P476 ?pbid .
+                FILTER regex(?pbid, '{{database}} {{table}} ') .
+                {{bitagapGroupFilter}}
+                ?item p:P543 ?statement .
+                ?statement pq:P70 ?label
+              }
+              `
+            }
+          },
+          explicit: {
+            active: true,
+            section: 'primary',
+            label: 'search.form.texid.explicit.label',
+            hint: 'search.form.texid.explicit.hint',
+            type: 'autocomplete',
+            value: {},
+            visible: true,
+            disabled: false,
+            autocomplete: {
+              query:
+              `
+              SELECT DISTINCT ?label {
+                ?item wdt:P476 ?pbid .
+                FILTER regex(?pbid, '{{database}} {{table}} ') .
+                {{bitagapGroupFilter}}
+                ?item p:P543 ?statement .
+                ?statement pq:P602 ?label
+              }
+              `
+            }
+          },
+          associated_person: {
+            active: true,
+            section: 'primary',
+            label: 'search.form.texid.associated_person.label',
+            hint: 'search.form.common.personal_name.hint',
+            type: 'autocomplete',
+            value: {},
+            visible: true,
+            disabled: false,
+            autocomplete: {
+              query:
+              `
+              SELECT DISTINCT ?target_item ?label ?desc {
+                {
+                  SELECT DISTINCT ?target_item {
+                    ?item wdt:P476 ?pbid .
+                    FILTER regex(?pbid, '{{database}} {{table}} ') .
+                    {{bitagapGroupFilter}}
+                    ?item wdt:P703 ?target_item .
+                  }
+                }
+                {{targetItemLangGroupPattern}}
+              }
+              `
+            }
+          },
+          place_composition: {
+            active: true,
+            section: 'primary',
+            label: 'search.form.texid.place_composition.label',
+            hint: 'search.form.common.place.hint',
+            type: 'autocomplete',
+            value: {},
+            visible: true,
+            disabled: false,
+            autocomplete: {
+              query:
+              `
+              SELECT DISTINCT ?target_item ?label {
+                {
+                  SELECT DISTINCT ?target_item WHERE {
+                    ?item wdt:P476 ?pbid .
+                    FILTER regex(?pbid, '{{database}} {{table}} ') .
+                    {{bitagapGroupFilter}}
+                    ?item p:P137 ?history_statement .
+                    ?history_statement pq:P47 ?target_item .
+                    ?target_item wdt:P476 ?target_item_pbid .
+                    FILTER regex(?target_item_pbid, '(.*) geoid ') .
+                  }
+                }
+                {{targetItemLangGroupPattern}}
+              }
+              `
+            }
+          },
+          date_composition: {
+            active: true,
+            section: 'primary',
+            label: 'search.form.texid.date_composition.label',
+            hint: 'search.form.texid.date_composition.hint',
+            type: 'date',
+            value: {},
+            visible: true,
+            disabled: false
+          },
+          type: {
+            active: true,
+            section: 'advanced',
+            label: 'search.form.texid.type.label',
+            hint: 'search.form.texid.type.hint',
+            type: 'autocomplete',
+            value: {},
+            visible: true,
+            disabled: false,
+            autocomplete: {
+              query:
+              `
+              SELECT DISTINCT ?target_item ?label ?desc {
+                {
+                  SELECT DISTINCT ?target_item WHERE {
+                    ?item wdt:P476 ?pbid .
+                    FILTER regex(?pbid, '{{database}} {{table}} ') .
+                    {{bitagapGroupFilter}}
+                    ?item p:P121 ?statement .
+                    ?statement pq:P700 ?target_item .
+                  }
+                }
+                {{targetItemLangGroupPattern}}
+              }
+              `
+            }
+          },
+          language: {
+            active: true,
+            section: 'advanced',
+            label: 'search.form.texid.language.label',
+            hint: 'search.form.texid.language.hint',
+            type: 'autocomplete',
+            value: {},
+            visible: true,
+            disabled: false,
+            autocomplete: {
+              query:
+              `
+              SELECT DISTINCT ?target_item ?label ?desc {
+                {
+                  SELECT DISTINCT ?target_item {
+                    ?item wdt:P476 ?pbid .
+                    FILTER regex(?pbid, '{{database}} {{table}} ') .
+                    {{bitagapGroupFilter}}
+                    ?item wdt:P18 ?target_item .
+                  }
+                }
+                {{targetItemLangGroupPattern}}
+              }
+              `
+            }
+          },
+          poetic_form: {
+            active: true,
+            section: 'advanced',
+            label: 'search.form.texid.poetic_form.label',
+            hint: 'search.form.texid.poetic_form.hint',
+            type: 'autocomplete',
+            value: {},
+            visible: true,
+            disabled: false,
+            autocomplete: {
+              query:
+              `
+              SELECT DISTINCT ?label {
+                ?item wdt:P476 ?item_pbid .
+                FILTER regex(?item_pbid, '{{database}} {{table}} ') .
+                {{bitagapGroupFilter}}
+                ?item wdt:P781 ?label
+              }
+              `
+            }
+          },
+          subject: {
+            active: true,
+            section: 'advanced',
+            label: 'search.form.common.subject.label',
+            hint: 'search.form.common.subject.hint',
+            type: 'autocomplete',
+            value: {},
+            visible: true,
+            disabled: false,
+            autocomplete: {
+              query:
+              `
+              SELECT DISTINCT ?target_item ?label ?desc WHERE {
+                {
+                  SELECT DISTINCT ?target_item WHERE {
+                    ?item wdt:P476 ?pbid .
+                    FILTER regex(?pbid, '{{database}} {{table}} ')
+                    {{bitagapGroupSubjectFilter}}
+                    BIND ( wdt:P243 as ?property)
+                    ?item ?property ?target_item .
+                  }
+                }
+                {{targetItemLangGroupPattern}}
+              }
+              `
+            }
+          },
+          search_type: {
+            permanent: true,
+            value: true,
+            disabled: false
+          }
+        }
+      }
+</script>
+
+<style scoped>
+.search {
+  width: 100% !important
+}
+</style>


### PR DESCRIPTION
Adds a new search page for textual witnesses (cnum) and registers it in the left-hand navigation menu.

Changes:
- frontend/layouts/default.vue — added cnum entry to searchItems so it appears in the Search group of the left menu
- frontend/pages/search/cnum/query.vue — new search page with fields: simple search, Q number, PhiloBiblon ID, witness of (P590 → texid), part of (P8 → manid), author (P21), incipit, explicit, associated person (P703), place of composition, date of composition, type, language (P18), poetic form (P781), and subject
- frontend/lang/{en,ca,es,gl,pt}.js — updated menu label for cnum from 'cnum' to the localized name; added search.form.cnum.witness_of and search.form.cnum.part_of translation keys in all 5 languages

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new search option for textual witness records, including a dedicated search page with multiple filters and autocomplete suggestions.
  * Expanded the search menu so the new textual witness search is now available alongside existing search options.

* **Localization**
  * Improved translations in Catalan, English, Spanish, Galician, and Portuguese.
  * Replaced placeholder labels with user-friendly text and added missing field labels and hints for the new search filters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->