### PR TITLE
fix(qualifier): show value input field after selecting qualifier property

### DIFF
--- a/frontend/components/item/Create.vue
+++ b/frontend/components/item/Create.vue
@@ -225,14 +225,9 @@ function getCreateDisabledReason () {
     const initialClaim = initialClaims.value.find(c => c.property?.id === propKey)
     const propertyLabel = initialClaim?.property?.label || propKey
 
-    if (!Array.isArray(claimArray) || claimArray.length === 0) {
+    const hasValue = Array.isArray(claimArray) && claimArray.some(item => item?.value != null && item?.value !== '')
+    if (!hasValue) {
       return t('messages.error.inputs.claim_value_missing', { propertyLabel })
-    }
-
-    for (const item of claimArray) {
-      if (item?.value == null || item?.value === '') {
-        return t('messages.error.inputs.claim_value_missing', { propertyLabel })
-      }
     }
   }
 

--- a/frontend/components/item/Create.vue
+++ b/frontend/components/item/Create.vue
@@ -209,7 +209,7 @@ function getCreateDisabledReason () {
   }
 
   if (props.table === 'bibid') {
-    const hasName = ['P247', 'P21', 'P1134'].some(p => {
+    const hasName = ['P247', 'P21', 'P845', 'P1134'].some(p => {
       const arr = claims.value[p]
       return Array.isArray(arr) && arr.length > 0 && arr[0]?.value != null && arr[0]?.value !== ''
     })
@@ -597,9 +597,11 @@ function getBibidDate () {
   if (!val) return null
   if (typeof val === 'string') return val
   if (typeof val === 'object' && val.time) {
-    const match = val.time.replace(/^\+/, '').match(/^(\d{4})-(\d{2})/)
+    const match = val.time.replace(/^\+/, '').match(/^(\d{4})-(\d{2})-(\d{2})/)
     if (!match) return null
-    return val.precision >= 10 ? `${match[1]}-${match[2]}` : match[1]
+    if (val.precision >= 11) return `${match[1]}-${match[2]}-${match[3]}`
+    if (val.precision >= 10) return `${match[1]}-${match[2]}`
+    return match[1]
   }
   return null
 }

--- a/frontend/components/item/Create.vue
+++ b/frontend/components/item/Create.vue
@@ -591,6 +591,19 @@ function getManidPrefix () {
   return ''
 }
 
+function getBibidDate () {
+  const claim = initialClaims.value.find(cl => cl.property?.id === 'P49')
+  const val = claim?.value?.datavalue?.value
+  if (!val) return null
+  if (typeof val === 'string') return val
+  if (typeof val === 'object' && val.time) {
+    const match = val.time.replace(/^\+/, '').match(/^(\d{4})-(\d{2})/)
+    if (!match) return null
+    return val.precision >= 10 ? `${match[1]}-${match[2]}` : match[1]
+  }
+  return null
+}
+
 function generateLabelFromClaims () {
   let generatedLabel = ''
   switch (props.table) {
@@ -614,9 +627,9 @@ function generateLabelFromClaims () {
     case 'bibid': {
       const surname = getClaimValue('P247')
       const author = getClaimValue('P21')
-      const creator = getClaimValue('P1134')
+      const creator = getClaimValue('P845') || getClaimValue('P1134')
       const title = getClaimValue('P11')
-      const date = getClaimValue('P222')
+      const date = getBibidDate()
 
       const name = surname || author || creator
 

--- a/frontend/components/item/qualifier/Create.vue
+++ b/frontend/components/item/qualifier/Create.vue
@@ -151,13 +151,15 @@ function onNewValue (event, qualifier) {
 async function onChangeProperty (event, index) {
   const qualifier = qualifiers[index]
   if (event) {
+    qualifier.datatype = event.datatype
+    qualifier.datavalue = { value: null }
     const altLabel = await $wikibase.getEntityLabel(props.table, event.id, locale.value)
     qualifier.property = { id: event.id, label: altLabel?.value ?? event.label, datatype: event.datatype }
   } else {
     qualifier.property = null
+    qualifier.datatype = null
+    qualifier.datavalue = { value: null }
   }
-  qualifier.datatype = event?.datatype
-  qualifier.datavalue = { value: null }
 }
 
 function addQualifier () {


### PR DESCRIPTION
When adding a new qualifier, Vuetify's v-model updates qualifier.property synchronously before onChangeProperty runs. This triggered a key change on item-value-base, remounting it with qualifier.datatype still null — causing getWbValue to return undefined and the value input to never appear.

Fix: move qualifier.datatype and qualifier.datavalue assignments before the await so Vue processes all three reactive updates in the same batch. The component remounts once with the correct datatype, getWbValue returns the right type, and the underlined input field is rendered.

Also: explicit null assignment in the else branch (was implicitly undefined), keeping consistency with addQualifier's initial state.

CLoses #387

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed qualifier fields to reliably reset datatype and value when a property is selected or cleared.
  * Updated “create” enablement validation to require at least one claim item with a non-null, non-empty value before allowing creation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->