### PR TITLE
Add new geo item #390 v2

### DIFF
--- a/frontend/components/item/Create.vue
+++ b/frontend/components/item/Create.vue
@@ -314,8 +314,12 @@ async function getDefaultClaims (itemNumber) {
           }
           dateQualifier.hidden = true
         }
-        claim = buildClaim(entity, qualifiers, { id: 'Q447227' })
-        claim.hidden = true
+        if (props.table === 'geoid') {
+          claim = buildClaim(entity, qualifiers, { id: 'Q447227' })
+          claim.hidden = true
+        } else {
+          claim = buildClaim(entity, qualifiers, null)
+        }
       } else if (props.table === 'cnum' && entity.id === 'P590') {
         claim = buildClaim(entity, qualifiers, null, false)
       } else if (props.table === 'copid' && entity.id === 'P839') {

--- a/frontend/components/item/Create.vue
+++ b/frontend/components/item/Create.vue
@@ -314,7 +314,8 @@ async function getDefaultClaims (itemNumber) {
           }
           dateQualifier.hidden = true
         }
-        claim = buildClaim(entity, qualifiers, null)
+        claim = buildClaim(entity, qualifiers, { id: 'Q447227' })
+        claim.hidden = true
       } else if (props.table === 'cnum' && entity.id === 'P590') {
         claim = buildClaim(entity, qualifiers, null, false)
       } else if (props.table === 'copid' && entity.id === 'P839') {

--- a/frontend/components/item/Create.vue
+++ b/frontend/components/item/Create.vue
@@ -574,7 +574,14 @@ function generateLabelFromClaims () {
       }
       break
     }
-    case 'geoid':
+    case 'geoid': {
+      const name = getClaimValue('P34')
+      const region = getClaimValue('P297')
+      if (name) {
+        generatedLabel = region ? `${name}, ${region}` : name
+      }
+      break
+    }
     case 'insid': {
       const name = getClaimValue('P34')
       const region = getClaimValue('P297')

--- a/frontend/components/item/claim/Create.vue
+++ b/frontend/components/item/claim/Create.vue
@@ -2,6 +2,7 @@
   <div class="claim">
     <v-row
       v-for="(claim, key) in claims"
+      v-show="!claim.hidden"
       :key="claim?.property?.id"
       class="even-row pt-5"
       no-gutters


### PR DESCRIPTION
Changes
Following reviewer feedback on this PR:

1. P799 (Dataset status) — hidden and auto-filled
P799 was showing in the creation form with an empty value that the user had to fill in manually. It is now pre-filled automatically with Q447227 ("PhiloBiblon record created") and hidden from the form, alongside the already-hidden P106 date qualifier. Both are submitted silently when the item is created.

2. P297 (Territorial localisation) — already optional
The label generation for geoid already uses if (name) (P34 alone is enough), so P297 has never been required in this branch. If it appeared required during testing, it was likely because the staging environment was still running the previous version without this branch merged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automatically pre-fills and hides the default P799 claim during item creation.
  * Generates clearer labels for geographic entries, including entries with no region.

* **Bug Fixes**
  * Hidden claims no longer appear in the claim editor.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->