### PR TITLE
fix(session): navigate to home on new login instead of restoring item view

### DIFF
--- a/frontend/pages/oauth_callback.vue
+++ b/frontend/pages/oauth_callback.vue
@@ -24,6 +24,8 @@ onMounted(async () => {
     console.error('OAuth login failed:', response.error)
     $notification.error(t('messages.error.auth.login_failed'))
   }
-  router.push(localePath(previousPathCookie.value || '/'))
+  const previousPath = previousPathCookie.value || '/'
+  const isItemView = previousPath.includes('/item/') && !previousPath.endsWith('/create')
+  router.push(localePath(isItemView ? '/' : previousPath))
 })
 </script>


### PR DESCRIPTION
After OAuth login, the app was redirecting back to the item page the user had open when they clicked Login, violating the tabula rasa requirement for new sessions.

oauth_callback.vue now checks the saved previous path: if it points to an item view page (matches /item/ but not /create), it redirects to home instead. Search pages and the create flow are still restored as before.

Closes #510