### PR TITLE
Fix claude-code-review: it has never posted a single comment

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
+      pull-requests: write
       issues: read
       id-token: write
 
@@ -38,7 +38,11 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
-          prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
+          # --comment is required: without it the skill only reports findings
+          # internally (visible in an interactive session) and never posts
+          # them as PR comments, so this workflow silently reviewed nothing
+          # on every prior run despite completing "successfully".
+          prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }} --comment'
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
 

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -43,6 +43,11 @@ jobs:
           # them as PR comments, so this workflow silently reviewed nothing
           # on every prior run despite completing "successfully".
           prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }} --comment'
+          # Temporary: prior runs showed permission_denials_count > 0 with no
+          # visibility into which tool was denied. Keep this on until we've
+          # confirmed a real run with --comment posts comments cleanly with
+          # zero denials, then remove it.
+          show_full_output: true
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
 


### PR DESCRIPTION
## Summary
Investigated why `claude-code-review.yml` always shows green with zero comments, even on this branch's own PR (#504) where a real bug slipped through. Checked run history across many past PRs (different branches, different dates, 2-31 turns, \$0.15-\$1.57 cost each) — **every single run** ends with `No buffered inline comments`. It has never once posted a review comment; the green check just means the job didn't error, not that it approved anything.

Root cause: the `/code-review` skill only reports findings internally by default (meant for an interactive session watching the chat) — it needs `--comment` to actually post them to the PR. The workflow's prompt never passed it:
```
prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
```

Fix:
- Add `--comment` to the prompt.
- Bump `pull-requests` permission from `read` to `write` so the token can actually post the comment.

## Test plan
- [ ] Merge this PR, then open (or push to) another PR and confirm `claude-code-review` posts actual review comments instead of finishing silently.
- [ ] Confirm the job still completes successfully (no permission errors when posting).

🤖 Generated with [Claude Code](https://claude.com/claude-code)