### PR TITLE
fix(frontend): refine bioid, cnum and copid label generation (#240)

### DIFF
--- a/frontend/components/item/Create.vue
+++ b/frontend/components/item/Create.vue
@@ -101,12 +101,6 @@ import { useI18n } from 'vue-i18n'
 import { useAuthStore } from '~/stores/auth'
 import { WikibaseService } from '~/service/wikibase.service'
 
-const CNUM_LABEL_PREFIXES = {
-  BETA: { work: 'Testimonio de', partOf: 'Parte de' },
-  BITECA: { work: 'Testimoni de', partOf: 'Part de' },
-  BITAGAP: { work: 'Testimonio de', partOf: 'Parte de' }
-}
-
 const props = defineProps({
   database: { type: String, required: true },
   table: { type: String, required: true }
@@ -606,7 +600,7 @@ function generateLabelFromClaims () {
       const work = getClaimValue('P590')
       const partOf = getClaimValue('P8')
       if (work && partOf) {
-        const prefixes = CNUM_LABEL_PREFIXES[props.database] || {}
+        const prefixes = WikibaseService.CNUM_LABEL_PREFIXES[props.database] || {}
         const prefixedWork = prefixes.work ? `${prefixes.work} ${work}` : work
         const prefixedPartOf = prefixes.partOf ? `${prefixes.partOf} ${partOf}` : partOf
         const workTerminated = /[.!?]\s*$/.test(prefixedWork) ? prefixedWork.trimEnd() : `${prefixedWork}.`

--- a/frontend/components/item/Create.vue
+++ b/frontend/components/item/Create.vue
@@ -101,6 +101,12 @@ import { useI18n } from 'vue-i18n'
 import { useAuthStore } from '~/stores/auth'
 import { WikibaseService } from '~/service/wikibase.service'
 
+const CNUM_LABEL_PREFIXES = {
+  BETA: { work: 'Testimonio de', partOf: 'Parte de' },
+  BITECA: { work: 'Testimoni de', partOf: 'Part de' },
+  BITAGAP: { work: 'Testimonio de', partOf: 'Parte de' }
+}
+
 const props = defineProps({
   database: { type: String, required: true },
   table: { type: String, required: true }
@@ -194,19 +200,8 @@ function getCreateDisabledReason () {
   if (props.table === 'copid') { requiredPropertyIds.add('P839'); requiredPropertyIds.add('P329') }
   if (props.table === 'geoid' || props.table === 'insid') { requiredPropertyIds.add('P34'); requiredPropertyIds.add('P297') }
   if (props.table === 'libid') { requiredPropertyIds.add('P34'); requiredPropertyIds.add('P47') }
-  if (props.table === 'subid') requiredPropertyIds.add('P34')
+  if (props.table === 'subid' || props.table === 'bioid') requiredPropertyIds.add('P34')
   if (props.table === 'texid') { requiredPropertyIds.add('P21'); requiredPropertyIds.add('P11') }
-
-  if (props.table === 'bioid') {
-    const hasName = ['P34', 'P173', 'P291', 'P165', 'P746'].some(p => {
-      const arr = claims.value[p]
-      return Array.isArray(arr) && arr.length > 0 && arr[0]?.value != null && arr[0]?.value !== ''
-    })
-    if (!hasName) {
-      const propertyLabel = initialClaims.value.find(c => c.property?.id === 'P34')?.property?.label || 'P34'
-      return t('messages.error.inputs.claim_value_missing', { propertyLabel })
-    }
-  }
 
   if (props.table === 'bibid') {
     const hasName = ['P247', 'P21', 'P1134'].some(p => {
@@ -611,8 +606,11 @@ function generateLabelFromClaims () {
       const work = getClaimValue('P590')
       const partOf = getClaimValue('P8')
       if (work && partOf) {
-        const workTerminated = /[.!?]\s*$/.test(work) ? work.trimEnd() : `${work}.`
-        generatedLabel = `${workTerminated} ${partOf}`
+        const prefixes = CNUM_LABEL_PREFIXES[props.database] || {}
+        const prefixedWork = prefixes.work ? `${prefixes.work} ${work}` : work
+        const prefixedPartOf = prefixes.partOf ? `${prefixes.partOf} ${partOf}` : partOf
+        const workTerminated = /[.!?]\s*$/.test(prefixedWork) ? prefixedWork.trimEnd() : `${prefixedWork}.`
+        generatedLabel = `${workTerminated} ${prefixedPartOf}`
       }
       break
     }
@@ -632,13 +630,9 @@ function generateLabelFromClaims () {
       break
     }
     case 'bioid': {
-      const fallbackProps = ['P34', 'P173', 'P291', 'P165', 'P746']
-      for (const bioPbid of fallbackProps) {
-        const val = getClaimValue(bioPbid)
-        if (val) {
-          generatedLabel = val
-          break
-        }
+      const name = getClaimValue('P34')
+      if (name) {
+        generatedLabel = name
       }
       break
     }
@@ -657,8 +651,8 @@ function generateLabelFromClaims () {
       if (holding && edition) {
         const position = getClaimValue('P10') || getQualifierValue('P329', 'P10')
         generatedLabel = position
-          ? `${holding}, ${position} (${edition})`
-          : `${holding} (${edition})`
+          ? `${edition}. ${holding}, ${position}`
+          : `${edition}. ${holding}`
       }
       break
     }

--- a/frontend/service/wikibase.service.js
+++ b/frontend/service/wikibase.service.js
@@ -11,6 +11,11 @@ export class WikibaseService {
   static PROPERTY_FORMATTER_URL = 'P236'
   static PROPERTY_NOTES = 'P817'
   static BIBLIOGRAPHY_MAP = { BETA: 'Q254471', BITECA: 'Q256810', BITAGAP: 'Q256809' }
+  static CNUM_LABEL_PREFIXES = {
+    BETA: { work: 'Testimonio de', partOf: 'Parte de' },
+    BITECA: { work: 'Testimoni de', partOf: 'Part de' },
+    BITAGAP: { work: 'Testimonio de', partOf: 'Parte de' }
+  }
   static ITEM_PHILOBIBLON_PROPERTIES = 'Q394229'
   static COMMONS_WIKIMEDIA_URL_ENDPOINT =
     'https://en.wikipedia.org/w/api.php?action=query&titles=File:$file&prop=imageinfo&iiprop=url&format=json&origin=*'


### PR DESCRIPTION
## Summary
Refines the auto-generated item **Label** (issue #240) based on the domain-expert testing feedback left on the issue thread, closing 3 concrete gaps between the current implementation and the latest spec:

- **bioid**: generate the label from P34 (naming) only, dropping the P173/P291/P165/P746 fallback cascade — the reporter retracted the original cascade spec, clarifying the Label should be based solely on P34 (the fallback chain was actually meant for the legacy "Moniker", which combines Label + Description; PBUI has no Description slot for this yet).
- **cnum (ANA)**: prefix the work (P590) and part-of (P8) label segments with a bibliography-specific phrase — "Testimonio de"/"Parte de" for BETA, "Testimoni de"/"Part de" for BITECA, "Testimonio de"/"Parte de" for BITAGAP — keyed off `props.database`, not the UI locale.
- **copid**: reorder the label from `{holding}, {position} ({edition})` to `{edition}. {holding}, {position}` per the reporter's specified punctuation/order.

Out of scope (tracked separately, not code changes): default P2 (instance-of) values per table and MAN's multi-option instance-of picker are both achievable via the `Ui_ControlledVocabulary` wiki page's `default_value`/query columns already wired into `Entity.vue` — no frontend change needed, just wiki content. The cnum required-fields question (P8/P329/P10) looks possibly already resolved on the `Ui_SortedProperties_NewItem` wiki config side and needs a fresh sandbox check before any code change.

## Test plan
- [x] `yarn lint` passes clean on the changed file
- [x] Verified the 3 transformed label formats against representative inputs (bioid/cnum per bibliography/copid with and without position) match the spec
- [ ] Manual verification on a FactGrid sandbox via `yarn dev` (requires OAuth login not available in this environment): create draft bioid/cnum/copid items and confirm the live label matches expectations

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Updated label formatting for item properties to display more consistently across database sources
  * Refined edition information positioning in labels for improved clarity and readability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->