### PR TITLE
fix(frontend): show full property template on item view after login (#313)

### DIFF
--- a/frontend/components/item/Base.vue
+++ b/frontend/components/item/Base.vue
@@ -96,12 +96,13 @@ const externalIdClaims = ref([])
 const templateClaims = ref([])
 const hasRelatedTable = ref(false)
 const hasNotes = ref(false)
+let templateClaimsRequested = false
 
 const isUserLogged = computed(() => authStore.isLogged)
 
 watch(isUserLogged, async (isLogged) => {
-  if (isLogged && item.value && templateClaims.value.length === 0) {
-    await appendTemplateClaims(item.value.claims)
+  if (isLogged && item.value) {
+    await appendTemplateClaims(item.value.claims).catch(notifyError)
   }
 })
 
@@ -150,39 +151,46 @@ async function handleClaims (entity) {
 }
 
 async function appendTemplateClaims (existingClaims) {
-  const template = await $wikibase.getClaimsOrderForNewItem(props.table)
-  if (!template) return
+  if (templateClaimsRequested) return
+  templateClaimsRequested = true
+  try {
+    const template = await $wikibase.getClaimsOrderForNewItem(props.table)
+    if (!template) return
 
-  const existingPropertyIds = new Set(Object.keys(existingClaims))
-  const missingPropIds = Object.keys(template).filter(id => !existingPropertyIds.has(id))
-  if (!missingPropIds.length) return
+    const existingPropertyIds = new Set(Object.keys(existingClaims))
+    const missingPropIds = Object.keys(template).filter(id => !existingPropertyIds.has(id))
+    if (!missingPropIds.length) return
 
-  const entities = await $wikibase.getEntities(missingPropIds, locale.value)
+    const entities = await $wikibase.getEntities(missingPropIds, locale.value)
 
-  const bibliographyId = WikibaseService.BIBLIOGRAPHY_MAP?.[props.database]
-  for (const propId of missingPropIds) {
-    const entityProperty = entities[propId]
-    if (!entityProperty?.datatype || entityProperty.datatype === 'external-id') continue
+    const bibliographyId = WikibaseService.BIBLIOGRAPHY_MAP?.[props.database]
+    for (const propId of missingPropIds) {
+      const entityProperty = entities[propId]
+      if (!entityProperty?.datatype || entityProperty.datatype === 'external-id') continue
 
-    const altLabel = await $wikibase.getEntityLabel(props.table, propId, locale.value)
-    const defaultValue = propId === 'P131' && bibliographyId ? { id: bibliographyId } : null
+      const altLabel = await $wikibase.getEntityLabel(props.table, propId, locale.value)
+      const defaultValue = propId === 'P131' && bibliographyId ? { id: bibliographyId } : null
 
-    templateClaims.value.push({
-      default: true,
-      property: {
-        label: altLabel?.value ?? propId,
-        id: propId,
-        datatype: entityProperty.datatype
-      },
-      mainsnak: { property: propId },
-      claimsValues: [],
-      value: {
-        property: propId,
-        datatype: entityProperty.datatype,
-        datavalue: { value: defaultValue }
-      },
-      qualifiers: []
-    })
+      templateClaims.value.push({
+        default: true,
+        property: {
+          label: altLabel?.value ?? propId,
+          id: propId,
+          datatype: entityProperty.datatype
+        },
+        mainsnak: { property: propId },
+        claimsValues: [],
+        value: {
+          property: propId,
+          datatype: entityProperty.datatype,
+          datavalue: { value: defaultValue }
+        },
+        qualifiers: []
+      })
+    }
+  } catch (err) {
+    templateClaimsRequested = false
+    throw err
   }
 }
 

--- a/frontend/components/item/Base.vue
+++ b/frontend/components/item/Base.vue
@@ -66,7 +66,7 @@
 </template>
 
 <script setup>
-import { computed, onMounted, onBeforeUnmount, ref } from 'vue'
+import { computed, onMounted, onBeforeUnmount, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useAuthStore } from '~/stores/auth'
 import { useBreadcrumbStore } from '~/stores/breadcrumb'
@@ -98,6 +98,12 @@ const hasRelatedTable = ref(false)
 const hasNotes = ref(false)
 
 const isUserLogged = computed(() => authStore.isLogged)
+
+watch(isUserLogged, async (isLogged) => {
+  if (isLogged && item.value && templateClaims.value.length === 0) {
+    await appendTemplateClaims(item.value.claims)
+  }
+})
 
 onMounted(async () => {
   if (props.id) {


### PR DESCRIPTION
## Problem

When a user opens an existing item (e.g. a newly created UNI) after closing the browser and logging in again, the full property template — which allows filling in missing fields — does not appear.

## Root cause

In Vue 3, child component `onMounted` hooks fire before the parent's. `Base.vue` calls `handleClaims()` during its own `onMounted`, which checks `isUserLogged` to decide whether to call `appendTemplateClaims`. But the cookie-based session restoration (`autoLoginByCookie()`) runs in `default.vue`'s `onMounted`, which fires after `Base.vue`'s. So `isUserLogged` is still `false` when the check runs, and `appendTemplateClaims` is silently skipped.

## Fix

Added `watch(isUserLogged, ...)` in `Base.vue` that calls `appendTemplateClaims` whenever the user's login state changes to `true`, provided the item is already loaded and no template claims have been appended yet. This covers both cookie auto-login and manual login.

Closes #313

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Populate template claims automatically when a user logs in after an item has already finished loading.
  * Prevent duplicate template-claim generation across repeated login/claim flows and reliably surface errors if generation fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->