### PR TITLE
feat(subject): add P422 and P1031 to subject property search

### DIFF
--- a/frontend/pages/search/bibid/query.vue
+++ b/frontend/pages/search/bibid/query.vue
@@ -1,4 +1,4 @@
-template>
+<template>
   <search-base
     table="bibid"
     :form-definition="form"

--- a/frontend/pages/search/bibid/query.vue
+++ b/frontend/pages/search/bibid/query.vue
@@ -1,4 +1,4 @@
-<template>
+﻿<template>
   <search-base
     table="bibid"
     :form-definition="form"
@@ -318,7 +318,7 @@ const form = {
                   SELECT DISTINCT ?target_item WHERE {
                     ?item wdt:P476 ?pbid .
                     FILTER regex(?pbid, '{{database}} {{table}} ')
-                    VALUES ?property { wdt:P97 wdt:P121 wdt:P122 wdt:P243 wdt:P304 wdt:P452 wdt:P608 wdt:P1094 wdt:P1278 }
+                    VALUES ?property { wdt:P97 wdt:P121 wdt:P122 wdt:P243 wdt:P304 wdt:P422 wdt:P452 wdt:P608 wdt:P1031 wdt:P1094 wdt:P1278 }
                     ?item ?property ?target_item .
                     {{bitagapGroupSubjectFilter}}
                   }

--- a/frontend/pages/search/bibid/query.vue
+++ b/frontend/pages/search/bibid/query.vue
@@ -1,4 +1,4 @@
-﻿<template>
+template>
   <search-base
     table="bibid"
     :form-definition="form"

--- a/frontend/pages/search/bioid/query.vue
+++ b/frontend/pages/search/bioid/query.vue
@@ -1,4 +1,4 @@
-<template>
+﻿<template>
   <search-base
     table="bioid"
     :form-definition="form"
@@ -338,7 +338,7 @@ const form = {
                   SELECT DISTINCT ?target_item WHERE {
                     ?item wdt:P476 ?pbid .
                     FILTER regex(?pbid, '{{database}} {{table}} ')
-                    VALUES ?property { wdt:P97 wdt:P121 wdt:P122 wdt:P243 wdt:P304 wdt:P452 wdt:P608 wdt:P1094 wdt:P1278 }
+                    VALUES ?property { wdt:P97 wdt:P121 wdt:P122 wdt:P243 wdt:P304 wdt:P422 wdt:P452 wdt:P608 wdt:P1031 wdt:P1094 wdt:P1278 }
                     ?item ?property ?target_item .
                     {{bitagapGroupSubjectFilter}}
                   }

--- a/frontend/pages/search/bioid/query.vue
+++ b/frontend/pages/search/bioid/query.vue
@@ -1,4 +1,4 @@
-﻿<template>
+template>
   <search-base
     table="bioid"
     :form-definition="form"

--- a/frontend/pages/search/bioid/query.vue
+++ b/frontend/pages/search/bioid/query.vue
@@ -1,4 +1,4 @@
-template>
+<template>
   <search-base
     table="bioid"
     :form-definition="form"

--- a/frontend/pages/search/cnum/query.vue
+++ b/frontend/pages/search/cnum/query.vue
@@ -1,4 +1,4 @@
-<template>
+﻿<template>
   <search-base
     table="cnum"
     :form-definition="form"
@@ -698,7 +698,7 @@ const form = {
               ?item wdt:P476 ?pbid .
               FILTER regex(?pbid, '{{database}} {{table}} ')
               {{bitagapGroupSubjectFilter}}
-              VALUES ?property { wdt:P97 wdt:P121 wdt:P122 wdt:P243 wdt:P304 wdt:P452 wdt:P608 wdt:P1094 wdt:P1278 }
+              VALUES ?property { wdt:P97 wdt:P121 wdt:P122 wdt:P243 wdt:P304 wdt:P422 wdt:P452 wdt:P608 wdt:P1031 wdt:P1094 wdt:P1278 }
               ?item ?property ?target_item .
             }
           }

--- a/frontend/pages/search/cnum/query.vue
+++ b/frontend/pages/search/cnum/query.vue
@@ -1,4 +1,4 @@
-﻿<template>
+template>
   <search-base
     table="cnum"
     :form-definition="form"

--- a/frontend/pages/search/cnum/query.vue
+++ b/frontend/pages/search/cnum/query.vue
@@ -1,4 +1,4 @@
-template>
+<template>
   <search-base
     table="cnum"
     :form-definition="form"

--- a/frontend/pages/search/copid/query.vue
+++ b/frontend/pages/search/copid/query.vue
@@ -1,4 +1,4 @@
-<template>
+﻿<template>
   <search-base
     table="copid"
     :form-definition="form"
@@ -356,7 +356,7 @@ const form = {
                     ?item wdt:P476 ?pbid .
                     FILTER regex(?pbid, '{{database}} {{table}} ')
                     {{bitagapGroupSubjectFilter}}
-                    VALUES ?property { wdt:P97 wdt:P121 wdt:P122 wdt:P243 wdt:P304 wdt:P452 wdt:P608 wdt:P1094 wdt:P1278 }
+                    VALUES ?property { wdt:P97 wdt:P121 wdt:P122 wdt:P243 wdt:P304 wdt:P422 wdt:P452 wdt:P608 wdt:P1031 wdt:P1094 wdt:P1278 }
                     ?item ?property ?target_item .
                   }
                 }

