### PR TITLE
Notify staging deploys via PR comment

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,9 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(yarn lint:*)",
+      "Bash(gh pr view:*)",
+      "Bash(gh issue view:*)"
+    ]
+  }
+}

--- a/.claude/skills/rebase-conflicting-prs/SKILL.md
+++ b/.claude/skills/rebase-conflicting-prs/SKILL.md
@@ -30,13 +30,13 @@ List the matching PRs (number, title, author, branch) and get the user's confirm
 
 Work through the confirmed list in order. For each PR:
 
-1. **Check out the branch.** `git status` first — the working tree must be clean; if not, stop and ask the user (stash/commit), never discard uncommitted work silently. Then checkout the PR's `headRefName`, fetching it from origin first if it doesn't exist locally. If `headRepositoryOwner` differs from this repo's owner, the PR is from a fork — fetch/checkout from there instead.
+1. **Check out the branch.** `git status` first — the working tree must be clean; if not, stop and ask the user (stash/commit), never discard uncommitted work silently. Then run `gh pr checkout <number>` to check out the PR's branch — for same-repo PRs this tracks `origin`; for fork PRs (`headRepositoryOwner` differs from this repo's owner) it creates and tracks a remote pointing at the fork, so the push step below automatically goes to the right place.
 2. **Rebase.** Invoke the `rebase` skill with this branch onto `master`. That skill invokes `resolving-merge-conflicts` for any hunks and runs the project's checks (`yarn lint` in `frontend/`, `./mvnw test` in `backend/`, per `AGENTS.md`, for whatever the rebased commits touch).
-3. **Push.** `git push --force-with-lease origin <headRefName>`.
+3. **Push.** `git push --force-with-lease` (no explicit remote — resolves to the tracking remote `gh pr checkout` set up: the fork's remote for fork PRs, `origin` otherwise). If the push is rejected (e.g. the fork owner hasn't enabled "Allow edits from maintainers"), don't retry against `origin` — report and skip like any other per-PR failure.
 4. **Request review.** `gh pr comment <number> --body "@claude review this PR"`.
 5. **Notify the author.** `gh pr comment <number> --body "@<author-login> I've applied a rebase and triggered a new review. Could you please check and test again?"` — always in English, regardless of the conversation's language.
 
