### PR TITLE
fix: paginate related P21/P703 records and fix bioid author label (#166)

### DIFF
--- a/frontend/components/item/related/Table.vue
+++ b/frontend/components/item/related/Table.vue
@@ -43,7 +43,7 @@ const { t } = useI18n()
 const items = ref([])
 const currentPage = ref(1)
 const totalResults = ref(0)
-const resultsPerPage = 20
+const resultsPerPage = props.references?.resultsPerPage ?? 10
 
 onMounted(async () => {
   if (props.itemId) {

--- a/frontend/components/item/related/Table.vue
+++ b/frontend/components/item/related/Table.vue
@@ -43,7 +43,7 @@ const { t } = useI18n()
 const items = ref([])
 const currentPage = ref(1)
 const totalResults = ref(0)
-const resultsPerPage = 10
+const resultsPerPage = 20
 
 onMounted(async () => {
   if (props.itemId) {

--- a/frontend/components/item/related/Tables.vue
+++ b/frontend/components/item/related/Tables.vue
@@ -100,7 +100,7 @@ const relatedTables = {
       ]
     },
     {
-      label: 'item.related.bioid.authors',
+      label: 'item.related.bioid.texts',
       refTables: [
         { refTable: 'texid', property: 'P21' }
       ]

--- a/frontend/components/item/related/Tables.vue
+++ b/frontend/components/item/related/Tables.vue
@@ -101,6 +101,7 @@ const relatedTables = {
     },
     {
       label: 'item.related.bioid.texts',
+      resultsPerPage: 20,
       refTables: [
         { refTable: 'texid', property: 'P21' }
       ]
@@ -151,6 +152,7 @@ const relatedTables = {
     },
     {
       label: 'item.related.bioid.related_individuals',
+      resultsPerPage: 20,
       refTables: [
         { refTable: 'bioid', property: 'P703' },
         { refTable: 'cnum', property: 'P703' },

--- a/frontend/lang/ca.js
+++ b/frontend/lang/ca.js
@@ -598,7 +598,7 @@ export default {
       },
       bioid: {
         subject_references: 'Referències temàtiques',
-        texts: 'Text',
+        texts: 'Textos',
         commentary: 'Comentari',
         financed_by: 'Finançat per',
         former_owners: 'Antics propietaris',

--- a/frontend/lang/ca.js
+++ b/frontend/lang/ca.js
@@ -598,7 +598,7 @@ export default {
       },
       bioid: {
         subject_references: 'Referències temàtiques',
-        authors: 'Autors',
+        texts: 'Text',
         commentary: 'Comentari',
         financed_by: 'Finançat per',
         former_owners: 'Antics propietaris',

--- a/frontend/lang/en.js
+++ b/frontend/lang/en.js
@@ -600,7 +600,7 @@ export default {
       },
       bioid: {
         subject_references: 'Subject references',
-        texts: 'Text',
+        texts: 'Texts',
         commentary: 'Commentary',
         financed_by: 'Financed by',
         former_owners: 'Former owners',

--- a/frontend/lang/en.js
+++ b/frontend/lang/en.js
@@ -600,7 +600,7 @@ export default {
       },
       bioid: {
         subject_references: 'Subject references',
-        authors: 'Authors',
+        texts: 'Text',
         commentary: 'Commentary',
         financed_by: 'Financed by',
         former_owners: 'Former owners',

--- a/frontend/lang/es.js
+++ b/frontend/lang/es.js
@@ -598,7 +598,7 @@ export default {
       },
       bioid: {
         subject_references: 'Referencias del tema',
-        authors: 'Autores',
+        texts: 'Texto',
         commentary: 'Comentario',
         financed_by: 'Financiado por',
         former_owners: 'Ex propietarios',

--- a/frontend/lang/es.js
+++ b/frontend/lang/es.js
@@ -598,7 +598,7 @@ export default {
       },
       bioid: {
         subject_references: 'Referencias del tema',
-        texts: 'Texto',
+        texts: 'Textos',
         commentary: 'Comentario',
         financed_by: 'Financiado por',
         former_owners: 'Ex propietarios',

--- a/frontend/lang/gl.js
+++ b/frontend/lang/gl.js
@@ -598,7 +598,7 @@ export default {
       },
       bioid: {
         subject_references: 'Referencias temáticas',
-        authors: 'Autores',
+        texts: 'Texto',
         commentary: 'Comentario',
         financed_by: 'Financiado por',
         former_owners: 'Antigos propietarios',

--- a/frontend/lang/gl.js
+++ b/frontend/lang/gl.js
@@ -598,7 +598,7 @@ export default {
       },
       bioid: {
         subject_references: 'Referencias temáticas',
-        texts: 'Texto',
+        texts: 'Textos',
         commentary: 'Comentario',
         financed_by: 'Financiado por',
         former_owners: 'Antigos propietarios',

--- a/frontend/lang/pt.js
+++ b/frontend/lang/pt.js
@@ -598,7 +598,7 @@ export default {
       },
       bioid: {
         subject_references: 'Referências de assunto',
-        texts: 'Texto',
+        texts: 'Textos',
         commentary: 'Comentário',
         financed_by: 'Financiado por',
         former_owners: 'Antigos proprietários',

--- a/frontend/lang/pt.js
+++ b/frontend/lang/pt.js
@@ -598,7 +598,7 @@ export default {
       },
       bioid: {
         subject_references: 'Referências de assunto',
-        authors: 'Autores',
+        texts: 'Texto',
         commentary: 'Comentário',
         financed_by: 'Financiado por',
         former_owners: 'Antigos proprietários',


### PR DESCRIPTION
## Summary
- Bump the shared default page size for related-item sections (`Table.vue`) from 10 to 20, so the "Authors" (P21) and "Related individuals" (P703) sections on `bioid` pages page through results the same way P12 (Secondary literature) already does.
- Rename the `bioid` "Authors"/"Autores" section label to "Text"/"Texto", since P21 on a bioid record lists the texts authored by that person, not authors of the record itself. Updated in all 5 locale files (en, es, ca, gl, pt) and the label key referenced in `Tables.vue`.

Closes #166

## Test plan
- [x] `yarn lint` (pre-existing unrelated warnings/error in `useAlternativeLabels.js` and two other files, not touched by this PR)
- [x] Manually verify a `bioid` record with >20 related texts/individuals (e.g. BETA bioid 1104/1105, Fernando V) shows 20 per page and paginates correctly
- [x] Verify the "Text"/"Texto" label renders correctly across all 5 locales
- [x] Spot-check another related-table section (e.g. `bibid` "Related bibliography") still works with the new default page size

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Related-data tables now support configurable results per page.
  * BioID related tables display texts and individuals with 20 results per page.

* **Bug Fixes**
  * Pagination now correctly reflects each related table’s configured page size.

* **Translations**
  * Updated Catalan, English, Spanish, Galician, and Portuguese labels from “Authors” to “Texts.”

<!-- end of auto-generated comment: release notes by coderabbit.ai -->