### PR TITLE
Show full item template for logged-in users on existing records #313

### DIFF
--- a/frontend/components/item/Base.vue
+++ b/frontend/components/item/Base.vue
@@ -70,6 +70,7 @@ import { computed, onMounted, onBeforeUnmount, ref } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useAuthStore } from '~/stores/auth'
 import { useBreadcrumbStore } from '~/stores/breadcrumb'
+import { WikibaseService } from '~/service/wikibase.service'
 
 const props = defineProps({
   id: { type: String, default: null },
@@ -145,13 +146,13 @@ async function appendTemplateClaims (existingClaims) {
   if (!template) return
 
   const existingPropertyIds = new Set(Object.keys(existingClaims))
+  const missingPropIds = Object.keys(template).filter(id => !existingPropertyIds.has(id))
+  if (!missingPropIds.length) return
 
-  const bibliographyMap = { BETA: 'Q254471', BITECA: 'Q256810', BITAGAP: 'Q256809' }
+  const entities = await $wikibase.getEntities(missingPropIds, locale.value)
 
-  for (const [propId, qualifiersOrder] of Object.entries(template)) {
-    if (existingPropertyIds.has(propId)) continue
-
-    const entityProperty = await $wikibase.getEntity(propId, locale.value)
+  for (const propId of missingPropIds) {
+    const entityProperty = entities[propId]
     if (!entityProperty?.datatype || entityProperty.datatype === 'external-id') continue
 
     const claim = {
@@ -159,11 +160,12 @@ async function appendTemplateClaims (existingClaims) {
       datatype: entityProperty.datatype,
       values: [],
       hasQualifiers: false,
-      qualifiersOrder
+      qualifiersOrder: template[propId]
     }
 
-    if (propId === 'P131' && bibliographyMap[props.database]) {
-      claim.defaultValue = { id: bibliographyMap[props.database] }
+    const bibliographyId = WikibaseService.BIBLIOGRAPHY_MAP[props.database]
+    if (propId === 'P131' && bibliographyId) {
+      claim.defaultValue = { id: bibliographyId }
     }
 
     claimsOrdered.value.push(claim)

--- a/frontend/components/item/Base.vue
+++ b/frontend/components/item/Base.vue
@@ -134,6 +134,40 @@ async function handleClaims (entity) {
       claimsOrdered.value.push(claim)
     }
   }
+
+  if (isUserLogged.value) {
+    await appendTemplateClaims(entity.claims)
+  }
+}
+
+async function appendTemplateClaims (existingClaims) {
+  const template = await $wikibase.getClaimsOrderForNewItem(props.table)
+  if (!template) return
+
+  const existingPropertyIds = new Set(Object.keys(existingClaims))
+
+  const bibliographyMap = { BETA: 'Q254471', BITECA: 'Q256810', BITAGAP: 'Q256809' }
+
+  for (const [propId, qualifiersOrder] of Object.entries(template)) {
+    if (existingPropertyIds.has(propId)) continue
+
+    const entityProperty = await $wikibase.getEntity(propId, locale.value)
+    if (!entityProperty?.datatype || entityProperty.datatype === 'external-id') continue
+
+    const claim = {
+      property: propId,
+      datatype: entityProperty.datatype,
+      values: [],
+      hasQualifiers: false,
+      qualifiersOrder
+    }
+
+    if (propId === 'P131' && bibliographyMap[props.database]) {
+      claim.defaultValue = { id: bibliographyMap[props.database] }
+    }
+
+    claimsOrdered.value.push(claim)
+  }
 }
 
 function setBreadCrumb (database, table, entity) {

--- a/frontend/components/item/Create.vue
+++ b/frontend/components/item/Create.vue
@@ -99,6 +99,7 @@
 import { computed, nextTick, onMounted, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useAuthStore } from '~/stores/auth'
+import { WikibaseService } from '~/service/wikibase.service'
 
 const props = defineProps({
   database: { type: String, required: true },
@@ -364,12 +365,7 @@ async function getDefaultClaims (itemNumber) {
       if (entity.id === 'P476') {
         claim = buildClaim(entity, [], generatePbId(itemNumber), false)
       } else if (entity.id === 'P131') {
-        const bibliographyMap = {
-          BETA: 'Q254471',
-          BITECA: 'Q256810',
-          BITAGAP: 'Q256809'
-        }
-        const bibliographyId = bibliographyMap[props.database] || null
+        const bibliographyId = WikibaseService.BIBLIOGRAPHY_MAP[props.database] || null
 
         const bibliographyQualifiers = [
           buildQualifier(entity, qualifiersArr['P700'])

--- a/frontend/components/item/claim/AddValue.vue
+++ b/frontend/components/item/claim/AddValue.vue
@@ -70,14 +70,15 @@
 </template>
 
 <script setup>
-import { reactive } from 'vue'
+import { onMounted, reactive } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useAuthStore } from '~/stores/auth'
 
 const props = defineProps({
   item: { type: Object, default: null },
   value: { type: Object, default: null },
-  forCreate: { type: Boolean, default: false }
+  forCreate: { type: Boolean, default: false },
+  defaultValue: { type: Object, default: null }
 })
 
 const emit = defineEmits(['update-claims-values', 'create-claim'])
@@ -89,6 +90,17 @@ const authStore = useAuthStore()
 
 const items = reactive({})
 const claims = reactive({})
+
+onMounted(() => {
+  if (props.defaultValue && !props.forCreate) {
+    const newKey = `P${Date.now()}`
+    claims[newKey] = {
+      property: props.value.property,
+      datatype: props.value.datatype,
+      datavalue: { value: props.defaultValue, default: true }
+    }
+  }
+})
 
 function addClaim () {
   const newKey = `P${Date.now()}`

--- a/frontend/components/item/claim/AddValue.vue
+++ b/frontend/components/item/claim/AddValue.vue
@@ -97,7 +97,7 @@ onMounted(() => {
     claims[newKey] = {
       property: props.value.property,
       datatype: props.value.datatype,
-      datavalue: { value: props.defaultValue, default: true }
+      datavalue: { value: props.defaultValue }
     }
   }
 })
@@ -136,7 +136,8 @@ function updateClaimValue (value, key) {
 }
 
 async function createClaim (index) {
-  const value = claims[index]?.datavalue?.value
+  const raw = claims[index]?.datavalue?.value
+  const value = raw && typeof raw === 'object' && 'id' in raw ? raw.id ?? null : raw
   if (value == null) {
     return
   }

--- a/frontend/components/item/claim/Base.vue
+++ b/frontend/components/item/claim/Base.vue
@@ -12,7 +12,7 @@
         :key="claim.values.length"
         :item="item"
         :value="claim?.values[0]?.mainsnak ?? { property: claim.property, datatype: claim.datatype }"
-        :default-value="claim.defaultValue"
+        :default-value="claim.values.length === 0 ? claim.defaultValue : null"
         @create-claim="emit('create-claim', $event)"
       />
     </v-container>

--- a/frontend/components/item/claim/Base.vue
+++ b/frontend/components/item/claim/Base.vue
@@ -6,12 +6,13 @@
       </div>
     </v-row>
     <v-container class="claim-values">
-      <item-claim-values :table="table" :claim="claim" @delete-claim="emit('delete-claim', $event)" />
+      <item-claim-values v-if="claim.values.length > 0" :table="table" :claim="claim" @delete-claim="emit('delete-claim', $event)" />
       <item-claim-add-value
         v-if="isUserLogged && isAllowedAddValue"
         :key="claim.values.length"
         :item="item"
-        :value="claim?.values[0]?.mainsnak"
+        :value="claim?.values[0]?.mainsnak ?? { property: claim.property, datatype: claim.datatype }"
+        :default-value="claim.defaultValue"
         @create-claim="emit('create-claim', $event)"
       />
     </v-container>

--- a/frontend/components/item/value/type/Entity.vue
+++ b/frontend/components/item/value/type/Entity.vue
@@ -63,8 +63,13 @@ const propertyAutocomplete = ref({})
 const loading = ref(true)
 
 const isUserLogged = computed(() => authStore.isLogged)
+const propertyKey = computed(() => {
+  const p = props.valueToView?.property
+  return (p && typeof p === 'object') ? p.id : p
+})
+
 const isItemWithCustomOptions = computed(
-  () => propertyAutocomplete.value && props.valueToView.property in propertyAutocomplete.value
+  () => propertyAutocomplete.value && propertyKey.value in propertyAutocomplete.value
 )
 
 onMounted(async () => {
@@ -132,7 +137,7 @@ function getDefaultValue (currentValue, defaultValue) {
 
 function setOptionsAutocomplete () {
   if (isItemWithCustomOptions.value) {
-    const autocomplete = propertyAutocomplete.value[props.valueToView.property]
+    const autocomplete = propertyAutocomplete.value[propertyKey.value]
     const fullSparqlQuery = buildFullQuery(autocomplete.query)
     return $wikibase.runSparqlQuery(fullSparqlQuery, true)
       .catch((error) => { notifyError(error); return [] })

--- a/frontend/service/wikibase.service.js
+++ b/frontend/service/wikibase.service.js
@@ -10,6 +10,7 @@ export class WikibaseService {
   static PROPERTY_PBID = 'P476'
   static PROPERTY_FORMATTER_URL = 'P236'
   static PROPERTY_NOTES = 'P817'
+  static BIBLIOGRAPHY_MAP = { BETA: 'Q254471', BITECA: 'Q256810', BITAGAP: 'Q256809' }
   static ITEM_PHILOBIBLON_PROPERTIES = 'Q394229'
   static COMMONS_WIKIMEDIA_URL_ENDPOINT =
     'https://en.wikipedia.org/w/api.php?action=query&titles=File:$file&prop=imageinfo&iiprop=url&format=json&origin=*'


### PR DESCRIPTION
When a logged-in user opens an existing item, the full property template from Ui_SortedProperties_NewItem is now shown alongside existing claims. Properties that have no value yet appear as empty placeholder fields with an "+ add value" button, matching the experience of the Create Item screen.

Changes:
- Base.vue: after loading existing claims, fetch the new-item template and append empty placeholder claims for any property not yet on the item (skipping external-id properties)
- claim/Base.vue: hide the empty v-data-table when values = [] to avoid "no data" noise; pass a fallback { property, datatype } to AddValue when the claim has no values yet; forward defaultValue prop
- AddValue.vue: accept a defaultValue prop and pre-populate the input on mount (used for P131 auto-fill based on bibliography)
- Entity.vue: fix controlled vocabulary lookup for qualifiers — qualifier property is stored as an object { id, label, datatype } but the propertyAutocomplete lookup uses string keys, causing the `in` check to always evaluate to false and the SPARQL vocabulary query to never run

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Logged-in users may now see additional suggested claims automatically added for the current table when editing an item.
  * New claims can now start with a predefined default value when available.

* **Bug Fixes**
  * Improved how entity values detect and use the correct property, helping controlled-vocabulary options and autocomplete behave more consistently.
  * The “add value” flow now better preserves and reuses existing claim data when opening an item for editing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->