-A PR whose rebase fails partway (unresolvable conflict, broken checks) should be reported and skipped, not force-pushed in a broken state — continue with the rest of the batch.
+A PR whose rebase fails partway (unresolvable conflict, broken checks, rejected push) should be reported and skipped, not force-pushed in a broken state — continue with the rest of the batch. If the failure leaves the repo mid-rebase (an unresolvable conflict `resolving-merge-conflicts` couldn't clear), run `git rebase --abort` and confirm `git status` is clean before checking out the next PR — `resolving-merge-conflicts`'s own contract never aborts on your behalf, but this skill's batch loop overrides that for the unattended case, since leaving one PR mid-rebase would break every checkout after it. A clean rebase that only fails checks doesn't need an abort — just skip the push/comment steps for that PR.
 
 ### 5. Return
 

--- a/.claude/skills/rebase-conflicting-prs/SKILL.md
+++ b/.claude/skills/rebase-conflicting-prs/SKILL.md
@@ -1,0 +1,47 @@
+---
+name: rebase-conflicting-prs
+description: Find every open PR assigned to or review-requested from the current user that has merge conflicts with master, rebase each one, force-push the update, and comment to request a fresh review from @claude and from the author. Use when the user wants to clear out PRs stuck on conflicts, review PRs that need rebase, or bulk-rebase their conflicting PR queue.
+---
+
+## Process
+
+### 1. Find candidate PRs
+
+Same two queries as the `review-queue` skill (the repo is resolved from `git remote -v`):
+
+```
+gh pr list --state open --search "review-requested:@me" --limit 200 --json number,title,url,author,headRefName,headRepositoryOwner,mergeable,mergeStateStatus
+gh pr list --state open --assignee "@me" --limit 200 --json number,title,url,author,headRefName,headRepositoryOwner,mergeable,mergeStateStatus
+```
+
+Merge and dedupe by PR `number`.
+
+Filter down to PRs where `mergeable` is `CONFLICTING`, or `mergeStateStatus` is `DIRTY`. For any PR whose `mergeable` is still `UNKNOWN` (GitHub computes it lazily), re-fetch once with `gh pr view <number> --json mergeable` and re-check before deciding it doesn't qualify.
+
+### 2. Empty case
+
+If nothing matches, report "no conflicting PRs" and stop — don't proceed to confirmation or the loop.
+
+### 3. Confirm the batch
+
+List the matching PRs (number, title, author, branch) and get the user's confirmation once for the whole batch before touching anything. This step rebases and force-pushes PR branches other people may have checked out locally — get sign-off up front, not per PR.
+
+### 4. Per PR
+
+Work through the confirmed list in order. For each PR:
+
+1. **Check out the branch.** `git status` first — the working tree must be clean; if not, stop and ask the user (stash/commit), never discard uncommitted work silently. Then checkout the PR's `headRefName`, fetching it from origin first if it doesn't exist locally. If `headRepositoryOwner` differs from this repo's owner, the PR is from a fork — fetch/checkout from there instead.
+2. **Rebase.** Invoke the `rebase` skill with this branch onto `master`. That skill invokes `resolving-merge-conflicts` for any hunks and runs the project's checks (`yarn lint` in `frontend/`, `./mvnw test` in `backend/`, per `AGENTS.md`, for whatever the rebased commits touch).
+3. **Push.** `git push --force-with-lease origin <headRefName>`.
+4. **Request review.** `gh pr comment <number> --body "@claude review this PR"`.
+5. **Notify the author.** `gh pr comment <number> --body "@<author-login> I've applied a rebase and triggered a new review. Could you please check and test again?"` — always in English, regardless of the conversation's language.
+
+A PR whose rebase fails partway (unresolvable conflict, broken checks) should be reported and skipped, not force-pushed in a broken state — continue with the rest of the batch.
+
+### 5. Return
+
+After the last PR, check out the branch the user started on (typically `master`) so the working tree isn't left sitting on a PR branch.
+
+### 6. Report
+
+Summarize per PR: whether it had conflicts and in which files, whether checks passed after rebase, and that both comments were posted. Flag any PR that was skipped and why.

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -142,6 +142,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 1
+          persist-credentials: false
 
       - name: Find linked issues and their authors
         id: issues
@@ -216,6 +217,21 @@ jobs:
           **Test plan:**
           ${TEST_PLAN}"
           gh pr comment "$PR_NUMBER" --body "$BODY"
+
+      - name: Post fallback success comment if Claude summary failed
+        if: always() && steps.claude.outcome != 'success'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ needs.find-pr.outputs.number }}
+          ISSUE_AUTHORS: ${{ steps.issues.outputs.authors }}
+          DEFAULT_USER: ${{ vars.DEPLOY_NOTIFY_SUCCESS_GITHUB_DEFAULT_USER }}
+        run: |
+          if [ -n "$ISSUE_AUTHORS" ]; then
+            MENTIONS="$(echo "$ISSUE_AUTHORS" | tr ' ' '\n' | sed 's/^/@/' | paste -sd' ')"
+          else
+            MENTIONS="@${DEFAULT_USER}"
+          fi
+          gh pr comment "$PR_NUMBER" --body "${MENTIONS} deployed to staging. (Summary generation failed — see the workflow run for details.)"
 
   notify-failure:
     name: Notify deploy failure via GitHub comment

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -10,6 +10,33 @@ env:
   OWNER: ${{ github.repository_owner }}
 
 jobs:
