### PR TITLE
Diagnose notify-success Claude permission denials

### DIFF
--- a/.github/workflows/staging-deploy-notify.yml
+++ b/.github/workflows/staging-deploy-notify.yml
@@ -151,6 +151,11 @@ jobs:
             - test_plan: concrete steps to verify the change works.
           claude_args: |
             --json-schema '{"type":"object","properties":{"summary":{"type":"string"},"test_plan":{"type":"string"}},"required":["summary","test_plan"]}'
+          # Temporary: the last real run had permission_denials_count: 11 out
+          # of 21 turns and ended up filling summary/test_plan with "test"
+          # placeholder text instead of real content. Keep this on until we've
+          # seen which tool calls are being denied, then remove it.
+          show_full_output: true
 
       - name: Post deploy success comment on the PR
         env:


### PR DESCRIPTION
## Summary
The deploy success comment on PR #484 came out with `summary`/`test_plan` literally set to `"test"` for both fields — https://github.com/PhiloBiblon/philobiblon-ui/pull/484#issuecomment-4946927141. The underlying run (29156871943) shows `permission_denials_count: 11` out of 21 turns, `is_error: false` — Claude likely hit repeated tool denials (probably `.claude/settings.json`'s narrow Bash allowlist) trying to gather context, then filled the required JSON-schema fields with placeholder text just to complete instead of failing outright.

Temporarily enable `show_full_output: true` on `notify-success`'s "Generate summary and test plan with Claude" step so the next real deploy notification run shows exactly which tool calls are being denied, before deciding whether `.claude/settings.json` needs a broader allowlist.

## Test plan
- [ ] Merge, then trigger a real staging deploy notification (push touching `backend/`/`frontend/`) and inspect the full log of the Claude step to see which commands got denied.
- [ ] Once diagnosed, remove `show_full_output: true` and fix the actual permission gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)