### PR TITLE
Only trigger the staging deploy when backend/, frontend/ or the workflow change

### DIFF
--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -3,6 +3,10 @@ name: Staging — build, push & deploy
 on:
   push:
     branches: [master]
+    paths:
+      - 'backend/**'
+      - 'frontend/**'
+      - '.github/workflows/staging.yml'
   workflow_dispatch:
 
 env:

--- a/docs/cicd.md
+++ b/docs/cicd.md
@@ -2,7 +2,9 @@
 
 ## Workflows
 
-### `staging.yml` — triggers: push to `master`, manual
+### `staging.yml` — triggers: push to `master` touching `backend/`, `frontend/` or the workflow file itself, manual
+
+Pushes that only touch other paths (docs, wiki pages, agent config…) don't produce a deployable change — the images are built solely from `backend/` and `frontend/` — so no run is triggered and, consequently, no deploy notification is posted either.
 
 1. Looks up the pull request associated with the pushed commit (`find-pr` job), if any.
 2. Builds `philobiblon-ui-backend` and `philobiblon-ui-frontend` images (with layer cache via GitHub Actions cache).


### PR DESCRIPTION
## Summary
Every push to `master` currently rebuilds and redeploys, even when nothing deployable changed. The images are built solely from `backend/` and `frontend/` (build args come from GitHub environment variables, and the deploy step uses compose files that live on the server, not in the checkout), so docs/wiki/agent-config-only merges produced identical images and a pointless redeploy.

- Add a `paths:` filter to `staging.yml`'s push trigger: `backend/**`, `frontend/**` and the workflow file itself (so pipeline changes are exercised on merge instead of lying dormant until the next code change).
- `workflow_dispatch` remains available for manual runs.
- Consequence, documented in `docs/cicd.md`: a non-deployable merge triggers no staging run, and therefore no deploy notification either — consistent, since nothing was deployed.

Note: independent of #504 (touches the `on:` block only, which #504 doesn't modify); the small `docs/cicd.md` edit may need a trivial rebase depending on merge order.

## Test plan
- [ ] Merge a docs-only change to `master` and confirm no staging run is triggered.
- [ ] Merge a `frontend/` or `backend/` change and confirm the deploy runs as before.
- [ ] Confirm **Run workflow** (manual `workflow_dispatch`) still works regardless of paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)