--- a/frontend/pages/search/copid/query.vue
+++ b/frontend/pages/search/copid/query.vue
@@ -1,4 +1,4 @@
-﻿<template>
+template>
   <search-base
     table="copid"
     :form-definition="form"

--- a/frontend/pages/search/copid/query.vue
+++ b/frontend/pages/search/copid/query.vue
@@ -1,4 +1,4 @@
-template>
+<template>
   <search-base
     table="copid"
     :form-definition="form"

--- a/frontend/pages/search/geoid/query.vue
+++ b/frontend/pages/search/geoid/query.vue
@@ -1,4 +1,4 @@
-<template>
+﻿<template>
   <search-base
     table="geoid"
     :form-definition="form"
@@ -152,7 +152,7 @@ const form = {
                   SELECT DISTINCT ?target_item WHERE {
                     ?item wdt:P476 ?pbid .
                     FILTER regex(?pbid, '{{database}} {{table}} ')
-                    VALUES ?property { wdt:P97 wdt:P121 wdt:P122 wdt:P243 wdt:P304 wdt:P452 wdt:P608 wdt:P1094 wdt:P1278 }
+                    VALUES ?property { wdt:P97 wdt:P121 wdt:P122 wdt:P243 wdt:P304 wdt:P422 wdt:P452 wdt:P608 wdt:P1031 wdt:P1094 wdt:P1278 }
                     ?item ?property ?target_item .
                     {{bitagapGroupSubjectFilter}}
                   }

--- a/frontend/pages/search/geoid/query.vue
+++ b/frontend/pages/search/geoid/query.vue
@@ -1,4 +1,4 @@
-﻿<template>
+template>
   <search-base
     table="geoid"
     :form-definition="form"

--- a/frontend/pages/search/geoid/query.vue
+++ b/frontend/pages/search/geoid/query.vue
@@ -1,4 +1,4 @@
-template>
+<template>
   <search-base
     table="geoid"
     :form-definition="form"

--- a/frontend/pages/search/insid/query.vue
+++ b/frontend/pages/search/insid/query.vue
@@ -1,4 +1,4 @@
-<template>
+﻿<template>
   <search-base
     table="insid"
     :form-definition="form"
@@ -185,7 +185,7 @@ const form = {
                     ?item wdt:P476 ?pbid .
                     FILTER regex(?pbid, '{{database}} {{table}} ')
                     {{bitagapGroupSubjectFilter}}
-                    VALUES ?property { wdt:P97 wdt:P121 wdt:P122 wdt:P243 wdt:P304 wdt:P452 wdt:P608 wdt:P1094 wdt:P1278 }
+                    VALUES ?property { wdt:P97 wdt:P121 wdt:P122 wdt:P243 wdt:P304 wdt:P422 wdt:P452 wdt:P608 wdt:P1031 wdt:P1094 wdt:P1278 }
                     ?item ?property ?target_item .
                   }
                 }

--- a/frontend/pages/search/insid/query.vue
+++ b/frontend/pages/search/insid/query.vue
@@ -1,4 +1,4 @@
-template>
+<template>
   <search-base
     table="insid"
     :form-definition="form"

--- a/frontend/pages/search/insid/query.vue
+++ b/frontend/pages/search/insid/query.vue
@@ -1,4 +1,4 @@
-﻿<template>
+template>
   <search-base
     table="insid"
     :form-definition="form"

--- a/frontend/pages/search/libid/query.vue
+++ b/frontend/pages/search/libid/query.vue
@@ -1,4 +1,4 @@
-﻿<template>
+template>
   <search-base
     table="libid"
     :form-definition="form"

--- a/frontend/pages/search/libid/query.vue
+++ b/frontend/pages/search/libid/query.vue
@@ -1,4 +1,4 @@
-template>
+<template>
   <search-base
     table="libid"
     :form-definition="form"

--- a/frontend/pages/search/libid/query.vue
+++ b/frontend/pages/search/libid/query.vue
@@ -1,4 +1,4 @@
-<template>
+﻿<template>
   <search-base
     table="libid"
     :form-definition="form"
