### PR TITLE
Add Additional Copy (copid) search page and left-hand menu entry #382

### DIFF
--- a/frontend/lang/ca.js
+++ b/frontend/lang/ca.js
@@ -64,7 +64,7 @@ export default {
             label: 'cnum'
           },
           copid: {
-            label: 'copid'
+            label: 'Exemplar addicional'
           }
         }
       },
@@ -431,6 +431,12 @@ export default {
         subject: {
           label: 'Matèria',
           hint: ''
+        }
+      },
+      copid: {
+        edition: {
+          label: 'Edició',
+          hint: 'Cerqueu per l\'edició impresa (MsEd) de la qual aquest és un exemplar addicional.'
         }
       }
     },

--- a/frontend/lang/en.js
+++ b/frontend/lang/en.js
@@ -64,7 +64,7 @@ export default {
             label: 'cnum'
           },
           copid: {
-            label: 'copid'
+            label: 'Additional Copy'
           }
         }
       },
@@ -433,6 +433,12 @@ export default {
         subject: {
           label: 'Subject',
           hint: ''
+        }
+      },
+      copid: {
+        edition: {
+          label: 'Edition',
+          hint: 'Search by the printed edition (MsEd) of which this is an additional copy.'
         }
       }
     },

--- a/frontend/lang/es.js
+++ b/frontend/lang/es.js
@@ -64,7 +64,7 @@ export default {
             label: 'cnum'
           },
           copid: {
-            label: 'copid'
+            label: 'Ejemplar adicional'
           }
         }
       },
@@ -431,6 +431,12 @@ export default {
         subject: {
           label: 'Materia',
           hint: ''
+        }
+      },
+      copid: {
+        edition: {
+          label: 'Edición',
+          hint: 'Busque por la edición impresa (MsEd) de la que este es un ejemplar adicional.'
         }
       }
     },

--- a/frontend/lang/gl.js
+++ b/frontend/lang/gl.js
@@ -64,7 +64,7 @@ export default {
             label: 'cnum'
           },
           copid: {
-            label: 'copid'
+            label: 'Copia adicional'
           }
         }
       },
@@ -431,6 +431,12 @@ export default {
         subject: {
           label: 'Materia',
           hint: ''
+        }
+      },
+      copid: {
+        edition: {
+          label: 'Edición',
+          hint: 'Busca pola edición impresa (MsEd) da que este é unha copia adicional.'
         }
       }
     },

--- a/frontend/lang/pt.js
+++ b/frontend/lang/pt.js
@@ -65,7 +65,7 @@ export default {
             label: 'cnum'
           },
           copid: {
-            label: 'copid'
+            label: 'Cópia adicional'
           }
         }
       },
@@ -431,6 +431,12 @@ export default {
         subject: {
           label: 'Assuntos',
           hint: ''
+        }
+      },
+      copid: {
+        edition: {
+          label: 'Edição',
+          hint: 'Pesquise pela edição impressa (MsEd) da qual esta é uma cópia adicional.'
         }
       }
     },

