### PR TITLE
fix(session): navigate to home on new login instead of restoring item view

### DIFF
--- a/frontend/pages/oauth_callback.vue
+++ b/frontend/pages/oauth_callback.vue
@@ -24,6 +24,8 @@ onMounted(async () => {
     console.error('OAuth login failed:', response.error)
     $notification.error(t('messages.error.auth.login_failed'))
   }
-  router.push(localePath(previousPathCookie.value || '/'))
+  const previousPath = previousPathCookie.value || '/'
+  const isItemView = previousPath.includes('/item/') && !previousPath.endsWith('/create')
+  router.push(localePath(isItemView ? '/' : previousPath))
 })
 </script>

--- a/frontend/pages/oauth_callback.vue
+++ b/frontend/pages/oauth_callback.vue
@@ -18,14 +18,15 @@ const previousPathCookie = useCookie('previous-path')
 onMounted(async () => {
   const { oauth_token: oauthToken, oauth_verifier: oauthVerifier } = route.query
   const response = await $wikibase.$oauth.step3(oauthToken, oauthVerifier)
+  const previousPath = previousPathCookie.value || '/'
   if (response.status === 0) {
     $notification.success(t('auth.login.success', { name: authStore.username }))
+    const isItemView = previousPath.includes('/item/') && !previousPath.endsWith('/create')
+    router.push(localePath(isItemView ? '/' : previousPath))
   } else {
     console.error('OAuth login failed:', response.error)
     $notification.error(t('messages.error.auth.login_failed'))
+    router.push(localePath(previousPath))
   }
-  const previousPath = previousPathCookie.value || '/'
-  const isItemView = previousPath.includes('/item/') && !previousPath.endsWith('/create')
-  router.push(localePath(isItemView ? '/' : previousPath))
 })
 </script>


### PR DESCRIPTION
After OAuth login, the app was redirecting back to the item page the user had open when they clicked Login, violating the tabula rasa requirement for new sessions.

oauth_callback.vue now checks the saved previous path: if it points to an item view page (matches /item/ but not /create), it redirects to home instead. Search pages and the create flow are still restored as before.

Closes #510

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved OAuth callback navigation by returning item views to the home page.
  * Preserved the intended previous location for other pages after authentication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->