+  find-pr:
+    name: Find associated pull request
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+
+    outputs:
+      number: ${{ steps.find.outputs.number }}
+      title: ${{ steps.find.outputs.title }}
+      url: ${{ steps.find.outputs.url }}
+
+    steps:
+      - name: Find pull request for this commit
+        id: find
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          PR_JSON="$(gh api "repos/${{ github.repository }}/commits/${{ github.sha }}/pulls" --jq '.[0] // empty')"
+          if [ -z "$PR_JSON" ]; then
+            echo "No pull request associated with ${{ github.sha }}"
+            exit 0
+          fi
+          echo "number=$(echo "$PR_JSON" | jq -r '.number')" >> "$GITHUB_OUTPUT"
+          echo "title=$(echo "$PR_JSON" | jq -r '.title')" >> "$GITHUB_OUTPUT"
+          echo "url=$(echo "$PR_JSON" | jq -r '.html_url')" >> "$GITHUB_OUTPUT"
+
   build-and-push:
     name: Build & push images
     runs-on: ubuntu-latest
@@ -97,6 +124,113 @@ jobs:
             docker compose -f docker-compose.ui-local.yml -f docker-compose.ui-dev.yml pull
             docker compose -f docker-compose.ui-local.yml -f docker-compose.ui-dev.yml up -d
             docker images --filter "dangling=true" --filter "label=org.opencontainers.image.source=https://github.com/PhiloBiblon/philobiblon-ui" -q | xargs -r docker rmi -f
+
+  notify-success:
+    name: Notify deploy success via PR comment
+    needs: [build-and-push, deploy, find-pr]
+    if: always() && needs.build-and-push.result == 'success' && needs.deploy.result == 'success' && needs.find-pr.outputs.number != ''
+    runs-on: ubuntu-latest
+    environment: staging
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: read
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Generate summary and test plan with Claude
+        id: claude
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          track_progress: false
+          prompt: |
+            REPO: ${{ github.repository }}
+            PR NUMBER: ${{ needs.find-pr.outputs.number }}
+
+            Read that pull request's title, body, comments and reviews with:
+              gh pr view ${{ needs.find-pr.outputs.number }} --json title,body,url,comments,reviews
+
+            If the PR title or body references an issue (patterns like "#123" or
+            "Fixes #123"), also read that issue's description and comments with:
+              gh issue view <issue-number> --json title,body,comments
+
+            Ignore any comment or content authored by the "coderabbitai" bot —
+            it is an automated review bot that is not relevant here and will
+            soon be disabled.
+
+            Using all of the above, write in English:
+            - summary: a short description of what this change fixes/does.
+            - test_plan: concrete steps to verify the change works.
+          claude_args: |
+            --json-schema '{"type":"object","properties":{"summary":{"type":"string"},"test_plan":{"type":"string"}},"required":["summary","test_plan"]}'
+
+      - name: Post deploy success comment on the PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ needs.find-pr.outputs.number }}
+          NOTIFY_USER: ${{ vars.DEPLOY_NOTIFY_SUCCESS_GITHUB_USER }}
+          SUMMARY: ${{ fromJSON(steps.claude.outputs.structured_output).summary }}
+          TEST_PLAN: ${{ fromJSON(steps.claude.outputs.structured_output).test_plan }}
+        run: |
+          BODY="@${NOTIFY_USER} deployed to staging.
+
+          ${SUMMARY}
+
+          **Test plan:**
+          ${TEST_PLAN}"
+          gh pr comment "$PR_NUMBER" --body "$BODY"
+
+  notify-failure:
+    name: Notify deploy failure via GitHub comment
+    needs: [build-and-push, deploy, find-pr]
+    if: always() && (needs.build-and-push.result == 'failure' || needs.deploy.result == 'failure')
+    runs-on: ubuntu-latest
+    environment: staging
+    permissions:
+      contents: write
+      pull-requests: write
+
+    steps:
+      - name: Determine failed job(s)
+        id: failed
+        run: |
+          FAILED=""
+          for pair in "build-and-push:${{ needs.build-and-push.result }}" "deploy:${{ needs.deploy.result }}"; do
+            name="${pair%%:*}"
+            result="${pair##*:}"
+            if [ "$result" != "success" ]; then
+              FAILED="${FAILED:+$FAILED, }$name ($result)"
+            fi
+          done
+          echo "jobs=$FAILED" >> "$GITHUB_OUTPUT"
+
+      - name: Post failure comment on the PR
+        if: needs.find-pr.outputs.number != ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ needs.find-pr.outputs.number }}
+          NOTIFY_USER: ${{ vars.DEPLOY_NOTIFY_FAILURE_GITHUB_USER }}
+          FAILED_JOBS: ${{ steps.failed.outputs.jobs }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          gh pr comment "$PR_NUMBER" --body "@${NOTIFY_USER} staging deploy failed (job: ${FAILED_JOBS}). Run: ${RUN_URL}"
+
+      - name: Post failure comment on the commit
+        if: needs.find-pr.outputs.number == ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NOTIFY_USER: ${{ vars.DEPLOY_NOTIFY_FAILURE_GITHUB_USER }}
+          FAILED_JOBS: ${{ steps.failed.outputs.jobs }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          gh api "repos/${{ github.repository }}/commits/${{ github.sha }}/comments" \
+            -f body="@${NOTIFY_USER} staging deploy failed (job: ${FAILED_JOBS}). Run: ${RUN_URL}"
 
   cleanup:
     name: Clean up old staging images

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -143,6 +143,30 @@ jobs:
         with:
           fetch-depth: 1
 
+      - name: Find linked issues and their authors
+        id: issues
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ needs.find-pr.outputs.number }}
+        run: |
+          PR_TEXT="$(gh pr view "$PR_NUMBER" --json title,body -q '(.title + "\n" + .body)')"
+          CANDIDATES="$(echo "$PR_TEXT" | grep -oE '#[0-9]+' | tr -d '#' | sort -u)"
+          AUTHORS=""
+          for n in $CANDIDATES; do
+            if [ "$n" = "$PR_NUMBER" ]; then
+              continue
+            fi
+            AUTHOR="$(gh issue view "$n" --json author -q '.author.login' 2>/dev/null || true)"
+            if [ -n "$AUTHOR" ]; then
+              case " $AUTHORS " in
+                *" $AUTHOR "*) ;;
+                *) AUTHORS="${AUTHORS:+$AUTHORS }$AUTHOR" ;;
+              esac
+            fi
+          done
+          echo "numbers=$(echo "$CANDIDATES" | tr '\n' ' ')" >> "$GITHUB_OUTPUT"
+          echo "authors=$AUTHORS" >> "$GITHUB_OUTPUT"
+
       - name: Generate summary and test plan with Claude
         id: claude
         uses: anthropics/claude-code-action@v1
