### PR TITLE
fix(frontend): expand item detail subject_references to all subject properties

### DIFF
--- a/frontend/components/item/related/Tables.vue
+++ b/frontend/components/item/related/Tables.vue
@@ -13,6 +13,7 @@
 
 <script setup>
 import { ref } from 'vue'
+import { SUBJECT_PROPERTIES } from '~/service/query.service'
 
 defineProps({
   itemId: { type: String, default: null },
@@ -87,16 +88,14 @@ const relatedTables = {
     {
       label: 'item.related.bioid.subject_references',
       refTables: [
-        { refTable: 'bibid', property: 'P243' },
-        { refTable: 'bioid', property: 'P243' },
-        { refTable: 'copid', property: 'P243' },
-        { refTable: 'copid', property: 'P243' },
-        { refTable: 'geoid', property: 'P243' },
-        { refTable: 'geoid', property: 'P243' },
-        { refTable: 'insid', property: 'P243' },
-        { refTable: 'libid', property: 'P243' },
-        { refTable: 'manid', property: 'P243' },
-        { refTable: 'texid', property: 'P243' }
+        { refTable: 'bibid', property: SUBJECT_PROPERTIES },
+        { refTable: 'bioid', property: SUBJECT_PROPERTIES },
+        { refTable: 'copid', property: SUBJECT_PROPERTIES },
+        { refTable: 'geoid', property: SUBJECT_PROPERTIES },
+        { refTable: 'insid', property: SUBJECT_PROPERTIES },
+        { refTable: 'libid', property: SUBJECT_PROPERTIES },
+        { refTable: 'manid', property: SUBJECT_PROPERTIES },
+        { refTable: 'texid', property: SUBJECT_PROPERTIES }
       ]
     },
     {
@@ -285,14 +284,14 @@ const relatedTables = {
     {
       label: 'item.related.geoid.subject_references',
       refTables: [
-        { refTable: 'bibid', property: 'P243' },
-        { refTable: 'bioid', property: 'P243' },
-        { refTable: 'copid', property: 'P243' },
-        { refTable: 'geoid', property: 'P243' },
-        { refTable: 'insid', property: 'P243' },
-        { refTable: 'libid', property: 'P243' },
-        { refTable: 'manid', property: 'P243' },
-        { refTable: 'texid', property: 'P243' }
+        { refTable: 'bibid', property: SUBJECT_PROPERTIES },
+        { refTable: 'bioid', property: SUBJECT_PROPERTIES },
+        { refTable: 'copid', property: SUBJECT_PROPERTIES },
+        { refTable: 'geoid', property: SUBJECT_PROPERTIES },
+        { refTable: 'insid', property: SUBJECT_PROPERTIES },
+        { refTable: 'libid', property: SUBJECT_PROPERTIES },
+        { refTable: 'manid', property: SUBJECT_PROPERTIES },
+        { refTable: 'texid', property: SUBJECT_PROPERTIES }
       ]
     }
   ],
@@ -362,7 +361,7 @@ const relatedTables = {
     {
       label: 'item.related.insid.subject_references',
       refTables: [
-        { refTable: 'subid', property: 'P243' }
+        { refTable: 'subid', property: SUBJECT_PROPERTIES }
       ]
     }
   ],
@@ -384,14 +383,14 @@ const relatedTables = {
     {
       label: 'item.related.subid.subject_references',
       refTables: [
-        { refTable: 'bibid', property: 'P243' },
-        { refTable: 'bioid', property: 'P243' },
-        { refTable: 'cnum', property: 'P243' },
-        { refTable: 'geoid', property: 'P243' },
-        { refTable: 'insid', property: 'P243' },
-        { refTable: 'libid', property: 'P243' },
-        { refTable: 'manid', property: 'P243' },
-        { refTable: 'texid', property: 'P243' }
+        { refTable: 'bibid', property: SUBJECT_PROPERTIES },
+        { refTable: 'bioid', property: SUBJECT_PROPERTIES },
+        { refTable: 'cnum', property: SUBJECT_PROPERTIES },
+        { refTable: 'geoid', property: SUBJECT_PROPERTIES },
+        { refTable: 'insid', property: SUBJECT_PROPERTIES },
+        { refTable: 'libid', property: SUBJECT_PROPERTIES },
+        { refTable: 'manid', property: SUBJECT_PROPERTIES },
+        { refTable: 'texid', property: SUBJECT_PROPERTIES }
       ]
     }
   ]

--- a/frontend/components/search/Base.vue
+++ b/frontend/components/search/Base.vue
@@ -103,11 +103,10 @@ function countAndSearch () {
 
 // Capture the subject selected for the executed query so the results can link
 // back to its subid item page (where the back pointers list every record with
-// that heading). subid table stores the id under `item`; other tables under
-// `target_item`.
+// that heading).
 function captureSearchedSubject () {
   const subjectValue = form.value?.input?.subject?.value
-  const qid = subjectValue?.target_item || subjectValue?.item
+  const qid = subjectValue?.target_item
   searchedSubject.value = qid ? { label: subjectValue.label, qid } : null
 }
 

--- a/frontend/service/query.service.js
+++ b/frontend/service/query.service.js
@@ -4,7 +4,7 @@ import { useQueryStatusStore } from '~/stores/queryStatus'
 // to them, injecting the configured SPARQL prefix.
 import * as templates from './query.templates'
 
-export const SUBJECT_PROPERTIES = ['P97', 'P121', 'P122', 'P243', 'P304', 'P422', 'P452', 'P608', 'P1031', 'P1094', 'P1278']
+export const { SUBJECT_PROPERTIES } = templates
 export class QueryService {
   static DATE_SORT_PATTERNS = {
     bibid: 'OPTIONAL { ?item wdt:P49 ?date_raw }',

--- a/frontend/service/query.service.js
+++ b/frontend/service/query.service.js
@@ -4,6 +4,7 @@ import { useQueryStatusStore } from '~/stores/queryStatus'
 // to them, injecting the configured SPARQL prefix.
 import * as templates from './query.templates'
 
+export const SUBJECT_PROPERTIES = ['P97', 'P121', 'P122', 'P243', 'P304', 'P422', 'P452', 'P608', 'P1031', 'P1094', 'P1278']
 export class QueryService {
   static DATE_SORT_PATTERNS = {
     bibid: 'OPTIONAL { ?item wdt:P49 ?date_raw }',
@@ -210,7 +211,7 @@ export class QueryService {
     if (form.input.subject && form.input.subject.value) {
       filters +=
         `
-        VALUES ?prop_subject { wdt:P97 wdt:P121 wdt:P122 wdt:P243 wdt:P304 wdt:P422 wdt:P452 wdt:P608 wdt:P1031 wdt:P1094 wdt:P1278 }
+        VALUES ?prop_subject { ${SUBJECT_PROPERTIES.map(p => `wdt:${p}`).join(' ')} }
         ?item ?prop_subject wd:${form.input.subject.value.target_item} .
         `
     }
@@ -437,7 +438,7 @@ export class QueryService {
     if (form.input.subject && form.input.subject.value) {
       filters +=
         `
-        VALUES ?prop_subject { wdt:P97 wdt:P121 wdt:P122 wdt:P243 wdt:P304 wdt:P422 wdt:P452 wdt:P608 wdt:P1031 wdt:P1094 wdt:P1278 }
+        VALUES ?prop_subject { ${SUBJECT_PROPERTIES.map(p => `wdt:${p}`).join(' ')} }
         ?item ?prop_subject wd:${form.input.subject.value.target_item} .
         `
     }
@@ -525,7 +526,7 @@ export class QueryService {
     if (form.input.subject && form.input.subject.value) {
       filters +=
         `
-        VALUES ?prop_subject { wdt:P97 wdt:P121 wdt:P122 wdt:P243 wdt:P304 wdt:P422 wdt:P452 wdt:P608 wdt:P1031 wdt:P1094 wdt:P1278 }
+        VALUES ?prop_subject { ${SUBJECT_PROPERTIES.map(p => `wdt:${p}`).join(' ')} }
         ?item ?prop_subject wd:${form.input.subject.value.target_item} .
         `
     }
@@ -571,7 +572,7 @@ export class QueryService {
     if (form.input.subject && form.input.subject.value) {
       filters +=
         `
-        VALUES ?prop_subject { wdt:P97 wdt:P121 wdt:P122 wdt:P243 wdt:P304 wdt:P422 wdt:P452 wdt:P608 wdt:P1031 wdt:P1094 wdt:P1278 }
+        VALUES ?prop_subject { ${SUBJECT_PROPERTIES.map(p => `wdt:${p}`).join(' ')} }
         ?item ?prop_subject wd:${form.input.subject.value.target_item} .
         `
     }
@@ -651,7 +652,7 @@ export class QueryService {
     if (form.input.subject && form.input.subject.value) {
       filters +=
         `
-        VALUES ?prop_subject { wdt:P97 wdt:P121 wdt:P122 wdt:P243 wdt:P304 wdt:P422 wdt:P452 wdt:P608 wdt:P1031 wdt:P1094 wdt:P1278 }
+        VALUES ?prop_subject { ${SUBJECT_PROPERTIES.map(p => `wdt:${p}`).join(' ')} }
         ?item ?prop_subject wd:${form.input.subject.value.target_item} .
         `
     }
@@ -675,7 +676,7 @@ export class QueryService {
     if (form.input.subject && form.input.subject.value) {
       filters +=
         `
-        VALUES ?prop_subject { wdt:P97 wdt:P121 wdt:P122 wdt:P243 wdt:P304 wdt:P422 wdt:P452 wdt:P608 wdt:P1031 wdt:P1094 wdt:P1278 }
+        VALUES ?prop_subject { ${SUBJECT_PROPERTIES.map(p => `wdt:${p}`).join(' ')} }
         ?item ?prop_subject wd:${form.input.subject.value.target_item} .
         `
     }
@@ -989,7 +990,7 @@ export class QueryService {
     if (form.input.subject && form.input.subject.value) {
       filters +=
         `
-        VALUES ?prop_subject { wdt:P97 wdt:P121 wdt:P122 wdt:P243 wdt:P304 wdt:P422 wdt:P452 wdt:P608 wdt:P1031 wdt:P1094 wdt:P1278 }
+        VALUES ?prop_subject { ${SUBJECT_PROPERTIES.map(p => `wdt:${p}`).join(' ')} }
         ?item ?prop_subject wd:${form.input.subject.value.target_item} .
         `
     }
@@ -1159,7 +1160,7 @@ export class QueryService {
     }
     if (form.input.subject && form.input.subject.value) {
       filters += `
-        VALUES ?prop_subject { wdt:P97 wdt:P121 wdt:P122 wdt:P243 wdt:P304 wdt:P422 wdt:P452 wdt:P608 wdt:P1031 wdt:P1094 wdt:P1278 }
+        VALUES ?prop_subject { ${SUBJECT_PROPERTIES.map(p => `wdt:${p}`).join(' ')} }
         ?item ?prop_subject wd:${form.input.subject.value.target_item} .
         `
     }
@@ -1255,7 +1256,7 @@ export class QueryService {
     if (form.input.subject && form.input.subject.value) {
       filters +=
         `
-        VALUES ?prop_subject { wdt:P97 wdt:P121 wdt:P122 wdt:P243 wdt:P304 wdt:P422 wdt:P452 wdt:P608 wdt:P1031 wdt:P1094 wdt:P1278 }
+        VALUES ?prop_subject { ${SUBJECT_PROPERTIES.map(p => `wdt:${p}`).join(' ')} }
         ?item ?prop_subject wd:${form.input.subject.value.target_item} .
         `
     }
@@ -1427,16 +1428,25 @@ export class QueryService {
     const commonCondition = `
           ?item wdt:P476 ?item_pbid .
           FILTER regex(?item_pbid, '(.*) ${refTable.refTable} ') .`
+    const properties = Array.isArray(refTable.property) ? refTable.property : [refTable.property]
     if (refTable.qualifier) {
+      const statementCondition = properties.length > 1
+        ? `VALUES ?ref_prop { ${properties.map(p => `p:${p}`).join(' ')} }
+          ?item ?ref_prop ?related_prop .`
+        : `?item p:${properties[0]} ?related_prop .`
       return `
           ${commonCondition}
-          ?item p:${refTable.property} ?related_prop .
+          ${statementCondition}
           ?related_prop pq:${refTable.qualifier} wd:${pbid} .
         `
     } else {
+      const directCondition = properties.length > 1
+        ? `VALUES ?ref_prop { ${properties.map(p => `wdt:${p}`).join(' ')} }
+          ?item ?ref_prop wd:${pbid} .`
+        : `?item wdt:${properties[0]} wd:${pbid} .`
       return `
           ${commonCondition}
-          ?item wdt:${refTable.property} wd:${pbid} .
+          ${directCondition}
         `
     }
   }

--- a/frontend/service/query.service.js
+++ b/frontend/service/query.service.js
@@ -688,7 +688,8 @@ export class QueryService {
     if (form.input.subject && form.input.subject.value) {
       filters +=
         `
-        FILTER(?item = wd:${form.input.subject.value.item})
+        VALUES ?prop_subject { ${SUBJECT_PROPERTIES.map(p => `wdt:${p}`).join(' ')} }
+        ?item ?prop_subject wd:${form.input.subject.value.target_item} .
         `
     }
     return filters

--- a/frontend/service/query.service.js
+++ b/frontend/service/query.service.js
@@ -1462,7 +1462,7 @@ export class QueryService {
   getRelatedItems (pbid, refTables, currentPage, resultsPerPage) {
     const query =
       `
-      SELECT ?item ?item_pbid
+      SELECT DISTINCT ?item ?item_pbid
       WHERE {
         ${this.getRefTableConditions(pbid, refTables)}
         BIND(REPLACE(?item_pbid, ".* ([0-9]+)$", "$1") AS ?item_number)
@@ -1478,7 +1478,7 @@ export class QueryService {
   getRelatedItemsCount (pbid, refTables) {
     const query =
       `
-      SELECT (COUNT(?item) AS ?total)
+      SELECT (COUNT(DISTINCT ?item) AS ?total)
       WHERE {
         ${this.getRefTableConditions(pbid, refTables)}
         BIND(REPLACE(?item_pbid, ".* ([0-9]+)$", "$1") AS ?item_number)

--- a/frontend/service/query.templates.js
+++ b/frontend/service/query.templates.js
@@ -8,6 +8,12 @@
 const BITAGAP_DB = 'BITAGAP'
 const CARTAS_TEXT = '[Cartas de]'
 
+// Single source of truth for the FactGrid properties that link an item to a
+// subject (#365/#517): reused by query.service.js's search filters, Tables.vue's
+// item-detail subject_references and every search-forms/*.js subject autocomplete,
+// so a future property change can't make one of them silently fall out of sync.
+export const SUBJECT_PROPERTIES = ['P97', 'P121', 'P122', 'P243', 'P304', 'P422', 'P452', 'P608', 'P1031', 'P1094', 'P1278']
+
 export function fillTemplate (template, replacements) {
   return template.replace(/{{(\w+)}}/g, (match, p1) => replacements[p1] || '')
 }

--- a/frontend/service/search-forms/bibid.js
+++ b/frontend/service/search-forms/bibid.js
@@ -4,6 +4,8 @@
  * filled by query.templates.js filterQuery), importable from Nuxt and Node
  * (scripts/seed-cache uses it to generate every autocomplete query).
  */
+import { SUBJECT_PROPERTIES } from '../query.templates.js'
+
 export default function createForm () {
   return {
         section: [
@@ -319,17 +321,7 @@ export default function createForm () {
                     ?item wdt:P476 ?pbid .
                     FILTER regex(?pbid, '{{database}} {{table}} ')
                     BIND(STRBEFORE(?pbid, ' ') AS ?db) .
-                    { ?item wdt:P97   ?target_item }
-                    UNION { ?item wdt:P121  ?target_item }
-                    UNION { ?item wdt:P122  ?target_item }
-                    UNION { ?item wdt:P243  ?target_item }
-                    UNION { ?item wdt:P304  ?target_item }
-                    UNION { ?item wdt:P422  ?target_item }
-                    UNION { ?item wdt:P452  ?target_item }
-                    UNION { ?item wdt:P608  ?target_item }
-                    UNION { ?item wdt:P1031 ?target_item }
-                    UNION { ?item wdt:P1094 ?target_item }
-                    UNION { ?item wdt:P1278 ?target_item }
+                    ${SUBJECT_PROPERTIES.map(p => `{ ?item wdt:${p} ?target_item }`).join('\n                    UNION ')}
                     {{bitagapGroupSubjectFilter}}
                   }
                 }

--- a/frontend/service/search-forms/bioid.js
+++ b/frontend/service/search-forms/bioid.js
@@ -4,6 +4,8 @@
  * filled by query.templates.js filterQuery), importable from Nuxt and Node
  * (scripts/seed-cache uses it to generate every autocomplete query).
  */
+import { SUBJECT_PROPERTIES } from '../query.templates.js'
+
 export default function createForm () {
   return {
         section: [
@@ -358,17 +360,7 @@ export default function createForm () {
                     ?item wdt:P476 ?pbid .
                     FILTER regex(?pbid, '{{database}} {{table}} ')
                     BIND(STRBEFORE(?pbid, ' ') AS ?db) .
-                    { ?item wdt:P97   ?target_item }
-                    UNION { ?item wdt:P121  ?target_item }
-                    UNION { ?item wdt:P122  ?target_item }
-                    UNION { ?item wdt:P243  ?target_item }
-                    UNION { ?item wdt:P304  ?target_item }
-                    UNION { ?item wdt:P422  ?target_item }
-                    UNION { ?item wdt:P452  ?target_item }
-                    UNION { ?item wdt:P608  ?target_item }
-                    UNION { ?item wdt:P1031 ?target_item }
-                    UNION { ?item wdt:P1094 ?target_item }
-                    UNION { ?item wdt:P1278 ?target_item }
+                    ${SUBJECT_PROPERTIES.map(p => `{ ?item wdt:${p} ?target_item }`).join('\n                    UNION ')}
                     {{bitagapGroupSubjectFilter}}
                   }
                 }

--- a/frontend/service/search-forms/geoid.js
+++ b/frontend/service/search-forms/geoid.js
@@ -4,6 +4,8 @@
  * filled by query.templates.js filterQuery), importable from Nuxt and Node
  * (scripts/seed-cache uses it to generate every autocomplete query).
  */
+import { SUBJECT_PROPERTIES } from '../query.templates.js'
+
 export default function createForm () {
   return {
         section: [
@@ -146,17 +148,7 @@ export default function createForm () {
                     ?item wdt:P476 ?pbid .
                     FILTER regex(?pbid, '{{database}} {{table}} ')
                     BIND(STRBEFORE(?pbid, ' ') AS ?db) .
-                    { ?item wdt:P97   ?target_item }
-                    UNION { ?item wdt:P121  ?target_item }
-                    UNION { ?item wdt:P122  ?target_item }
-                    UNION { ?item wdt:P243  ?target_item }
-                    UNION { ?item wdt:P304  ?target_item }
-                    UNION { ?item wdt:P422  ?target_item }
-                    UNION { ?item wdt:P452  ?target_item }
-                    UNION { ?item wdt:P608  ?target_item }
-                    UNION { ?item wdt:P1031 ?target_item }
-                    UNION { ?item wdt:P1094 ?target_item }
-                    UNION { ?item wdt:P1278 ?target_item }
+                    ${SUBJECT_PROPERTIES.map(p => `{ ?item wdt:${p} ?target_item }`).join('\n                    UNION ')}
                     {{bitagapGroupSubjectFilter}}
                   }
                 }

--- a/frontend/service/search-forms/insid.js
+++ b/frontend/service/search-forms/insid.js
@@ -4,6 +4,8 @@
  * filled by query.templates.js filterQuery), importable from Nuxt and Node
  * (scripts/seed-cache uses it to generate every autocomplete query).
  */
+import { SUBJECT_PROPERTIES } from '../query.templates.js'
+
 export default function createForm () {
   return {
         section: [
@@ -178,17 +180,7 @@ export default function createForm () {
                     ?item wdt:P476 ?pbid .
                     FILTER regex(?pbid, '{{database}} {{table}} ')
                     BIND(STRBEFORE(?pbid, ' ') AS ?db) .
-                    { ?item wdt:P97   ?target_item }
-                    UNION { ?item wdt:P121  ?target_item }
-                    UNION { ?item wdt:P122  ?target_item }
-                    UNION { ?item wdt:P243  ?target_item }
-                    UNION { ?item wdt:P304  ?target_item }
-                    UNION { ?item wdt:P422  ?target_item }
-                    UNION { ?item wdt:P452  ?target_item }
-                    UNION { ?item wdt:P608  ?target_item }
-                    UNION { ?item wdt:P1031 ?target_item }
-                    UNION { ?item wdt:P1094 ?target_item }
-                    UNION { ?item wdt:P1278 ?target_item }
+                    ${SUBJECT_PROPERTIES.map(p => `{ ?item wdt:${p} ?target_item }`).join('\n                    UNION ')}
                     {{bitagapGroupSubjectFilter}}
                   }
                 }

--- a/frontend/service/search-forms/libid.js
+++ b/frontend/service/search-forms/libid.js
@@ -4,6 +4,8 @@
  * filled by query.templates.js filterQuery), importable from Nuxt and Node
  * (scripts/seed-cache uses it to generate every autocomplete query).
  */
+import { SUBJECT_PROPERTIES } from '../query.templates.js'
+
 export default function createForm () {
   return {
         section: [
@@ -181,17 +183,7 @@ export default function createForm () {
                     ?item wdt:P476 ?pbid .
                     FILTER regex(?pbid, '{{database}} {{table}} ')
                     BIND(STRBEFORE(?pbid, ' ') AS ?db) .
-                    { ?item wdt:P97   ?target_item }
-                    UNION { ?item wdt:P121  ?target_item }
-                    UNION { ?item wdt:P122  ?target_item }
-                    UNION { ?item wdt:P243  ?target_item }
-                    UNION { ?item wdt:P304  ?target_item }
-                    UNION { ?item wdt:P422  ?target_item }
-                    UNION { ?item wdt:P452  ?target_item }
-                    UNION { ?item wdt:P608  ?target_item }
-                    UNION { ?item wdt:P1031 ?target_item }
-                    UNION { ?item wdt:P1094 ?target_item }
-                    UNION { ?item wdt:P1278 ?target_item }
+                    ${SUBJECT_PROPERTIES.map(p => `{ ?item wdt:${p} ?target_item }`).join('\n                    UNION ')}
                     {{bitagapGroupSubjectFilter}}
                   }
                 }

--- a/frontend/service/search-forms/manid.js
+++ b/frontend/service/search-forms/manid.js
@@ -4,6 +4,8 @@
  * filled by query.templates.js filterQuery), importable from Nuxt and Node
  * (scripts/seed-cache uses it to generate every autocomplete query).
  */
+import { SUBJECT_PROPERTIES } from '../query.templates.js'
+
 export default function createForm () {
   return {
         section: [
@@ -535,17 +537,7 @@ export default function createForm () {
                     ?item wdt:P476 ?pbid .
                     FILTER regex(?pbid, '{{database}} {{table}} ')
                     BIND(STRBEFORE(?pbid, ' ') AS ?db) .
-                    { ?item wdt:P97   ?target_item }
-                    UNION { ?item wdt:P121  ?target_item }
-                    UNION { ?item wdt:P122  ?target_item }
-                    UNION { ?item wdt:P243  ?target_item }
-                    UNION { ?item wdt:P304  ?target_item }
-                    UNION { ?item wdt:P422  ?target_item }
-                    UNION { ?item wdt:P452  ?target_item }
-                    UNION { ?item wdt:P608  ?target_item }
-                    UNION { ?item wdt:P1031 ?target_item }
-                    UNION { ?item wdt:P1094 ?target_item }
-                    UNION { ?item wdt:P1278 ?target_item }
+                    ${SUBJECT_PROPERTIES.map(p => `{ ?item wdt:${p} ?target_item }`).join('\n                    UNION ')}
                     {{bitagapGroupSubjectFilter}}
                   }
                 }

--- a/frontend/service/search-forms/subid.js
+++ b/frontend/service/search-forms/subid.js
@@ -4,6 +4,8 @@
  * filled by query.templates.js filterQuery), importable from Nuxt and Node
  * (scripts/seed-cache uses it to generate every autocomplete query).
  */
+import { SUBJECT_PROPERTIES } from '../query.templates.js'
+
 export default function createForm () {
   return {
         section: [
@@ -91,17 +93,7 @@ export default function createForm () {
                     ?item wdt:P476 ?pbid .
                     FILTER regex(?pbid, '{{database}} {{table}} ')
                     BIND(STRBEFORE(?pbid, ' ') AS ?db) .
-                    { ?item wdt:P97   ?target_item }
-                    UNION { ?item wdt:P121  ?target_item }
-                    UNION { ?item wdt:P122  ?target_item }
-                    UNION { ?item wdt:P243  ?target_item }
-                    UNION { ?item wdt:P304  ?target_item }
-                    UNION { ?item wdt:P422  ?target_item }
-                    UNION { ?item wdt:P452  ?target_item }
-                    UNION { ?item wdt:P608  ?target_item }
-                    UNION { ?item wdt:P1031 ?target_item }
-                    UNION { ?item wdt:P1094 ?target_item }
-                    UNION { ?item wdt:P1278 ?target_item }
+                    ${SUBJECT_PROPERTIES.map(p => `{ ?item wdt:${p} ?target_item }`).join('\n                    UNION ')}
                     FILTER isIRI(?target_item) .
                     {{bitagapGroupSubjectFilter}}
                   }

--- a/frontend/service/search-forms/subid.js
+++ b/frontend/service/search-forms/subid.js
@@ -85,23 +85,28 @@ export default function createForm () {
             autocomplete: {
               query:
               `
-              SELECT DISTINCT ?item ?label ?desc ?lang ?db ?bg {
+              SELECT DISTINCT ?target_item ?label ?desc ?lang ?db ?bg WHERE {
                 {
-                  ?item wdt:P476 ?pbid .
-                  FILTER regex(?pbid, '{{database}} {{table}} ') .
-                  BIND(STRBEFORE(?pbid, ' ') AS ?db) .
-                  {{bitagapGroupFilter}}
-                  {
-                    ?item wdt:P1031 ?label .
-                    BIND('P1031' AS ?property)
-                  }
-                  UNION
-                  {
-                    ?item rdfs:label ?labelObj .
-                    BIND('label' AS ?property)
+                  SELECT DISTINCT ?target_item ?db ?bg WHERE {
+                    ?item wdt:P476 ?pbid .
+                    FILTER regex(?pbid, '{{database}} {{table}} ')
+                    BIND(STRBEFORE(?pbid, ' ') AS ?db) .
+                    { ?item wdt:P97   ?target_item }
+                    UNION { ?item wdt:P121  ?target_item }
+                    UNION { ?item wdt:P122  ?target_item }
+                    UNION { ?item wdt:P243  ?target_item }
+                    UNION { ?item wdt:P304  ?target_item }
+                    UNION { ?item wdt:P422  ?target_item }
+                    UNION { ?item wdt:P452  ?target_item }
+                    UNION { ?item wdt:P608  ?target_item }
+                    UNION { ?item wdt:P1031 ?target_item }
+                    UNION { ?item wdt:P1094 ?target_item }
+                    UNION { ?item wdt:P1278 ?target_item }
+                    FILTER isIRI(?target_item) .
+                    {{bitagapGroupSubjectFilter}}
                   }
                 }
-                {{itemLangGroupPattern}}
+                {{targetItemLangGroupPattern}}
               }
               `
             }

--- a/frontend/service/search-forms/texid.js
+++ b/frontend/service/search-forms/texid.js
@@ -4,6 +4,8 @@
  * filled by query.templates.js filterQuery), importable from Nuxt and Node
  * (scripts/seed-cache uses it to generate every autocomplete query).
  */
+import { SUBJECT_PROPERTIES } from '../query.templates.js'
+
 export default function createForm () {
   return {
         section: [
@@ -429,17 +431,7 @@ export default function createForm () {
                     ?item wdt:P476 ?pbid .
                     FILTER regex(?pbid, '{{database}} {{table}} ')
                     BIND(STRBEFORE(?pbid, ' ') AS ?db) .
-                    { ?item wdt:P97   ?target_item }
-                    UNION { ?item wdt:P121  ?target_item }
-                    UNION { ?item wdt:P122  ?target_item }
-                    UNION { ?item wdt:P243  ?target_item }
-                    UNION { ?item wdt:P304  ?target_item }
-                    UNION { ?item wdt:P422  ?target_item }
-                    UNION { ?item wdt:P452  ?target_item }
-                    UNION { ?item wdt:P608  ?target_item }
-                    UNION { ?item wdt:P1031 ?target_item }
-                    UNION { ?item wdt:P1094 ?target_item }
-                    UNION { ?item wdt:P1278 ?target_item }
+                    ${SUBJECT_PROPERTIES.map(p => `{ ?item wdt:${p} ?target_item }`).join('\n                    UNION ')}
                     {{bitagapGroupSubjectFilter}}
                   }
                 }


### PR DESCRIPTION
## Summary
- The item-detail \"related tables\" `subject_references` blocks (bioid, geoid, insid, subid) in `Tables.vue` were hardcoded to only match `wdt:P243`, while the search-page subject filter (#498, fixing #365) already covers all 11 subject properties via a `VALUES` clause.
- Generalizes `getRefTableCondition`/`getRefTableConditions` in `query.service.js` to accept an array of properties (rendered as a `VALUES ?ref_prop {...}` clause), while leaving the existing single-property call sites byte-identical (no behavior change for the ~40 other `relatedTables` entries).
- Extracts the previously 8x-duplicated `VALUES ?prop_subject {...}` literal in `query.service.js` into a single exported `SUBJECT_PROPERTIES` constant, reused by both the search filters and the new `Tables.vue` blocks — addressing the reviewer's minor-inconsistency note from #498.
- Drops two accidental duplicate `refTable` entries (`copid`, `geoid`) in the `bioid.subject_references` block while touching that code.

Fixes #509

## Test plan
- [x] `yarn lint` passes on both changed files (pre-existing unrelated warnings/error in other files untouched)
- [x] Verified in-browser against the live FactGrid SPARQL endpoint: no new console errors, and the generated query (e.g. for `bioid.subject_references`) executes successfully with `VALUES ?ref_prop { wdt:P97 wdt:P121 wdt:P122 wdt:P243 wdt:P304 wdt:P422 wdt:P452 wdt:P608 wdt:P1031 wdt:P1094 wdt:P1278 }` per UNION branch
- [x] Confirmed the single-property code path (all other `relatedTables` entries) still generates identical SPARQL to before

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved consistency when filtering and displaying related subject references across tables.
  * Enhanced reference queries to support multiple applicable properties, improving results for related items.
  * Removed duplicate reference mappings in related table results.
  * Improved subject search suggestions by including linked items across additional reference properties.
  * Improved search selection accuracy by using the identified target item consistently.
  * Improved related-item result counts by preventing duplicate entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->