### PR TITLE
fix(frontend): render date preview labels in UTC to avoid off-by-one day

### DIFF
--- a/frontend/components/item/Create.vue
+++ b/frontend/components/item/Create.vue
@@ -541,7 +541,8 @@ function formatTime (raw) {
   return new Intl.DateTimeFormat('en', {
     year: 'numeric',
     month: 'long',
-    day: 'numeric'
+    day: 'numeric',
+    timeZone: 'UTC'
   }).format(date)
 }
 


### PR DESCRIPTION
## Summary
- `formatTime()` in `frontend/components/item/Create.vue`, used to build the auto-generated title/label preview during item creation (e.g. from P222 date of publication), parsed the Wikibase UTC time string with `new Date()` and formatted it with `Intl.DateTimeFormat` in the browser's local timezone. In any timezone behind UTC this rolled the displayed date back to Dec 31 of the previous year for year-only dates.
- Fixes the behavior reported by @faulhaber on #306 (2026-07-01 comment): entering a year like 2009 showed "31 de diciembre de 2008" in the label preview.
- Scope: only affects the preview label shown during item creation. The actual saved Wikibase value (built in `Time.vue`'s `toWikibaseTime`) was never affected.

Related to #306. Note: the `YYYY-DD` (year + day, no month) partial-date pattern mentioned in the original issue is intentionally not implemented — it's ambiguous with `YYYY-MM` for day values 01-12 (e.g. `2009-05` could mean May 2009 or day 5 of unknown month), so it's left out per discussion.

## Test plan
- [x] Reproduced the bug locally with `TZ=America/Los_Angeles` and confirmed `formatTime('+2009-01-01T00:00:00Z')` returned `December 31, 2008` before the fix and `January 1, 2009` after.
- [ ] Manually verify the item creation preview title (e.g. for a bibid with a P222 date) shows the correct date in a browser set to a UTC-behind timezone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)