@@ -152,12 +176,13 @@ jobs:
           prompt: |
             REPO: ${{ github.repository }}
             PR NUMBER: ${{ needs.find-pr.outputs.number }}
+            LINKED ISSUE NUMBERS: ${{ steps.issues.outputs.numbers }}
 
             Read that pull request's title, body, comments and reviews with:
               gh pr view ${{ needs.find-pr.outputs.number }} --json title,body,url,comments,reviews
 
-            If the PR title or body references an issue (patterns like "#123" or
-            "Fixes #123"), also read that issue's description and comments with:
+            For each of the linked issue numbers above (if any), also read that
+            issue's description and comments with:
               gh issue view <issue-number> --json title,body,comments
 
             Ignore any comment or content authored by the "coderabbitai" bot —
@@ -174,11 +199,17 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ needs.find-pr.outputs.number }}
-          NOTIFY_USER: ${{ vars.DEPLOY_NOTIFY_SUCCESS_GITHUB_USER }}
+          ISSUE_AUTHORS: ${{ steps.issues.outputs.authors }}
+          DEFAULT_USER: ${{ vars.DEPLOY_NOTIFY_SUCCESS_GITHUB_DEFAULT_USER }}
           SUMMARY: ${{ fromJSON(steps.claude.outputs.structured_output).summary }}
           TEST_PLAN: ${{ fromJSON(steps.claude.outputs.structured_output).test_plan }}
         run: |
-          BODY="@${NOTIFY_USER} deployed to staging.
+          if [ -n "$ISSUE_AUTHORS" ]; then
+            MENTIONS="$(echo "$ISSUE_AUTHORS" | tr ' ' '\n' | sed 's/^/@/' | paste -sd' ')"
+          else
+            MENTIONS="@${DEFAULT_USER}"
+          fi
+          BODY="${MENTIONS} deployed to staging.
 
           ${SUMMARY}
 

