### PR TITLE
Add associated_person filter to bioid search covering all relationship properties #363

### DIFF
--- a/frontend/lang/ca.js
+++ b/frontend/lang/ca.js
@@ -283,6 +283,10 @@ export default {
         related_institution: {
           label: 'Institució relacionada',
           hint: 'Cerqueu persones associades a una institució específica.'
+        },
+        associated_person: {
+          label: 'Persona associada',
+          hint: 'Cerqueu persones relacionades amb aquest individu (relacions familiars, professionals i d\'altre tipus).'
         }
       },
       bibid: {

--- a/frontend/lang/en.js
+++ b/frontend/lang/en.js
@@ -283,6 +283,10 @@ export default {
         related_institution: {
           label: 'Related institution',
           hint: 'Search for persons associated with a specific institution.'
+        },
+        associated_person: {
+          label: 'Associated person',
+          hint: 'Search for persons related to this individual (family, professional, and other relationships).'
         }
       },
       bibid: {

--- a/frontend/lang/es.js
+++ b/frontend/lang/es.js
@@ -283,6 +283,10 @@ export default {
         related_institution: {
           label: 'Institución relacionada',
           hint: 'Busque personas asociadas a una institución específica.'
+        },
+        associated_person: {
+          label: 'Persona asociada',
+          hint: 'Busque personas relacionadas con este individuo (relaciones familiares, profesionales y de otro tipo).'
         }
       },
       bibid: {

--- a/frontend/lang/gl.js
+++ b/frontend/lang/gl.js
@@ -283,6 +283,10 @@ export default {
         related_institution: {
           label: 'Institución relacionada',
           hint: 'Busca persoas asociadas a unha institución específica.'
+        },
+        associated_person: {
+          label: 'Persoa asociada',
+          hint: 'Busca persoas relacionadas con este individuo (relacións familiares, profesionais e doutro tipo).'
         }
       },
       bibid: {

--- a/frontend/lang/pt.js
+++ b/frontend/lang/pt.js
@@ -288,6 +288,10 @@ export default {
         related_institution: {
           label: 'Instituição relacionada',
           hint: 'Pesquise pessoas associadas a uma instituição específica.'
+        },
+        associated_person: {
+          label: 'Pessoa associada',
+          hint: 'Pesquise pessoas relacionadas com este indivíduo (relações familiares, profissionais e de outro tipo).'
         }
       },
       bibid: {

--- a/frontend/pages/search/bioid/query.vue
+++ b/frontend/pages/search/bioid/query.vue
@@ -294,6 +294,33 @@ const form = {
               `
             }
           },
+          associated_person: {
+            active: true,
+            section: 'advanced',
+            label: 'search.form.bioid.associated_person.label',
+            hint: 'search.form.common.personal_name.hint',
+            type: 'autocomplete',
+            value: {},
+            visible: true,
+            disabled: false,
+            autocomplete: {
+              query:
+              `
+              SELECT DISTINCT ?target_item ?label ?desc WHERE {
+                {
+                  SELECT DISTINCT ?target_item WHERE {
+                    ?item wdt:P476 ?pbid .
+                    FILTER regex(?pbid, '{{database}} {{table}} ') .
+                    {{bitagapGroupFilter}}
+                    VALUES ?property { wdt:P703 wdt:P141 wdt:P142 wdt:P150 wdt:P203 wdt:P84 wdt:P505 wdt:P629 wdt:P504 wdt:P258 wdt:P192 wdt:P191 wdt:P33 wdt:P161 wdt:P190 wdt:P220 wdt:P735 }
+                    ?item ?property ?target_item .
+                  }
+                }
+                {{targetItemLangGroupPattern}}
+              }
+              `
+            }
+          },
           subject: {
             active: true,
             section: 'advanced',

--- a/frontend/pages/search/bioid/query.vue
+++ b/frontend/pages/search/bioid/query.vue
@@ -312,7 +312,7 @@ const form = {
                     ?item wdt:P476 ?pbid .
                     FILTER regex(?pbid, '{{database}} {{table}} ') .
                     {{bitagapGroupFilter}}
-                    VALUES ?property { wdt:P703 wdt:P141 wdt:P142 wdt:P150 wdt:P203 wdt:P84 wdt:P505 wdt:P629 wdt:P504 wdt:P258 wdt:P192 wdt:P191 wdt:P33 wdt:P161 wdt:P190 wdt:P220 wdt:P735 }
+                    VALUES ?property { wdt:P703 wdt:P141 wdt:P142 wdt:P150 wdt:P203 wdt:P84 wdt:P505 wdt:P629 wdt:P504 wdt:P258 wdt:P192 wdt:P191 wdt:P33 wdt:P161 wdt:P190 wdt:P220 wdt:P735 wdt:P257 wdt:P486 wdt:P591 }
                     ?item ?property ?target_item .
                   }
                 }

--- a/frontend/pages/search/bioid/query.vue
+++ b/frontend/pages/search/bioid/query.vue
@@ -298,7 +298,7 @@ const form = {
             active: true,
             section: 'advanced',
             label: 'search.form.bioid.associated_person.label',
-            hint: 'search.form.common.personal_name.hint',
+            hint: 'search.form.bioid.associated_person.hint',
             type: 'autocomplete',
             value: {},
             visible: true,

--- a/frontend/service/query.service.js
+++ b/frontend/service/query.service.js
@@ -572,7 +572,7 @@ export class QueryService {
         ?item wdt:P232 wd:${form.input.related_institution.value.target_item} .
         `
     }
-    if (form.input.associated_person && form.input.associated_person.value) {
+    if (form.input.associated_person && form.input.associated_person.value && form.input.associated_person.value.target_item) {
       filters +=
         `
         VALUES ?prop_related_person { wdt:P703 wdt:P141 wdt:P142 wdt:P150 wdt:P203 wdt:P84 wdt:P505 wdt:P629 wdt:P504 wdt:P258 wdt:P192 wdt:P191 wdt:P33 wdt:P161 wdt:P190 wdt:P220 wdt:P735 }

--- a/frontend/service/query.service.js
+++ b/frontend/service/query.service.js
@@ -575,7 +575,7 @@ export class QueryService {
     if (form.input.associated_person && form.input.associated_person.value && form.input.associated_person.value.target_item) {
       filters +=
         `
-        VALUES ?prop_related_person { wdt:P703 wdt:P141 wdt:P142 wdt:P150 wdt:P203 wdt:P84 wdt:P505 wdt:P629 wdt:P504 wdt:P258 wdt:P192 wdt:P191 wdt:P33 wdt:P161 wdt:P190 wdt:P220 wdt:P735 }
+        VALUES ?prop_related_person { wdt:P703 wdt:P141 wdt:P142 wdt:P150 wdt:P203 wdt:P84 wdt:P505 wdt:P629 wdt:P504 wdt:P258 wdt:P192 wdt:P191 wdt:P33 wdt:P161 wdt:P190 wdt:P220 wdt:P735 wdt:P257 wdt:P486 wdt:P591 }
         ?item ?prop_related_person wd:${form.input.associated_person.value.target_item} .
         `
     }

--- a/frontend/service/query.service.js
+++ b/frontend/service/query.service.js
@@ -572,6 +572,13 @@ export class QueryService {
         ?item wdt:P232 wd:${form.input.related_institution.value.target_item} .
         `
     }
+    if (form.input.associated_person && form.input.associated_person.value) {
+      filters +=
+        `
+        VALUES ?prop_related_person { wdt:P703 wdt:P141 wdt:P142 wdt:P150 wdt:P203 wdt:P84 wdt:P505 wdt:P629 wdt:P504 wdt:P258 wdt:P192 wdt:P191 wdt:P33 wdt:P161 wdt:P190 wdt:P220 wdt:P735 }
+        ?item ?prop_related_person wd:${form.input.associated_person.value.target_item} .
+        `
+    }
     if (form.input.subject && form.input.subject.value) {
       filters +=
         `


### PR DESCRIPTION
The associated_person filter in the bioid search page previously only searched via P703 (Further persons connected). This did not capture relationships that were split into separate properties.

Changes:
- frontend/pages/search/bioid/query.vue — added associated_person autocomplete field (advanced section) with SPARQL query covering all 17 relationship properties
- frontend/service/query.service.js — added associated_person filter in addPersonFilters using VALUES clause with all relationship properties
- frontend/lang/{en,ca,es,gl,pt}.js — added search.form.bioid.associated_person translation key in all 5 locale files

Properties covered: P703, P141, P142, P150, P203, P84, P505, P629, P504, P258, P192, P191, P33, P161, P190, P220, P735

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an “Associated person” field to the advanced bio ID search, with autocomplete and a relationship-based filter (e.g., family, professional, and other ties).
  * Added/updated localized labels and hints for Catalan, English, Spanish, Galician, and Portuguese.
* **Bug Fixes**
  * Improved advanced search filtering so results can be narrowed using the “Associated person” criteria.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->