### PR TITLE
Fix stale label when paging through related items #276

### DIFF
--- a/frontend/components/item/related/Ritem.vue
+++ b/frontend/components/item/related/Ritem.vue
@@ -52,6 +52,8 @@ const item = ref(null)
 const claims = ref(null)
 const linkingQualifiers = ref([])
 
+let entityRequestId = 0
+
 const pbid = computed(() => props.value.item_pbid)
 const url = computed(() => localePath(`/item/${props.value.item}`))
 
@@ -68,11 +70,15 @@ watch(() => props.value.item, (newItem) => {
 })
 
 async function getEntity () {
+  const requestId = ++entityRequestId
   try {
     const entity = await $wikibase.getEntity(props.value.item, locale.value)
+    if (requestId !== entityRequestId) return
     item.value = entity
     claims.value = await $wikibase.getOrderedClaims(props.table, entity.claims)
+    if (requestId !== entityRequestId) return
     label.value = $wikibase.getValueByLang(entity.labels, locale.value)
+    linkingQualifiers.value = []
     if (props.itemId && props.table === 'bioid') {
       await extractLinkingQualifiers(entity.claims)
     }

--- a/frontend/components/item/related/Ritem.vue
+++ b/frontend/components/item/related/Ritem.vue
@@ -30,7 +30,7 @@
 </template>
 
 <script setup>
-import { computed, onMounted, ref } from 'vue'
+import { computed, onMounted, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 
 defineOptions({ inheritAttrs: false })
@@ -58,6 +58,12 @@ const url = computed(() => localePath(`/item/${props.value.item}`))
 onMounted(async () => {
   if (props.value.item) {
     await getEntity()
+  }
+})
+
+watch(() => props.value.item, (newItem) => {
+  if (newItem) {
+    getEntity()
   }
 })
 

--- a/frontend/components/item/related/Ritem.vue
+++ b/frontend/components/item/related/Ritem.vue
@@ -66,6 +66,11 @@ onMounted(async () => {
 watch(() => props.value.item, (newItem) => {
   if (newItem) {
     getEntity()
+  } else {
+    label.value = null
+    item.value = null
+    claims.value = null
+    linkingQualifiers.value = []
   }
 })
 
@@ -80,14 +85,14 @@ async function getEntity () {
     label.value = $wikibase.getValueByLang(entity.labels, locale.value)
     linkingQualifiers.value = []
     if (props.itemId && props.table === 'bioid') {
-      await extractLinkingQualifiers(entity.claims)
+      await extractLinkingQualifiers(entity.claims, requestId)
     }
   } catch (err) {
     notifyError(err)
   }
 }
 
-async function extractLinkingQualifiers (entityClaims) {
+async function extractLinkingQualifiers (entityClaims, requestId) {
   for (const statements of Object.values(entityClaims || {})) {
     for (const stmt of statements) {
       if (stmt.mainsnak?.datavalue?.value?.id === props.itemId && stmt.qualifiers) {
@@ -107,7 +112,9 @@ async function extractLinkingQualifiers (entityClaims) {
               }
             })
         )
-        linkingQualifiers.value = resolved.filter(q => q.valueDisplay)
+        if (requestId === entityRequestId) {
+          linkingQualifiers.value = resolved.filter(q => q.valueDisplay)
+        }
         return
       }
     }


### PR DESCRIPTION
label.value is set once in onMounted via getEntity(). When Vue reuses the Ritem component across page changes (same :key), onMounted does not fire again and the label stays stale while pbid updates reactively.

Add a watch on props.value.item so getEntity() reruns whenever the underlying item changes, regardless of whether the component remounts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Related item details now refresh reliably when the selected item changes, ensuring the displayed label, entity data, claims, and linking qualifiers stay current.
  * Improved handling of rapid item changes to prevent older background loads from overwriting newer results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->