--- a/docs/cicd.md
+++ b/docs/cicd.md
@@ -4,10 +4,13 @@
 
 ### `staging.yml` — triggers: push to `master`, manual
 
-1. Builds `philobiblon-ui-backend` and `philobiblon-ui-frontend` images (with layer cache via GitHub Actions cache).
-2. Pushes to GHCR with two tags each: `main-{7-char SHA}` and `main-latest`.
-3. Deploys to the staging server via SSH using `docker-compose.ui-dev.yml`.
-4. Deletes old image versions, keeping the 5 most recent. Tags matching `^v` (production releases) are never deleted.
+1. Looks up the pull request associated with the pushed commit (`find-pr` job), if any.
+2. Builds `philobiblon-ui-backend` and `philobiblon-ui-frontend` images (with layer cache via GitHub Actions cache).
+3. Pushes to GHCR with two tags each: `main-{7-char SHA}` and `main-latest`.
+4. Deploys to the staging server via SSH using `docker-compose.ui-dev.yml`.
+5. On success, if a PR was found, posts a comment on it (`notify-success` job) mentioning `vars.DEPLOY_NOTIFY_SUCCESS_GITHUB_USER` — GitHub emails that user via its normal @mention notification, so no SMTP setup is needed. The comment body is an English summary and test plan written by Claude (`anthropics/claude-code-action@v1`) from the PR's title, body, comments and reviews, plus the description/comments of any issue the PR references. Comments from the `coderabbitai` bot are ignored. Skipped entirely if there was no associated PR.
+6. On failure of the build or deploy step, posts a failure comment instead (`notify-failure` job) mentioning `vars.DEPLOY_NOTIFY_FAILURE_GITHUB_USER`, with the failed job(s) and a link to the workflow run — on the PR if one was found, otherwise as a comment on the commit itself. Runs even when `notify-success` is skipped.
+7. Deletes old image versions, keeping the 5 most recent. Tags matching `^v` (production releases) are never deleted.
 
 ### `production.yml` — triggers: push of a `v*` tag (e.g. `v1.2.3`), manual
 
@@ -45,6 +48,8 @@ Create two environments: `staging` and `production`, each with:
 | `BASE_URL` | Frontend base path (e.g. `/` or `/ui/`) — baked into the image at build time |
 | `API_BASE_URL` | Backend API URL (e.g. `https://example.com/api/`) — baked into the image at build time |
 | `DEPLOY_PATH` | Absolute path to the project on the server |
+| `DEPLOY_NOTIFY_SUCCESS_GITHUB_USER` | GitHub login mentioned in the PR comment on a successful staging deploy — staging only |
+| `DEPLOY_NOTIFY_FAILURE_GITHUB_USER` | GitHub login mentioned in the PR/commit comment on a failed staging deploy — staging only |
 
 ### Secrets (`secrets.*`) — encrypted
 
@@ -55,6 +60,7 @@ Create two environments: `staging` and `production`, each with:
 | `SSH_KEY` | Private SSH key (RSA or Ed25519) |
 
 `GITHUB_TOKEN` is provided automatically by GitHub Actions — no manual setup needed.
+`CLAUDE_CODE_OAUTH_TOKEN` is a repository-level secret (not per-environment), also used by `claude.yml` and `claude-code-review.yml`.
 
 ## Testing pipelines manually
 

--- a/docs/cicd.md
+++ b/docs/cicd.md
@@ -8,7 +8,7 @@
 2. Builds `philobiblon-ui-backend` and `philobiblon-ui-frontend` images (with layer cache via GitHub Actions cache).
 3. Pushes to GHCR with two tags each: `main-{7-char SHA}` and `main-latest`.
 4. Deploys to the staging server via SSH using `docker-compose.ui-dev.yml`.
