### PR TITLE
fix: don't block COP creation when qualifier has no property selected

### DIFF
--- a/frontend/components/item/Create.vue
+++ b/frontend/components/item/Create.vue
@@ -233,8 +233,6 @@ function getCreateDisabledReason () {
       if (item?.value == null || item?.value === '') {
         return t('messages.error.inputs.claim_value_missing', { propertyLabel })
       }
-
-
     }
   }
 

--- a/frontend/components/item/Create.vue
+++ b/frontend/components/item/Create.vue
@@ -234,8 +234,6 @@ function getCreateDisabledReason () {
         return t('messages.error.inputs.claim_value_missing', { propertyLabel })
       }
 
-      const claimLabel = initialClaim?.value?.datavalue?.value?.label || propertyLabel
-
       if (propKey !== 'P2') {
         for (const [qualifierKey, qualifierVal] of Object.entries(item.qualifiers || {})) {
           // Empty qualifiers are dropped by cleanClaims before saving, so they
@@ -247,8 +245,10 @@ function getCreateDisabledReason () {
           if (!hasValue) {
             continue
           }
+          // A qualifier with a value but no property selected (null key) is dropped by
+          // cleanClaims before saving, so it must not block creation either.
           if (!qualifierKey || qualifierKey === 'null') {
-            return t('messages.error.inputs.qualifier_key_missing', { claimLabel, propertyLabel })
+            continue
           }
         }
       }

--- a/frontend/components/item/Create.vue
+++ b/frontend/components/item/Create.vue
@@ -234,24 +234,7 @@ function getCreateDisabledReason () {
         return t('messages.error.inputs.claim_value_missing', { propertyLabel })
       }
 
-      if (propKey !== 'P2') {
-        for (const [qualifierKey, qualifierVal] of Object.entries(item.qualifiers || {})) {
-          // Empty qualifiers are dropped by cleanClaims before saving, so they
-          // must not block creation. This is what happens with the default
-          // empty qualifiers pre-filled on a required claim (e.g. P10/P805 on
-          // P329 for manid): leaving them blank should be allowed instead of
-          // forcing the user to fill or delete each line.
-          const hasValue = qualifierVal != null && qualifierVal !== '' && qualifierVal !== 'null'
-          if (!hasValue) {
-            continue
-          }
-          // A qualifier with a value but no property selected (null key) is dropped by
-          // cleanClaims before saving, so it must not block creation either.
-          if (!qualifierKey || qualifierKey === 'null') {
-            continue
-          }
-        }
-      }
+
     }
   }
 

--- a/frontend/lang/ca.js
+++ b/frontend/lang/ca.js
@@ -715,7 +715,6 @@ export default {
         description: 'Si us plau, ompliu la descripció',
         initial_claims: 'Les afirmacions s\'estan carregant',
         claim_value_missing: 'Si us plau, ompliu el valor de l\'afirmació per a "{propertyLabel}"',
-        qualifier_key_missing: 'Falta una propietat de qualificador a l\'afirmació "{claimLabel}" per a "{propertyLabel}"',
         incomplete_date: 'Si us plau, ompliu una data completa (any, mes i dia) per al qualificador "{propertyLabel}"'
       },
       creation: {

--- a/frontend/lang/en.js
+++ b/frontend/lang/en.js
@@ -717,7 +717,6 @@ export default {
         description: 'Please fill description',
         initial_claims: 'Claims are still loading',
         claim_value_missing: 'Please fill in the claim value for "{propertyLabel}"',
-        qualifier_key_missing: 'A qualifier property is missing in the claim "{claimLabel}" for "{propertyLabel}"',
         incomplete_date: 'Please fill in a complete date (year, month and day) for the "{propertyLabel}" qualifier'
       },
       creation: {

--- a/frontend/lang/es.js
+++ b/frontend/lang/es.js
@@ -715,7 +715,6 @@ export default {
         description: 'Por favor, rellena la descripción',
         initial_claims: 'Los enunciados todavía se están cargando',
         claim_value_missing: 'Por favor, rellena el valor del enunciado para "{propertyLabel}"',
-        qualifier_key_missing: 'Falta una propiedad calificadora en el enunciado "{claimLabel}" para "{propertyLabel}"',
         incomplete_date: 'Por favor, introduce una fecha completa (año, mes y día) para el calificador "{propertyLabel}"'
       },
       creation: {

--- a/frontend/lang/gl.js
+++ b/frontend/lang/gl.js
@@ -715,7 +715,6 @@ export default {
         description: 'Por favor, enche a descrición',
         initial_claims: 'Os enunciados aínda se están cargando',
         claim_value_missing: 'Por favor, enche o valor do enunciado para "{propertyLabel}"',
-        qualifier_key_missing: 'Falta unha propiedade cualificadora no enunciado "{claimLabel}" para "{propertyLabel}"',
         incomplete_date: 'Por favor, enche unha data completa (ano, mes e día) para o cualificador "{propertyLabel}"'
       },
       creation: {

--- a/frontend/lang/pt.js
+++ b/frontend/lang/pt.js
@@ -715,7 +715,6 @@ export default {
         description: 'Por favor, preencha a descrição',
         initial_claims: 'Os enunciados ainda estão a carregar',
         claim_value_missing: 'Por favor, preencha o valor do enunciado para "{propertyLabel}"',
-        qualifier_key_missing: 'Falta uma propriedade qualificadora no enunciado "{claimLabel}" para "{propertyLabel}"',
         incomplete_date: 'Por favor, preencha uma data completa (ano, mês e dia) para o qualificador "{propertyLabel}"'
       },
       creation: {


### PR DESCRIPTION
`getCreateDisabledReason` was returning a `qualifier_key_missing` error when a qualifier had a non-null value but a null property key. This blocked item creation even though `cleanClaims` silently drops such qualifiers before saving anyway — making the error both surprising and incorrect.

The fix aligns the validation with `cleanClaims`: if a qualifier with a null key would be discarded on save, it must not block creation either.

Pending (wiki config, no code required):
- P843 (FRBR entity class) auto-fill for copid (Q453706) needs a `default_value` entry in `Ui_ControlledVocabulary` under the copid section. Once added, it will auto-select on creation just like it does for cnum.

closes #389

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved item creation validation for missing required values.
  * Empty or unset qualifier keys are now ignored consistently, preventing unnecessary validation errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->