### PR TITLE
Remove hard coding for language values for P34 (Naming) #385

### DIFF
--- a/frontend/components/item/related/Ritem.vue
+++ b/frontend/components/item/related/Ritem.vue
@@ -30,7 +30,7 @@
 </template>
 
 <script setup>
-import { computed, onMounted, ref } from 'vue'
+import { computed, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 
 defineOptions({ inheritAttrs: false })
@@ -55,11 +55,9 @@ const linkingQualifiers = ref([])
 const pbid = computed(() => props.value.item_pbid)
 const url = computed(() => localePath(`/item/${props.value.item}`))
 
-onMounted(async () => {
-  if (props.value.item) {
-    await getEntity()
-  }
-})
+watch(() => props.value.item, async (newItem) => {
+  if (newItem) await getEntity()
+}, { immediate: true })
 
 async function getEntity () {
   try {

--- a/frontend/components/item/related/Ritem.vue
+++ b/frontend/components/item/related/Ritem.vue
@@ -30,7 +30,7 @@
 </template>
 
 <script setup>
-import { computed, ref, watch } from 'vue'
+import { computed, onMounted, ref } from 'vue'
 import { useI18n } from 'vue-i18n'
 
 defineOptions({ inheritAttrs: false })
@@ -55,9 +55,11 @@ const linkingQualifiers = ref([])
 const pbid = computed(() => props.value.item_pbid)
 const url = computed(() => localePath(`/item/${props.value.item}`))
 
-watch(() => props.value.item, async (newItem) => {
-  if (newItem) await getEntity()
-}, { immediate: true })
+onMounted(async () => {
+  if (props.value.item) {
+    await getEntity()
+  }
+})
 
 async function getEntity () {
   try {

--- a/frontend/components/item/value/type/TextLang.vue
+++ b/frontend/components/item/value/type/TextLang.vue
@@ -34,9 +34,10 @@
 </template>
 
 <script setup>
-import { computed, reactive, ref } from 'vue'
+import { computed, onMounted, reactive, ref } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useAuthStore } from '~/stores/auth'
+import { useBreadcrumbStore } from '~/stores/breadcrumb'
 
 defineOptions({ inheritAttrs: false })
 
@@ -50,13 +51,35 @@ const props = defineProps({
 
 const emit = defineEmits(['on-blur', 'new-value'])
 
-const { $notification } = useNuxtApp()
+const { $notification, $wikibase } = useNuxtApp()
 const { t } = useI18n()
 const authStore = useAuthStore()
+const breadcrumbStore = useBreadcrumbStore()
 
 const valueToView_ = reactive({ ...props.valueToView })
 const consolidatedLanguage = ref(props.valueToView.language)
-const languages = [
+
+// Maps FactGrid language Q-items to BCP-47 codes used for monolingual text storage
+const LANG_QITEM_MAP = {
+  Q11149: { code: 'en', title: 'English' },
+  Q11150: { code: 'de', title: 'Deutsch' },
+  Q11152: { code: 'fr', title: 'Français' },
+  Q11153: { code: 'es', title: 'Español' },
+  Q11154: { code: 'nl', title: 'Nederlands' },
+  Q11155: { code: 'it', title: 'Italiano' },
+  Q11157: { code: 'da', title: 'Dansk' },
+  Q144754: { code: 'sv', title: 'Svenska' },
+  Q152304: { code: 'hu', title: 'Magyar' },
+  Q164451: { code: 'pt', title: 'Português' },
+  Q361085: { code: 'ca', title: 'Català' },
+  Q361087: { code: 'gl', title: 'Galego' },
+  Q393616: { code: 'nl', title: 'Nederlands' },
+  Q448505: { code: 'cs', title: 'Čeština' },
+  Q456587: { code: 'pl', title: 'Polski' },
+  Q899064: { code: 'nb', title: 'Norsk bokmål' },
+}
+
+const FALLBACK_LANGUAGES = [
   { title: 'English', value: 'en' },
   { title: 'Español', value: 'es' },
   { title: 'Português', value: 'pt' },
@@ -65,8 +88,43 @@ const languages = [
   { title: '-', value: 'und' }
 ]
 
+const languages = ref([...FALLBACK_LANGUAGES])
+
 const isUserLogged = computed(() => authStore.isLogged)
 const isEditable = computed(() => props.mode === 'edit')
+
+onMounted(async () => {
+  if (!isUserLogged.value || !props.valueToView?.property) return
+
+  const config = await $wikibase.getControlledVocabularyConfig(
+    breadcrumbStore.table,
+    breadcrumbStore.database
+  )
+  const propConfig = config?.[props.valueToView.property]
+  if (!propConfig?.query) return
+
+  const seen = new Set()
+  const mapped = []
+  for (const [, qid] of propConfig.query.matchAll(/wd:(Q\d+)/g)) {
+    const lang = LANG_QITEM_MAP[qid]
+    if (lang && !seen.has(lang.code)) {
+      seen.add(lang.code)
+      mapped.push({ title: lang.title, value: lang.code })
+    }
+  }
+  if (mapped.length === 0) return
+
+  mapped.push({ title: '-', value: 'und' })
+  languages.value = mapped
+
+  if (!valueToView_.language && propConfig.default_value) {
+    const defaultLang = LANG_QITEM_MAP[propConfig.default_value]
+    if (defaultLang) {
+      valueToView_.language = defaultLang.code
+      emit('new-value', getMonolingualTextNewValue(valueToView_.value))
+    }
+  }
+})
 
 function newTextValue (value) {
   valueToView_.value = value

--- a/frontend/pages/search/bibid/query.vue
+++ b/frontend/pages/search/bibid/query.vue
@@ -4,7 +4,7 @@
     :form-definition="form"
     :breadcrumb-items="breadcrumb_items"
   />
-</template>
+</template> 
 
 <script setup>
 import { useI18n } from 'vue-i18n'


### PR DESCRIPTION
The language dropdown in TextLang.vue was hardcoded to always show 5 fixed languages (en, es, pt, ca, gl). This made it impossible to add or remove languages without a code change and deploy.

Now the component reads the allowed languages dynamically from the Ui_ControlledVocabulary wiki page, using the same infrastructure already in place for other property autocompletions. A static Q-item → BCP-47 mapping table converts FactGrid language entities to the codes Wikibase uses for monolingual text storage.

If a property has no entry in Ui_ControlledVocabulary (e.g. other monolingual text fields), the component falls back to the previous hardcoded list, so nothing is broken for other uses of the component.

When a new (empty) P34 value is created, the default language from the wiki config is pre-selected automatically.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Language options in the text editor are now loaded dynamically from available vocabulary settings.
  * The editor can now preselect a default language when configured.
  * Added an additional “undefined language” option when no language is specified.
* **Bug Fixes**
  * Improved handling of missing configuration by safely exiting when prerequisites aren’t met.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->