### PR TITLE
Persist bibliography group and bitagap subgroup selection across sessions #430

### DIFF
--- a/frontend/components/search/Filters.vue
+++ b/frontend/components/search/Filters.vue
@@ -356,7 +356,7 @@ function loadDefaultBibliography () {
     if (savedBibliography && ['BETA', 'BITAGAP', 'BITECA'].includes(savedBibliography)) {
       searchGroup.value = savedBibliography
       onGroupChange(savedBibliography)
-      if (savedBibliography === 'BITAGAP') {
+      if (savedBibliography === 'BITAGAP' && isBitagapSelected.value) {
         const savedBitagapGroup = localStorage.getItem('philobiblon_default_bitagap_group')
         if (savedBitagapGroup && ['ALL', 'ORIG', 'CARTAS'].includes(savedBitagapGroup)) {
           bitagapGroup.value = savedBitagapGroup

--- a/frontend/components/search/Filters.vue
+++ b/frontend/components/search/Filters.vue
@@ -32,6 +32,7 @@
             item-title="text"
             item-value="value"
             :label="t('search.form.common.bitagap_group.label')"
+            @update:model-value="saveBitagapGroup"
           />
         </v-col>
       </v-row>
@@ -355,13 +356,29 @@ function loadDefaultBibliography () {
     if (savedBibliography && ['BETA', 'BITAGAP', 'BITECA'].includes(savedBibliography)) {
       searchGroup.value = savedBibliography
       onGroupChange(savedBibliography)
+      if (savedBibliography === 'BITAGAP') {
+        const savedBitagapGroup = localStorage.getItem('philobiblon_default_bitagap_group')
+        if (savedBitagapGroup && ['ALL', 'ORIG', 'CARTAS'].includes(savedBitagapGroup)) {
+          bitagapGroup.value = savedBitagapGroup
+        }
+      }
     }
   }
 }
 
+function saveBitagapGroup (group) {
+  if (typeof localStorage !== 'undefined' && ['ALL', 'ORIG', 'CARTAS'].includes(group)) {
+    localStorage.setItem('philobiblon_default_bitagap_group', group)
+  }
+}
+
 function saveDefaultBibliography (bibliography) {
-  if (typeof localStorage !== 'undefined' && ['BETA', 'BITAGAP', 'BITECA'].includes(bibliography)) {
+  if (typeof localStorage === 'undefined') return
+  if (['BETA', 'BITAGAP', 'BITECA'].includes(bibliography)) {
     localStorage.setItem('philobiblon_default_bibliography', bibliography)
+  } else {
+    localStorage.removeItem('philobiblon_default_bibliography')
+    localStorage.removeItem('philobiblon_default_bitagap_group')
   }
 }
 


### PR DESCRIPTION
Ensures the selected database group (BETA/BITAGAP/BITECA) and BITAGAP subgroup (Omnia/Original/Cartas) are restored on the next visit, for both logged-in and anonymous users. Language was already persisted via the i18n cookie and required no changes.

Changes (frontend/components/search/Filters.vue only):
- saveDefaultBibliography: now clears localStorage when the user selects "All" (previously it silently skipped "All", leaving a stale saved value that would be restored on the next visit instead of "All")
- saveBitagapGroup: new function that saves the BITAGAP subgroup selection (Omnia/Original/Cartas) to localStorage
- loadDefaultBibliography: also restores the saved bitagap subgroup when restoring a BITAGAP selection
- <v-select> for bitagap subgroup: wired to saveBitagapGroup via @update:model-value so the subgroup is saved whenever the user changes it

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The selected bitagap group is now remembered between visits, so your last choice is restored automatically when available.

* **Bug Fixes**
  * Improved saved bibliography handling to keep stored bitagap group settings in sync with supported bibliography selections.
  * Removed outdated bitagap group preferences when the selected bibliography is no longer supported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->