### PR TITLE
fix(frontend): correct pt description typo and add language/bibliography mismatch validation #451

### DIFF
--- a/frontend/components/item/Create.vue
+++ b/frontend/components/item/Create.vue
@@ -101,6 +101,8 @@ import { useI18n } from 'vue-i18n'
 import { useAuthStore } from '~/stores/auth'
 import { WikibaseService } from '~/service/wikibase.service'
 
+const BIBLIOGRAPHY_LOCALE_MAP = { BETA: 'es', BITECA: 'ca', BITAGAP: 'pt' }
+
 const props = defineProps({
   database: { type: String, required: true },
   table: { type: String, required: true }
@@ -180,9 +182,8 @@ function cancel () {
 }
 
 function getCreateDisabledReason () {
-  const BIBLIOGRAPHY_LOCALE_MAP = { BETA: 'es', BITECA: 'ca', BITAGAP: 'pt' }
   const expectedLocale = BIBLIOGRAPHY_LOCALE_MAP[props.database]
-  if (expectedLocale && locale.value !== expectedLocale) {
+  if (expectedLocale && ['es', 'ca', 'pt'].includes(locale.value) && locale.value !== expectedLocale) {
     return t('messages.error.inputs.language_mismatch')
   }
 

--- a/frontend/components/item/Create.vue
+++ b/frontend/components/item/Create.vue
@@ -180,6 +180,12 @@ function cancel () {
 }
 
 function getCreateDisabledReason () {
+  const BIBLIOGRAPHY_LOCALE_MAP = { BETA: 'es', BITECA: 'ca', BITAGAP: 'pt' }
+  const expectedLocale = BIBLIOGRAPHY_LOCALE_MAP[props.database]
+  if (expectedLocale && locale.value !== expectedLocale) {
+    return t('messages.error.inputs.language_mismatch')
+  }
+
   if (!label.value) {
     return t('messages.error.inputs.label')
   }

--- a/frontend/lang/ca.js
+++ b/frontend/lang/ca.js
@@ -716,7 +716,8 @@ export default {
         description: 'Si us plau, ompliu la descripció',
         initial_claims: 'Les afirmacions s\'estan carregant',
         claim_value_missing: 'Si us plau, ompliu el valor de l\'afirmació per a "{propertyLabel}"',
-        incomplete_date: 'Si us plau, ompliu una data completa (any, mes i dia) per al qualificador "{propertyLabel}"'
+        incomplete_date: 'Si us plau, ompliu una data completa (any, mes i dia) per al qualificador "{propertyLabel}"',
+        language_mismatch: 'La llengua de la interfície no coincideix amb la bibliografia. Per a BETA usa el castellà, per a BITECA el català, per a BITAGAP el portuguès.'
       },
       creation: {
         pbid_already_exists: 'El PhiloBiblon ID "{pbid}" ja existeix en {item}.'

--- a/frontend/lang/en.js
+++ b/frontend/lang/en.js
@@ -718,7 +718,8 @@ export default {
         description: 'Please fill description',
         initial_claims: 'Claims are still loading',
         claim_value_missing: 'Please fill in the claim value for "{propertyLabel}"',
-        incomplete_date: 'Please fill in a complete date (year, month and day) for the "{propertyLabel}" qualifier'
+        incomplete_date: 'Please fill in a complete date (year, month and day) for the "{propertyLabel}" qualifier',
+        language_mismatch: 'The interface language does not match the bibliography. BETA requires Spanish, BITECA Catalan, BITAGAP Portuguese.'
       },
       creation: {
         pbid_already_exists: 'PhiloBiblon ID "{pbid}" already exists in {item}.'

--- a/frontend/lang/es.js
+++ b/frontend/lang/es.js
@@ -716,7 +716,8 @@ export default {
         description: 'Por favor, rellena la descripción',
         initial_claims: 'Los enunciados todavía se están cargando',
         claim_value_missing: 'Por favor, rellena el valor del enunciado para "{propertyLabel}"',
-        incomplete_date: 'Por favor, introduce una fecha completa (año, mes y día) para el calificador "{propertyLabel}"'
+        incomplete_date: 'Por favor, introduce una fecha completa (año, mes y día) para el calificador "{propertyLabel}"',
+        language_mismatch: 'La lengua de la interfaz no coincide con la bibliografía. Para BETA usa español, para BITECA catalán, para BITAGAP portugués.'
       },
       creation: {
         pbid_already_exists: 'El PhiloBiblon ID "{pbid}" ya existe en {item}.'

--- a/frontend/lang/gl.js
+++ b/frontend/lang/gl.js
@@ -716,7 +716,8 @@ export default {
         description: 'Por favor, enche a descrición',
         initial_claims: 'Os enunciados aínda se están cargando',
         claim_value_missing: 'Por favor, enche o valor do enunciado para "{propertyLabel}"',
-        incomplete_date: 'Por favor, enche unha data completa (ano, mes e día) para o cualificador "{propertyLabel}"'
+        incomplete_date: 'Por favor, enche unha data completa (ano, mes e día) para o cualificador "{propertyLabel}"',
+        language_mismatch: 'A lingua da interface non coincide coa bibliografía. Para BETA usa o español, para BITECA o catalán, para BITAGAP o portugués.'
       },
       creation: {
         pbid_already_exists: 'O PhiloBiblon ID "{pbid}" xa existe en {item}.'

--- a/frontend/lang/pt.js
+++ b/frontend/lang/pt.js
@@ -566,7 +566,7 @@ export default {
     title: 'Título',
     description: 'Descrição',
     alias: 'Pseudónimo',
-    cnum_description: 'testemunha textual',
+    cnum_description: 'testemunho textual',
     back: 'Volte',
     identifiers: 'Identificadores',
     related_items: 'Itens relacionados',
@@ -716,7 +716,8 @@ export default {
         description: 'Por favor, preencha a descrição',
         initial_claims: 'Os enunciados ainda estão a carregar',
         claim_value_missing: 'Por favor, preencha o valor do enunciado para "{propertyLabel}"',
-        incomplete_date: 'Por favor, preencha uma data completa (ano, mês e dia) para o qualificador "{propertyLabel}"'
+        incomplete_date: 'Por favor, preencha uma data completa (ano, mês e dia) para o qualificador "{propertyLabel}"',
+        language_mismatch: 'O idioma da interface não corresponde à bibliografia. Para BETA use o espanhol, para BITECA o catalão, para BITAGAP o português.'
       },
       creation: {
         pbid_already_exists: 'O PhiloBiblon ID "{pbid}" já existe em {item}.'


### PR DESCRIPTION

- Fix Portuguese cnum default description: 'testemunha textual' → 'testemunho textual'
- Block item creation when the interface language does not match the bibliography (BETA/Spanish, BITECA/Catalan, BITAGAP/Portuguese), with an error message in all five supported languages (es, ca, pt, en, gl)