--- a/frontend/layouts/default.vue
+++ b/frontend/layouts/default.vue
@@ -133,7 +133,8 @@ const searchItems = [
   { path: '/search/bibid/query', label: 'menu.item.search.item.bibid.label' },
   { path: '/search/manid/query', label: 'menu.item.search.item.manid.label' },
   { path: '/search/geoid/query', label: 'menu.item.search.item.geoid.label' },
-  { path: '/search/subid/query', label: 'menu.item.search.item.subid.label' }
+  { path: '/search/subid/query', label: 'menu.item.search.item.subid.label' },
+  { path: '/search/copid/query', label: 'menu.item.search.item.copid.label' }
 ]
 const createItems = [
   { path: '/item/texid/create', label: 'menu.item.create.item.texid.label' },

--- a/frontend/pages/search/copid/query.vue
+++ b/frontend/pages/search/copid/query.vue
@@ -1,0 +1,381 @@
+<template>
+  <search-base
+    table="copid"
+    :form-definition="form"
+    :breadcrumb-items="breadcrumb_items"
+  />
+</template>
+
+<script setup>
+import { useI18n } from 'vue-i18n'
+
+const { t } = useI18n()
+
+const breadcrumb_items = [
+  { title: t('menu.item.search.label'), disabled: true },
+  { title: t('menu.item.search.item.copid.label'), disabled: true }
+]
+
+const form = {
+        section: [
+          'primary'
+        ],
+        input: {
+          group: {
+            permanent: true,
+            value: 'ALL',
+            disabled: false
+          },
+          bitagap_group: {
+            permanent: true,
+            value: 'ALL',
+            disabled: false
+          },
+          simple_search: {
+            active: true,
+            section: 'primary',
+            label: 'search.form.common.simple_search.label',
+            hint: 'search.form.common.simple_search.hint',
+            type: 'autocomplete',
+            value: {},
+            visible: true,
+            disabled: false,
+            autocomplete: {
+              query:
+              `
+              SELECT DISTINCT ?item ?label ?desc
+              WHERE {
+                ?item wdt:P476 ?pbid .
+                FILTER regex(?pbid, '{{database}} {{table}} ') .
+                {{bitagapGroupFilter}}
+                {
+                  ?item rdfs:label ?labelObj .
+                }
+                UNION
+                {
+                  ?item skos:altLabel ?labelObj .
+                }
+                {{langFilter}}
+                {{descLangFilter}}
+              }
+              `,
+              allowFreeText: true
+            }
+          },
+          q_number: {
+            active: true,
+            section: 'primary',
+            label: 'search.form.common.q_number.label',
+            hint: 'search.form.common.q_number.hint',
+            type: 'text',
+            value: '',
+            visible: true,
+            disabled: false
+          },
+          philobiblon_id: {
+            active: true,
+            section: 'primary',
+            label: 'search.form.common.philobiblon_id.label',
+            hint: 'search.form.common.philobiblon_id.hint',
+            type: 'text',
+            value: '',
+            visible: true,
+            disabled: false
+          },
+          edition: {
+            active: true,
+            section: 'primary',
+            label: 'search.form.copid.edition.label',
+            hint: 'search.form.copid.edition.hint',
+            type: 'autocomplete',
+            value: {},
+            visible: true,
+            disabled: false,
+            autocomplete: {
+              query:
+              `
+              SELECT DISTINCT ?target_item ?label ?desc WHERE {
+                {
+                  SELECT DISTINCT ?target_item WHERE {
+                    ?item wdt:P476 ?pbid .
+                    FILTER regex(?pbid, '{{database}} {{table}} ') .
+                    {{bitagapGroupFilter}}
+                    ?item wdt:P839 ?target_item .
+                    ?target_item wdt:P476 ?target_pbid .
+                    FILTER regex(?target_pbid, '(.*) manid ') .
+                  }
+                }
+                {{targetItemLangGroupPattern}}
+              }
+              `
+            }
+          },
+          library: {
+            active: true,
+            section: 'primary',
+            label: 'search.form.manid.library.label',
+            hint: 'search.form.manid.library.hint',
+            type: 'autocomplete',
+            value: {},
+            visible: true,
+            disabled: false,
+            autocomplete: {
+              query:
+              `
+              SELECT DISTINCT ?target_item ?label ?desc WHERE {
+                {
+                  SELECT DISTINCT ?target_item WHERE {
+                    ?item wdt:P476 ?pbid .
+                    FILTER regex(?pbid, '{{database}} {{table}} ') .
+                    {{bitagapGroupFilter}}
+                    ?item wdt:P329 ?target_item .
+                  }
+                }
+                {{targetItemLangGroupPattern}}
+              }
+              `
+            }
+          },
+          collection: {
+            active: true,
+            section: 'primary',
+            label: 'search.form.manid.collection.label',
+            hint: 'search.form.manid.collection.hint',
+            type: 'autocomplete',
+            value: {},
+            visible: true,
+            disabled: false,
+            autocomplete: {
+              allowFreeText: true,
+              query:
+              `
+              SELECT DISTINCT ?label WHERE {
+                ?item wdt:P476 ?pbid .
+                FILTER regex(?pbid, '{{database}} {{table}} ') .
+                {{bitagapGroupFilter}}
+                ?item p:P329 ?library_stmt .
+                ?library_stmt pq:P1054 ?label .
+              }
+              `
+            }
+          },
+          call_number: {
+            active: true,
+            section: 'primary',
+            label: 'search.form.manid.call_number.label',
+            hint: 'search.form.manid.call_number.hint',
+            type: 'autocomplete',
+            value: {},
+            visible: true,
+            disabled: false,
+            autocomplete: {
+              query:
+              `
+              SELECT DISTINCT ?label WHERE {
+                ?item wdt:P476 ?pbid .
+                FILTER regex(?pbid, '{{database}} {{table}} ') .
+                {{bitagapGroupFilter}}
+                ?item p:P329 ?library_stmt .
+                {
+                  ?library_stmt pq:P10 ?label
+                }
+                UNION
+                {
+                  ?library_stmt pq:P30 ?label
+                }
+              }
+              `
+            }
+          },
+          previous_owner: {
+            active: true,
+            section: 'primary',
+            label: 'search.form.manid.previous_owner.label',
+            hint: 'search.form.manid.previous_owner.hint',
+            type: 'autocomplete',
+            value: {},
+            visible: true,
+            disabled: false,
+            autocomplete: {
+              query:
+              `
+              SELECT DISTINCT ?target_item ?label ?desc WHERE {
+                {
+                  SELECT DISTINCT ?target_item WHERE {
+                    ?item wdt:P476 ?pbid .
+                    FILTER regex(?pbid, '{{database}} {{table}} ') .
+                    {{bitagapGroupFilter}}
+                    ?item wdt:P229 ?target_item .
+                  }
+                }
+                {{targetItemLangGroupPattern}}
+              }
+              `
+            }
+          },
+          associated_person: {
+            active: true,
+            section: 'primary',
+            label: 'search.form.manid.associated_person.label',
+            hint: 'search.form.manid.associated_person.hint',
+            type: 'autocomplete',
+            value: {},
+            visible: true,
+            disabled: false,
+            autocomplete: {
+              query:
+              `
+              SELECT DISTINCT ?target_item ?label ?desc WHERE {
+                {
+                  SELECT DISTINCT ?target_item WHERE {
+                    ?item wdt:P476 ?pbid .
+                    FILTER regex(?pbid, '{{database}} {{table}} ') .
+                    {{bitagapGroupFilter}}
+                    ?item wdt:P703 ?target_item .
+                  }
+                }
+                {{targetItemLangGroupPattern}}
+              }
+              `
+            }
+          },
+          writing_surface: {
+            active: true,
+            section: 'primary',
+            label: 'search.form.manid.writing_surface.label',
+            hint: 'search.form.manid.writing_surface.hint',
+            type: 'autocomplete',
+            value: {},
+            visible: true,
+            disabled: false,
+            autocomplete: {
+              query:
+              `
+              SELECT DISTINCT ?target_item ?label ?desc WHERE {
+                {
+                  SELECT DISTINCT ?target_item WHERE {
+                    ?item wdt:P476 ?pbid .
+                    FILTER regex(?pbid, '{{database}} {{table}} ') .
+                    {{bitagapGroupFilter}}
+                    ?item wdt:P480 ?target_item .
+                  }
+                }
+                {{targetItemLangGroupPattern}}
+              }
+              `
+            }
+          },
+          binding: {
+            active: true,
+            section: 'primary',
+            label: 'search.form.manid.binding.label',
+            hint: 'search.form.manid.binding.hint',
+            type: 'autocomplete',
+            value: {},
+            visible: true,
+            disabled: false,
+            autocomplete: {
+              query:
+              `
+              SELECT DISTINCT ?label WHERE {
+                ?item wdt:P476 ?pbid .
+                FILTER regex(?pbid, '{{database}} {{table}} ') .
+                {{bitagapGroupFilter}}
+                ?item wdt:P800 ?label .
+              }
+              `
+            }
+          },
+          watermark: {
+            active: true,
+            section: 'primary',
+            label: 'search.form.manid.watermark.label',
+            hint: 'search.form.manid.watermark.hint',
+            type: 'autocomplete',
+            value: {},
+            visible: true,
+            disabled: false,
+            autocomplete: {
+              query:
+              `
+              SELECT DISTINCT ?target_item ?label ?desc WHERE {
+                {
+                  SELECT DISTINCT ?target_item WHERE {
+                    ?item wdt:P476 ?pbid .
+                    FILTER regex(?pbid, '{{database}} {{table}} ') .
+                    {{bitagapGroupFilter}}
+                    ?item wdt:P749 ?target_item .
+                  }
+                }
+                {{targetItemLangGroupPattern}}
+              }
+              `
+            }
+          },
+          graphic_feature: {
+            active: true,
+            section: 'primary',
+            label: 'search.form.manid.graphic_feature.label',
+            hint: 'search.form.manid.graphic_feature.hint',
+            type: 'autocomplete',
+            value: {},
+            visible: true,
+            disabled: false,
+            autocomplete: {
+              query:
+              `
+              SELECT DISTINCT ?target_item ?label ?desc WHERE {
+                {
+                  SELECT DISTINCT ?target_item WHERE {
+                    ?item wdt:P476 ?pbid .
+                    FILTER regex(?pbid, '{{database}} {{table}} ') .
+                    {{bitagapGroupFilter}}
+                    ?item wdt:P801 ?target_item .
+                  }
+                }
+                {{targetItemLangGroupPattern}}
+              }
+              `
+            }
+          },
+          subject: {
+            active: true,
+            section: 'primary',
+            label: 'search.form.common.subject.label',
+            hint: 'search.form.common.subject.hint',
+            type: 'autocomplete',
+            value: {},
+            visible: true,
+            disabled: false,
+            autocomplete: {
+              query:
+              `
+              SELECT DISTINCT ?target_item ?label ?desc WHERE {
+                {
+                  SELECT DISTINCT ?target_item WHERE {
+                    ?item wdt:P476 ?pbid .
+                    FILTER regex(?pbid, '{{database}} {{table}} ')
+                    {{bitagapGroupSubjectFilter}}
+                    BIND ( wdt:P243 as ?property)
+                    ?item ?property ?target_item .
+                  }
+                }
+                {{targetItemLangGroupPattern}}
+              }
+              `
+            }
+          },
+          search_type: {
+            permanent: true,
+            value: true,
+            disabled: false
+          }
+        }
+      }
+</script>
+
+<style scoped>
+.search {
+  width: 100% !important
+}
+</style>


### PR DESCRIPTION
Adds a new search page for additional copies (copid) and registers it in the left-hand navigation menu, mirroring the existing copid option in Create Item.

Changes:
- frontend/pages/search/copid/query.vue — new search page with all fields on a single section: simple search, Q number, PhiloBiblon ID, edition (P839 → manid, new field), library (P329), collection, inventory position (call_number), previous owner (P229), associated person (P703), writing surface (P480), binding (P800), watermark (P749), graphic feature (P801), and subject. Fields not applicable to additional copies (dates, place of production, scribe/printer, collation, font, etc.) are excluded per the issue spec.
- frontend/layouts/default.vue — added copid entry to searchItems so it appears in the Search group of the left menu
- frontend/lang/{en,ca,es,gl,pt}.js — updated menu label for copid from 'copid' to the localized name; added search.form.copid.edition translation key (Edition / Edició / Edición / Edición / Edição) in all 5 languages

Resolves #382