### PR TITLE
fix #393 don't block MANID creation on empty default qualifiers

### DIFF
--- a/frontend/components/item/Create.vue
+++ b/frontend/components/item/Create.vue
@@ -158,11 +158,17 @@ function getCreateDisabledReason () {
 
       if (propKey !== 'P2') {
         for (const [qualifierKey, qualifierVal] of Object.entries(item.qualifiers || {})) {
+          // Empty qualifiers are dropped by cleanClaims before saving, so they
+          // must not block creation. This is what happens with the default
+          // empty qualifiers pre-filled on a required claim (e.g. P10/P805 on
+          // P329 for manid): leaving them blank should be allowed instead of
+          // forcing the user to fill or delete each line.
+          const hasValue = qualifierVal != null && qualifierVal !== '' && qualifierVal !== 'null'
+          if (!hasValue) {
+            continue
+          }
           if (!qualifierKey || qualifierKey === 'null') {
             return t('messages.error.inputs.qualifier_key_missing', { claimLabel, propertyLabel })
-          }
-          if (!qualifierVal || qualifierVal === 'null') {
-            return t('messages.error.inputs.qualifier_value_missing', { claimLabel, propertyLabel })
           }
         }
       }

--- a/frontend/lang/ca.js
+++ b/frontend/lang/ca.js
@@ -606,7 +606,6 @@ export default {
         initial_claims: 'Les afirmacions s\'estan carregant',
         claim_value_missing: 'Si us plau, ompliu el valor de l\'afirmació per a "{propertyLabel}"',
         qualifier_key_missing: 'Falta una propietat de qualificador a l\'afirmació "{claimLabel}" per a "{propertyLabel}"',
-        qualifier_value_missing: 'Falta el valor d\'algun qualificador a l\'afirmació "{claimLabel}" per a "{propertyLabel}"',
         incomplete_date: 'Si us plau, ompliu una data completa (any, mes i dia) per al qualificador "{propertyLabel}"'
       },
       creation: {

--- a/frontend/lang/en.js
+++ b/frontend/lang/en.js
@@ -608,7 +608,6 @@ export default {
         initial_claims: 'Claims are still loading',
         claim_value_missing: 'Please fill in the claim value for "{propertyLabel}"',
         qualifier_key_missing: 'A qualifier property is missing in the claim "{claimLabel}" for "{propertyLabel}"',
-        qualifier_value_missing: 'Some qualifier(s) value are missing in the claim "{claimLabel}" for "{propertyLabel}"',
         incomplete_date: 'Please fill in a complete date (year, month and day) for the "{propertyLabel}" qualifier'
       },
       creation: {

--- a/frontend/lang/es.js
+++ b/frontend/lang/es.js
@@ -606,7 +606,6 @@ export default {
         initial_claims: 'Los enunciados todavía se están cargando',
         claim_value_missing: 'Por favor, rellena el valor del enunciado para "{propertyLabel}"',
         qualifier_key_missing: 'Falta una propiedad calificadora en el enunciado "{claimLabel}" para "{propertyLabel}"',
-        qualifier_value_missing: 'Falta el valor de algún calificador en el enunciado "{claimLabel}" para "{propertyLabel}"',
         incomplete_date: 'Por favor, introduce una fecha completa (año, mes y día) para el calificador "{propertyLabel}"'
       },
       creation: {

--- a/frontend/lang/gl.js
+++ b/frontend/lang/gl.js
@@ -606,7 +606,6 @@ export default {
         initial_claims: 'Os enunciados aínda se están cargando',
         claim_value_missing: 'Por favor, enche o valor do enunciado para "{propertyLabel}"',
         qualifier_key_missing: 'Falta unha propiedade cualificadora no enunciado "{claimLabel}" para "{propertyLabel}"',
-        qualifier_value_missing: 'Falta o valor dalgún cualificador no enunciado "{claimLabel}" para "{propertyLabel}"',
         incomplete_date: 'Por favor, enche unha data completa (ano, mes e día) para o cualificador "{propertyLabel}"'
       },
       creation: {

--- a/frontend/lang/pt.js
+++ b/frontend/lang/pt.js
@@ -606,7 +606,6 @@ export default {
         initial_claims: 'Os enunciados ainda estão a carregar',
         claim_value_missing: 'Por favor, preencha o valor do enunciado para "{propertyLabel}"',
         qualifier_key_missing: 'Falta uma propriedade qualificadora no enunciado "{claimLabel}" para "{propertyLabel}"',
-        qualifier_value_missing: 'Falta o valor de algum qualificador no enunciado "{claimLabel}" para "{propertyLabel}"',
         incomplete_date: 'Por favor, preencha uma data completa (ano, mês e dia) para o qualificador "{propertyLabel}"'
       },
       creation: {


### PR DESCRIPTION
## Issue

#393 — last comment (2026-06-29), MANID (manid) item creation. Two problems were reported:

1. **Creation blocked by an empty qualifier.** Creating a MAN failed with an error asking for a qualifier of P329 (Present holding); the missing one was P10 (Shelfmark). The user had to delete the empty Shelfmark line to create the record.
2. **Shelfmark not added to the label.** When P10 was filled, it wasn't reflected in the auto-generated label.

## What this PR changes

**Problem 1 — fixed here.** The new-item form pre-fills the required P329 claim with default *empty* qualifiers (P10 Shelfmark, P805 Barcode, from `Ui_SortedProperties_NewItem`). `getCreateDisabledReason` flagged any empty qualifier value as `qualifier_value_missing`, disabling CREATE until the user filled or deleted each blank line.

Empty qualifiers are already stripped by `cleanClaims` before saving, so they must not block creation. The validation now skips qualifiers with no value and only flags the genuinely broken case (a qualifier that has a value but no property selected).

## Problem 2 — no code change needed

Investigated and reproduced the full component reactivity chain (`EditTextField → Text → value/Base → qualifier/Create → claim/Create → Create`) with the real Vue runtime:

- selecting P329 → label `MS: <institution>`
- filling the P10 Shelfmark qualifier → label `MS: <institution>, <shelfmark>`

The label **does** pick up the shelfmark. This was already fixed by fcde556 ("Fix MANID item creation (#393)"). The report post-dated the fix but almost certainly came from a **stale frontend bundle** (the SPA was open from before the fcde556 staging deploy at 11:16 UTC and doesn't reload its bundle on its own). A fresh session (close/reopen the tab) shows it working.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated several languages’ validation messages for input errors.
  * Improved wording around missing claim values, missing qualifier keys, and incomplete dates.
  * Added clearer messages for cases where claim statements are still loading or data is incomplete.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->