@@ -187,7 +187,7 @@ const form = {
                     ?item wdt:P476 ?pbid .
                     FILTER regex(?pbid, '{{database}} {{table}} ')
                     {{bitagapGroupSubjectFilter}}
-                    VALUES ?property { wdt:P97 wdt:P121 wdt:P122 wdt:P243 wdt:P304 wdt:P452 wdt:P608 wdt:P1094 wdt:P1278 }
+                    VALUES ?property { wdt:P97 wdt:P121 wdt:P122 wdt:P243 wdt:P304 wdt:P422 wdt:P452 wdt:P608 wdt:P1031 wdt:P1094 wdt:P1278 }
                     ?item ?property ?target_item .
                   }
                 }

--- a/frontend/pages/search/manid/query.vue
+++ b/frontend/pages/search/manid/query.vue
@@ -1,4 +1,4 @@
-﻿<template>
+template>
   <search-base
     table="manid"
     :form-definition="form"

--- a/frontend/pages/search/manid/query.vue
+++ b/frontend/pages/search/manid/query.vue
@@ -1,4 +1,4 @@
-<template>
+﻿<template>
   <search-base
     table="manid"
     :form-definition="form"
@@ -524,7 +524,7 @@ const form = {
                     ?item wdt:P476 ?pbid .
                     FILTER regex(?pbid, '{{database}} {{table}} ')
                     {{bitagapGroupSubjectFilter}}
-                    VALUES ?property { wdt:P97 wdt:P121 wdt:P122 wdt:P243 wdt:P304 wdt:P452 wdt:P608 wdt:P1094 wdt:P1278 }
+                    VALUES ?property { wdt:P97 wdt:P121 wdt:P122 wdt:P243 wdt:P304 wdt:P422 wdt:P452 wdt:P608 wdt:P1031 wdt:P1094 wdt:P1278 }
                     ?item ?property ?target_item .
                   }
                 }

--- a/frontend/pages/search/manid/query.vue
+++ b/frontend/pages/search/manid/query.vue
@@ -1,4 +1,4 @@
-template>
+<template>
   <search-base
     table="manid"
     :form-definition="form"

--- a/frontend/pages/search/texid/query.vue
+++ b/frontend/pages/search/texid/query.vue
@@ -1,4 +1,4 @@
-template>
+<template>
   <search-base
     table="texid"
     :form-definition="form"

--- a/frontend/pages/search/texid/query.vue
+++ b/frontend/pages/search/texid/query.vue
@@ -1,4 +1,4 @@
-<template>
+﻿<template>
   <search-base
     table="texid"
     :form-definition="form"
@@ -423,7 +423,7 @@ const form = {
                     ?item wdt:P476 ?pbid .
                     FILTER regex(?pbid, '{{database}} {{table}} ')
                     {{bitagapGroupSubjectFilter}}
-                    VALUES ?property { wdt:P97 wdt:P121 wdt:P122 wdt:P243 wdt:P304 wdt:P452 wdt:P608 wdt:P1094 wdt:P1278 }
+                    VALUES ?property { wdt:P97 wdt:P121 wdt:P122 wdt:P243 wdt:P304 wdt:P422 wdt:P452 wdt:P608 wdt:P1031 wdt:P1094 wdt:P1278 }
                     ?item ?property ?target_item .
                   }
                 }

--- a/frontend/pages/search/texid/query.vue
+++ b/frontend/pages/search/texid/query.vue
@@ -1,4 +1,4 @@
-﻿<template>
+template>
   <search-base
     table="texid"
     :form-definition="form"

--- a/frontend/service/query.service.js
+++ b/frontend/service/query.service.js
@@ -1,4 +1,4 @@
-mport { useQueryStatusStore } from '~/stores/queryStatus'
+import { useQueryStatusStore } from '~/stores/queryStatus'
 
 const BITAGAP_DB = 'BITAGAP'
 const CARTAS_TEXT = '[Cartas de]'

--- a/frontend/service/query.service.js
+++ b/frontend/service/query.service.js
@@ -1,4 +1,4 @@
-import { useQueryStatusStore } from '~/stores/queryStatus'
+﻿import { useQueryStatusStore } from '~/stores/queryStatus'
 
 const BITAGAP_DB = 'BITAGAP'
 const CARTAS_TEXT = '[Cartas de]'
