### PR TITLE
Expand subject filter to cover all subject properties #365

### DIFF
--- a/frontend/pages/search/bibid/query.vue
+++ b/frontend/pages/search/bibid/query.vue
@@ -318,7 +318,7 @@ const form = {
                   SELECT DISTINCT ?target_item WHERE {
                     ?item wdt:P476 ?pbid .
                     FILTER regex(?pbid, '{{database}} {{table}} ')
-                    BIND ( wdt:P243 as ?property)
+                    VALUES ?property { wdt:P97 wdt:P121 wdt:P122 wdt:P243 wdt:P304 wdt:P452 wdt:P608 wdt:P1094 wdt:P1278 }
                     ?item ?property ?target_item .
                     {{bitagapGroupSubjectFilter}}
                   }

--- a/frontend/pages/search/bioid/query.vue
+++ b/frontend/pages/search/bioid/query.vue
@@ -311,7 +311,7 @@ const form = {
                   SELECT DISTINCT ?target_item WHERE {
                     ?item wdt:P476 ?pbid .
                     FILTER regex(?pbid, '{{database}} {{table}} ')
-                    BIND ( wdt:P243 as ?property)
+                    VALUES ?property { wdt:P97 wdt:P121 wdt:P122 wdt:P243 wdt:P304 wdt:P452 wdt:P608 wdt:P1094 wdt:P1278 }
                     ?item ?property ?target_item .
                     {{bitagapGroupSubjectFilter}}
                   }

--- a/frontend/pages/search/copid/query.vue
+++ b/frontend/pages/search/copid/query.vue
@@ -356,7 +356,7 @@ const form = {
                     ?item wdt:P476 ?pbid .
                     FILTER regex(?pbid, '{{database}} {{table}} ')
                     {{bitagapGroupSubjectFilter}}
-                    BIND ( wdt:P243 as ?property)
+                    VALUES ?property { wdt:P97 wdt:P121 wdt:P122 wdt:P243 wdt:P304 wdt:P452 wdt:P608 wdt:P1094 wdt:P1278 }
                     ?item ?property ?target_item .
                   }
                 }

--- a/frontend/pages/search/geoid/query.vue
+++ b/frontend/pages/search/geoid/query.vue
@@ -152,7 +152,7 @@ const form = {
                   SELECT DISTINCT ?target_item WHERE {
                     ?item wdt:P476 ?pbid .
                     FILTER regex(?pbid, '{{database}} {{table}} ')
-                    BIND ( wdt:P243 as ?property)
+                    VALUES ?property { wdt:P97 wdt:P121 wdt:P122 wdt:P243 wdt:P304 wdt:P452 wdt:P608 wdt:P1094 wdt:P1278 }
                     ?item ?property ?target_item .
                     {{bitagapGroupSubjectFilter}}
                   }

--- a/frontend/pages/search/insid/query.vue
+++ b/frontend/pages/search/insid/query.vue
@@ -185,7 +185,7 @@ const form = {
                     ?item wdt:P476 ?pbid .
                     FILTER regex(?pbid, '{{database}} {{table}} ')
                     {{bitagapGroupSubjectFilter}}
-                    BIND ( wdt:P243 as ?property)
+                    VALUES ?property { wdt:P97 wdt:P121 wdt:P122 wdt:P243 wdt:P304 wdt:P452 wdt:P608 wdt:P1094 wdt:P1278 }
                     ?item ?property ?target_item .
                   }
                 }

--- a/frontend/pages/search/libid/query.vue
+++ b/frontend/pages/search/libid/query.vue
@@ -187,7 +187,7 @@ const form = {
                     ?item wdt:P476 ?pbid .
                     FILTER regex(?pbid, '{{database}} {{table}} ')
                     {{bitagapGroupSubjectFilter}}
-                    BIND ( wdt:P243 as ?property)
+                    VALUES ?property { wdt:P97 wdt:P121 wdt:P122 wdt:P243 wdt:P304 wdt:P452 wdt:P608 wdt:P1094 wdt:P1278 }
                     ?item ?property ?target_item .
                   }
                 }

--- a/frontend/pages/search/manid/query.vue
+++ b/frontend/pages/search/manid/query.vue
@@ -524,7 +524,7 @@ const form = {
                     ?item wdt:P476 ?pbid .
                     FILTER regex(?pbid, '{{database}} {{table}} ')
                     {{bitagapGroupSubjectFilter}}
-                    BIND ( wdt:P243 as ?property)
+                    VALUES ?property { wdt:P97 wdt:P121 wdt:P122 wdt:P243 wdt:P304 wdt:P452 wdt:P608 wdt:P1094 wdt:P1278 }
                     ?item ?property ?target_item .
                   }
                 }