-5. On success, if a PR was found, posts a comment on it (`notify-success` job) mentioning `vars.DEPLOY_NOTIFY_SUCCESS_GITHUB_USER` — GitHub emails that user via its normal @mention notification, so no SMTP setup is needed. The comment body is an English summary and test plan written by Claude (`anthropics/claude-code-action@v1`) from the PR's title, body, comments and reviews, plus the description/comments of any issue the PR references. Comments from the `coderabbitai` bot are ignored. Skipped entirely if there was no associated PR.
+5. On success, if a PR was found, posts a comment on it (`notify-success` job) mentioning the GitHub author(s) of any issue(s) the PR references (`#123`-style patterns in its title/body), or `vars.DEPLOY_NOTIFY_SUCCESS_GITHUB_DEFAULT_USER` if none are linked — GitHub emails those users via its normal @mention notification, so no SMTP setup is needed. The comment body is an English summary and test plan written by Claude (`anthropics/claude-code-action@v1`) from the PR's title, body, comments and reviews, plus the description/comments of the linked issue(s). Comments from the `coderabbitai` bot are ignored. Skipped entirely if there was no associated PR.
 6. On failure of the build or deploy step, posts a failure comment instead (`notify-failure` job) mentioning `vars.DEPLOY_NOTIFY_FAILURE_GITHUB_USER`, with the failed job(s) and a link to the workflow run — on the PR if one was found, otherwise as a comment on the commit itself. Runs even when `notify-success` is skipped.
 7. Deletes old image versions, keeping the 5 most recent. Tags matching `^v` (production releases) are never deleted.
 
@@ -48,7 +48,7 @@ Create two environments: `staging` and `production`, each with:
 | `BASE_URL` | Frontend base path (e.g. `/` or `/ui/`) — baked into the image at build time |
 | `API_BASE_URL` | Backend API URL (e.g. `https://example.com/api/`) — baked into the image at build time |
 | `DEPLOY_PATH` | Absolute path to the project on the server |
-| `DEPLOY_NOTIFY_SUCCESS_GITHUB_USER` | GitHub login mentioned in the PR comment on a successful staging deploy — staging only |
+| `DEPLOY_NOTIFY_SUCCESS_GITHUB_DEFAULT_USER` | GitHub login mentioned in the PR comment on a successful staging deploy when the PR references no issue — staging only |
 | `DEPLOY_NOTIFY_FAILURE_GITHUB_USER` | GitHub login mentioned in the PR/commit comment on a failed staging deploy — staging only |
 
 ### Secrets (`secrets.*`) — encrypted


### PR DESCRIPTION
## Summary
- On a successful staging deploy, comment on the associated PR mentioning `vars.DEPLOY_NOTIFY_SUCCESS_GITHUB_USER`, with an English summary and test plan written by Claude from the PR's title/body/comments/reviews and any referenced issue (ignoring `coderabbitai` comments).
- On a failed build/deploy, comment instead mentioning `vars.DEPLOY_NOTIFY_FAILURE_GITHUB_USER` with the failed job(s) and a link to the run — on the PR if found, otherwise on the commit.
- Uses GitHub's own @mention email notifications, so no SMTP secrets are needed.
- Allow `yarn lint` and read-only `gh pr view` / `gh issue view` for Claude via a new committed `.claude/settings.json` (applies both locally and in the `claude.yml` / `claude-code-review.yml` GitHub Actions workflows).

## Test plan
- [x] Add `DEPLOY_NOTIFY_SUCCESS_GITHUB_USER` and `DEPLOY_NOTIFY_FAILURE_GITHUB_USER` variables to the `staging` GitHub environment.
- [ ] Merge a PR (or run `workflow_dispatch`) and confirm a success comment appears on it, mentioning the right user, in English, with summary + test plan.
- [ ] Simulate a `deploy` failure and confirm a failure comment appears mentioning the failure user, and that the success comment is not posted.
- [ ] Confirm a push without an associated PR falls back to a commit comment on failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Staging deployments now discover an associated pull request and automatically post Claude-generated success summaries and test plans.
  * Staging failures now post detailed failure notifications to the pull request, or as a commit comment when no PR is linked.
  * Added automation to identify and batch-rebase merge-conflicted pull requests.
* **Documentation**
  * Expanded CI/CD documentation for staging flow, image tagging/retention, and notification configuration.
* **Chores**
  * Updated automation permissions to allow linting and pull request/issue inspection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->