@@ -269,7 +269,7 @@ export class QueryService {
     if (form.input.subject && form.input.subject.value) {
       filters +=
         `
-        VALUES ?prop_subject { wdt:P97 wdt:P121 wdt:P122 wdt:P243 wdt:P304 wdt:P452 wdt:P608 wdt:P1094 wdt:P1278 }
+        VALUES ?prop_subject { wdt:P97 wdt:P121 wdt:P122 wdt:P243 wdt:P304 wdt:P422 wdt:P452 wdt:P608 wdt:P1031 wdt:P1094 wdt:P1278 }
         ?item ?prop_subject wd:${form.input.subject.value.target_item} .
         `
     }
@@ -496,7 +496,7 @@ export class QueryService {
     if (form.input.subject && form.input.subject.value) {
       filters +=
         `
-        VALUES ?prop_subject { wdt:P97 wdt:P121 wdt:P122 wdt:P243 wdt:P304 wdt:P452 wdt:P608 wdt:P1094 wdt:P1278 }
+        VALUES ?prop_subject { wdt:P97 wdt:P121 wdt:P122 wdt:P243 wdt:P304 wdt:P422 wdt:P452 wdt:P608 wdt:P1031 wdt:P1094 wdt:P1278 }
         ?item ?prop_subject wd:${form.input.subject.value.target_item} .
         `
     }
@@ -584,7 +584,7 @@ export class QueryService {
     if (form.input.subject && form.input.subject.value) {
       filters +=
         `
-        VALUES ?prop_subject { wdt:P97 wdt:P121 wdt:P122 wdt:P243 wdt:P304 wdt:P452 wdt:P608 wdt:P1094 wdt:P1278 }
+        VALUES ?prop_subject { wdt:P97 wdt:P121 wdt:P122 wdt:P243 wdt:P304 wdt:P422 wdt:P452 wdt:P608 wdt:P1031 wdt:P1094 wdt:P1278 }
         ?item ?prop_subject wd:${form.input.subject.value.target_item} .
         `
     }
@@ -630,7 +630,7 @@ export class QueryService {
     if (form.input.subject && form.input.subject.value) {
       filters +=
         `
-        VALUES ?prop_subject { wdt:P97 wdt:P121 wdt:P122 wdt:P243 wdt:P304 wdt:P452 wdt:P608 wdt:P1094 wdt:P1278 }
+        VALUES ?prop_subject { wdt:P97 wdt:P121 wdt:P122 wdt:P243 wdt:P304 wdt:P422 wdt:P452 wdt:P608 wdt:P1031 wdt:P1094 wdt:P1278 }
         ?item ?prop_subject wd:${form.input.subject.value.target_item} .
         `
     }
@@ -710,7 +710,7 @@ export class QueryService {
     if (form.input.subject && form.input.subject.value) {
       filters +=
         `
-        VALUES ?prop_subject { wdt:P97 wdt:P121 wdt:P122 wdt:P243 wdt:P304 wdt:P452 wdt:P608 wdt:P1094 wdt:P1278 }
+        VALUES ?prop_subject { wdt:P97 wdt:P121 wdt:P122 wdt:P243 wdt:P304 wdt:P422 wdt:P452 wdt:P608 wdt:P1031 wdt:P1094 wdt:P1278 }
         ?item ?prop_subject wd:${form.input.subject.value.target_item} .
         `
     }
@@ -734,7 +734,7 @@ export class QueryService {
     if (form.input.subject && form.input.subject.value) {
       filters +=
         `
-        VALUES ?prop_subject { wdt:P97 wdt:P121 wdt:P122 wdt:P243 wdt:P304 wdt:P452 wdt:P608 wdt:P1094 wdt:P1278 }
+        VALUES ?prop_subject { wdt:P97 wdt:P121 wdt:P122 wdt:P243 wdt:P304 wdt:P422 wdt:P452 wdt:P608 wdt:P1031 wdt:P1094 wdt:P1278 }
         ?item ?prop_subject wd:${form.input.subject.value.target_item} .
         `
     }
@@ -1048,7 +1048,7 @@ export class QueryService {
     if (form.input.subject && form.input.subject.value) {
       filters +=
         `
-        VALUES ?prop_subject { wdt:P97 wdt:P121 wdt:P122 wdt:P243 wdt:P304 wdt:P452 wdt:P608 wdt:P1094 wdt:P1278 }
+        VALUES ?prop_subject { wdt:P97 wdt:P121 wdt:P122 wdt:P243 wdt:P304 wdt:P422 wdt:P452 wdt:P608 wdt:P1031 wdt:P1094 wdt:P1278 }
         ?item ?prop_subject wd:${form.input.subject.value.target_item} .
         `
     }

--- a/frontend/service/query.service.js
+++ b/frontend/service/query.service.js
@@ -1,4 +1,4 @@
-﻿import { useQueryStatusStore } from '~/stores/queryStatus'
+mport { useQueryStatusStore } from '~/stores/queryStatus'
 
 const BITAGAP_DB = 'BITAGAP'
 const CARTAS_TEXT = '[Cartas de]'


### PR DESCRIPTION
Extends the subject search to include two additional FactGrid properties alongside the nine already covered by issue #365:

- P422 (Subject Headings)
- P1031 (Search terms used)

Updated all search pages (texid, manid, copid, libid, insid, bibid, bioid, geoid, cnum) and query.service.js to use the full 11-property VALUES clause.

Closes #508