--- a/frontend/pages/search/texid/query.vue
+++ b/frontend/pages/search/texid/query.vue
@@ -423,7 +423,7 @@ const form = {
                     ?item wdt:P476 ?pbid .
                     FILTER regex(?pbid, '{{database}} {{table}} ')
                     {{bitagapGroupSubjectFilter}}
-                    BIND ( wdt:P243 as ?property)
+                    VALUES ?property { wdt:P97 wdt:P121 wdt:P122 wdt:P243 wdt:P304 wdt:P452 wdt:P608 wdt:P1094 wdt:P1278 }
                     ?item ?property ?target_item .
                   }
                 }

--- a/frontend/service/query.service.js
+++ b/frontend/service/query.service.js
@@ -269,7 +269,8 @@ export class QueryService {
     if (form.input.subject && form.input.subject.value) {
       filters +=
         `
-        ?item wdt:P243 wd:${form.input.subject.value.target_item} .
+        VALUES ?prop_subject { wdt:P97 wdt:P121 wdt:P122 wdt:P243 wdt:P304 wdt:P452 wdt:P608 wdt:P1094 wdt:P1278 }
+        ?item ?prop_subject wd:${form.input.subject.value.target_item} .
         `
     }
     if (form.input.institution_type && form.input.institution_type.value) {
@@ -495,7 +496,8 @@ export class QueryService {
     if (form.input.subject && form.input.subject.value) {
       filters +=
         `
-        ?item wdt:P243 wd:${form.input.subject.value.target_item} .
+        VALUES ?prop_subject { wdt:P97 wdt:P121 wdt:P122 wdt:P243 wdt:P304 wdt:P452 wdt:P608 wdt:P1094 wdt:P1278 }
+        ?item ?prop_subject wd:${form.input.subject.value.target_item} .
         `
     }
     filters += this._dateRangeFilters(form.input.date_composition.value, {
@@ -575,7 +577,8 @@ export class QueryService {
     if (form.input.subject && form.input.subject.value) {
       filters +=
         `
-        ?item wdt:P243 wd:${form.input.subject.value.target_item} .
+        VALUES ?prop_subject { wdt:P97 wdt:P121 wdt:P122 wdt:P243 wdt:P304 wdt:P452 wdt:P608 wdt:P1094 wdt:P1278 }
+        ?item ?prop_subject wd:${form.input.subject.value.target_item} .
         `
     }
     return filters
@@ -620,7 +623,8 @@ export class QueryService {
     if (form.input.subject && form.input.subject.value) {
       filters +=
         `
-        ?item wdt:P243 wd:${form.input.subject.value.target_item} .
+        VALUES ?prop_subject { wdt:P97 wdt:P121 wdt:P122 wdt:P243 wdt:P304 wdt:P452 wdt:P608 wdt:P1094 wdt:P1278 }
+        ?item ?prop_subject wd:${form.input.subject.value.target_item} .
         `
     }
     return filters
@@ -699,7 +703,8 @@ export class QueryService {
     if (form.input.subject && form.input.subject.value) {
       filters +=
         `
-        ?item wdt:P243 wd:${form.input.subject.value.target_item} .
+        VALUES ?prop_subject { wdt:P97 wdt:P121 wdt:P122 wdt:P243 wdt:P304 wdt:P452 wdt:P608 wdt:P1094 wdt:P1278 }
+        ?item ?prop_subject wd:${form.input.subject.value.target_item} .
         `
     }
     return filters
@@ -722,7 +727,8 @@ export class QueryService {
     if (form.input.subject && form.input.subject.value) {
       filters +=
         `
-        ?item wdt:P243 wd:${form.input.subject.value.target_item} .
+        VALUES ?prop_subject { wdt:P97 wdt:P121 wdt:P122 wdt:P243 wdt:P304 wdt:P452 wdt:P608 wdt:P1094 wdt:P1278 }
+        ?item ?prop_subject wd:${form.input.subject.value.target_item} .
         `
     }
     return filters
@@ -1035,7 +1041,8 @@ export class QueryService {
     if (form.input.subject && form.input.subject.value) {
       filters +=
         `
-        ?item wdt:P243 wd:${form.input.subject.value.target_item} .
+        VALUES ?prop_subject { wdt:P97 wdt:P121 wdt:P122 wdt:P243 wdt:P304 wdt:P452 wdt:P608 wdt:P1094 wdt:P1278 }
+        ?item ?prop_subject wd:${form.input.subject.value.target_item} .
         `
     }
     return filters


### PR DESCRIPTION
The subject filter previously only searched via P243 (Topic). Extended to cover all subject-related properties.

Changes:
- frontend/service/query.service.js — replaced wdt:P243 with VALUES clause covering all 9 subject properties in all table filter functions (insid, texid, bioid, libid, bibid, geoid, manid, cnum/copid)
- frontend/pages/search/{texid,bibid,bioid,copid,geoid,insid,libid,manid}/query.vue — replaced BIND(wdt:P243 as ?property) with VALUES clause in subject autocomplete queries

Properties covered: P97, P121, P122, P243, P304, P452, P608, P1094, P1278