### PR TITLE
fix(search-forms): replace VALUES ?property with UNION branches to fix subject/associated-person autocomplete 500s (#541)

### DIFF
--- a/frontend/service/search-forms/bibid.js
+++ b/frontend/service/search-forms/bibid.js
@@ -319,8 +319,17 @@ export default function createForm () {
                     ?item wdt:P476 ?pbid .
                     FILTER regex(?pbid, '{{database}} {{table}} ')
                     BIND(STRBEFORE(?pbid, ' ') AS ?db) .
-                    VALUES ?property { wdt:P97 wdt:P121 wdt:P122 wdt:P243 wdt:P304 wdt:P422 wdt:P452 wdt:P608 wdt:P1031 wdt:P1094 wdt:P1278 }
-                    ?item ?property ?target_item .
+                    { ?item wdt:P97   ?target_item }
+                    UNION { ?item wdt:P121  ?target_item }
+                    UNION { ?item wdt:P122  ?target_item }
+                    UNION { ?item wdt:P243  ?target_item }
+                    UNION { ?item wdt:P304  ?target_item }
+                    UNION { ?item wdt:P422  ?target_item }
+                    UNION { ?item wdt:P452  ?target_item }
+                    UNION { ?item wdt:P608  ?target_item }
+                    UNION { ?item wdt:P1031 ?target_item }
+                    UNION { ?item wdt:P1094 ?target_item }
+                    UNION { ?item wdt:P1278 ?target_item }
                     {{bitagapGroupSubjectFilter}}
                   }
                 }

--- a/frontend/service/search-forms/bioid.js
+++ b/frontend/service/search-forms/bioid.js
@@ -313,8 +313,26 @@ export default function createForm () {
                     FILTER regex(?pbid, '{{database}} {{table}} ') .
                     BIND(STRBEFORE(?pbid, ' ') AS ?db) .
                     {{bitagapGroupFilter}}
-                    VALUES ?property { wdt:P703 wdt:P141 wdt:P142 wdt:P150 wdt:P203 wdt:P84 wdt:P505 wdt:P629 wdt:P504 wdt:P258 wdt:P192 wdt:P191 wdt:P33 wdt:P161 wdt:P190 wdt:P220 wdt:P735 wdt:P257 wdt:P486 wdt:P591 }
-                    ?item ?property ?target_item .
+                    { ?item wdt:P703 ?target_item }
+                    UNION { ?item wdt:P141 ?target_item }
+                    UNION { ?item wdt:P142 ?target_item }
+                    UNION { ?item wdt:P150 ?target_item }
+                    UNION { ?item wdt:P203 ?target_item }
+                    UNION { ?item wdt:P84  ?target_item }
+                    UNION { ?item wdt:P505 ?target_item }
+                    UNION { ?item wdt:P629 ?target_item }
+                    UNION { ?item wdt:P504 ?target_item }
+                    UNION { ?item wdt:P258 ?target_item }
+                    UNION { ?item wdt:P192 ?target_item }
+                    UNION { ?item wdt:P191 ?target_item }
+                    UNION { ?item wdt:P33  ?target_item }
+                    UNION { ?item wdt:P161 ?target_item }
+                    UNION { ?item wdt:P190 ?target_item }
+                    UNION { ?item wdt:P220 ?target_item }
+                    UNION { ?item wdt:P735 ?target_item }
+                    UNION { ?item wdt:P257 ?target_item }
+                    UNION { ?item wdt:P486 ?target_item }
+                    UNION { ?item wdt:P591 ?target_item }
                   }
                 }
                 {{targetItemLangGroupPattern}}
@@ -340,8 +358,17 @@ export default function createForm () {
                     ?item wdt:P476 ?pbid .
                     FILTER regex(?pbid, '{{database}} {{table}} ')
                     BIND(STRBEFORE(?pbid, ' ') AS ?db) .
-                    VALUES ?property { wdt:P97 wdt:P121 wdt:P122 wdt:P243 wdt:P304 wdt:P422 wdt:P452 wdt:P608 wdt:P1031 wdt:P1094 wdt:P1278 }
-                    ?item ?property ?target_item .
+                    { ?item wdt:P97   ?target_item }
+                    UNION { ?item wdt:P121  ?target_item }
+                    UNION { ?item wdt:P122  ?target_item }
+                    UNION { ?item wdt:P243  ?target_item }
+                    UNION { ?item wdt:P304  ?target_item }
+                    UNION { ?item wdt:P422  ?target_item }
+                    UNION { ?item wdt:P452  ?target_item }
+                    UNION { ?item wdt:P608  ?target_item }
+                    UNION { ?item wdt:P1031 ?target_item }
+                    UNION { ?item wdt:P1094 ?target_item }
+                    UNION { ?item wdt:P1278 ?target_item }
                     {{bitagapGroupSubjectFilter}}
                   }
                 }

--- a/frontend/service/search-forms/geoid.js
+++ b/frontend/service/search-forms/geoid.js
@@ -146,8 +146,17 @@ export default function createForm () {
                     ?item wdt:P476 ?pbid .
                     FILTER regex(?pbid, '{{database}} {{table}} ')
                     BIND(STRBEFORE(?pbid, ' ') AS ?db) .
-                    VALUES ?property { wdt:P97 wdt:P121 wdt:P122 wdt:P243 wdt:P304 wdt:P422 wdt:P452 wdt:P608 wdt:P1031 wdt:P1094 wdt:P1278 }
-                    ?item ?property ?target_item .
+                    { ?item wdt:P97   ?target_item }
+                    UNION { ?item wdt:P121  ?target_item }
+                    UNION { ?item wdt:P122  ?target_item }
+                    UNION { ?item wdt:P243  ?target_item }
+                    UNION { ?item wdt:P304  ?target_item }
+                    UNION { ?item wdt:P422  ?target_item }
+                    UNION { ?item wdt:P452  ?target_item }
+                    UNION { ?item wdt:P608  ?target_item }
+                    UNION { ?item wdt:P1031 ?target_item }
+                    UNION { ?item wdt:P1094 ?target_item }
+                    UNION { ?item wdt:P1278 ?target_item }
                     {{bitagapGroupSubjectFilter}}
                   }
                 }

--- a/frontend/service/search-forms/insid.js
+++ b/frontend/service/search-forms/insid.js
@@ -178,8 +178,17 @@ export default function createForm () {
                     ?item wdt:P476 ?pbid .
                     FILTER regex(?pbid, '{{database}} {{table}} ')
                     BIND(STRBEFORE(?pbid, ' ') AS ?db) .
-                    VALUES ?property { wdt:P97 wdt:P121 wdt:P122 wdt:P243 wdt:P304 wdt:P422 wdt:P452 wdt:P608 wdt:P1031 wdt:P1094 wdt:P1278 }
-                    ?item ?property ?target_item .
+                    { ?item wdt:P97   ?target_item }
+                    UNION { ?item wdt:P121  ?target_item }
+                    UNION { ?item wdt:P122  ?target_item }
+                    UNION { ?item wdt:P243  ?target_item }
+                    UNION { ?item wdt:P304  ?target_item }
+                    UNION { ?item wdt:P422  ?target_item }
+                    UNION { ?item wdt:P452  ?target_item }
+                    UNION { ?item wdt:P608  ?target_item }
+                    UNION { ?item wdt:P1031 ?target_item }
+                    UNION { ?item wdt:P1094 ?target_item }
+                    UNION { ?item wdt:P1278 ?target_item }
                     {{bitagapGroupSubjectFilter}}
                   }
                 }

--- a/frontend/service/search-forms/libid.js
+++ b/frontend/service/search-forms/libid.js
@@ -181,8 +181,17 @@ export default function createForm () {
                     ?item wdt:P476 ?pbid .
                     FILTER regex(?pbid, '{{database}} {{table}} ')
                     BIND(STRBEFORE(?pbid, ' ') AS ?db) .
-                    VALUES ?property { wdt:P97 wdt:P121 wdt:P122 wdt:P243 wdt:P304 wdt:P422 wdt:P452 wdt:P608 wdt:P1031 wdt:P1094 wdt:P1278 }
-                    ?item ?property ?target_item .
+                    { ?item wdt:P97   ?target_item }
+                    UNION { ?item wdt:P121  ?target_item }
+                    UNION { ?item wdt:P122  ?target_item }
+                    UNION { ?item wdt:P243  ?target_item }
+                    UNION { ?item wdt:P304  ?target_item }
+                    UNION { ?item wdt:P422  ?target_item }
+                    UNION { ?item wdt:P452  ?target_item }
+                    UNION { ?item wdt:P608  ?target_item }
+                    UNION { ?item wdt:P1031 ?target_item }
+                    UNION { ?item wdt:P1094 ?target_item }
+                    UNION { ?item wdt:P1278 ?target_item }
                     {{bitagapGroupSubjectFilter}}
                   }
                 }

--- a/frontend/service/search-forms/manid.js
+++ b/frontend/service/search-forms/manid.js
@@ -535,8 +535,17 @@ export default function createForm () {
                     ?item wdt:P476 ?pbid .
                     FILTER regex(?pbid, '{{database}} {{table}} ')
                     BIND(STRBEFORE(?pbid, ' ') AS ?db) .
-                    VALUES ?property { wdt:P97 wdt:P121 wdt:P122 wdt:P243 wdt:P304 wdt:P422 wdt:P452 wdt:P608 wdt:P1031 wdt:P1094 wdt:P1278 }
-                    ?item ?property ?target_item .
+                    { ?item wdt:P97   ?target_item }
+                    UNION { ?item wdt:P121  ?target_item }
+                    UNION { ?item wdt:P122  ?target_item }
+                    UNION { ?item wdt:P243  ?target_item }
+                    UNION { ?item wdt:P304  ?target_item }
+                    UNION { ?item wdt:P422  ?target_item }
+                    UNION { ?item wdt:P452  ?target_item }
+                    UNION { ?item wdt:P608  ?target_item }
+                    UNION { ?item wdt:P1031 ?target_item }
+                    UNION { ?item wdt:P1094 ?target_item }
+                    UNION { ?item wdt:P1278 ?target_item }
                     {{bitagapGroupSubjectFilter}}
                   }
                 }

--- a/frontend/service/search-forms/texid.js
+++ b/frontend/service/search-forms/texid.js
@@ -429,8 +429,17 @@ export default function createForm () {
                     ?item wdt:P476 ?pbid .
                     FILTER regex(?pbid, '{{database}} {{table}} ')
                     BIND(STRBEFORE(?pbid, ' ') AS ?db) .
-                    VALUES ?property { wdt:P97 wdt:P121 wdt:P122 wdt:P243 wdt:P304 wdt:P422 wdt:P452 wdt:P608 wdt:P1031 wdt:P1094 wdt:P1278 }
-                    ?item ?property ?target_item .
+                    { ?item wdt:P97   ?target_item }
+                    UNION { ?item wdt:P121  ?target_item }
+                    UNION { ?item wdt:P122  ?target_item }
+                    UNION { ?item wdt:P243  ?target_item }
+                    UNION { ?item wdt:P304  ?target_item }
+                    UNION { ?item wdt:P422  ?target_item }
+                    UNION { ?item wdt:P452  ?target_item }
+                    UNION { ?item wdt:P608  ?target_item }
+                    UNION { ?item wdt:P1031 ?target_item }
+                    UNION { ?item wdt:P1094 ?target_item }
+                    UNION { ?item wdt:P1278 ?target_item }
                     {{bitagapGroupSubjectFilter}}
                   }
                 }


### PR DESCRIPTION
Blazegraph 500s when the predicate position is a variable bound only via VALUES over many properties and joined against a broad outer pattern (all bioid/texid/... records). The query planner can't use per-property indexes and blows up server-side.

Fix: replace each VALUES block with an explicit UNION branch per property, letting the endpoint use the predicate index per branch.

Fields fixed (semantically identical, no properties added or removed):
- bioid.associated_person  (20 properties)
- bioid.subject            (11 properties)
- texid.subject            (11 properties)
- bibid.subject            (11 properties)  ← found during review
- geoid.subject            (11 properties)  ← found during review
- insid.subject            (11 properties)  ← found during review
- libid.subject            (11 properties)  ← found during review
- manid.subject            (11 properties)  ← found during review

The remaining VALUES blocks (bibid.js:94, bioid.js title/associated_place) use 2–4 properties and are not affected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved autocomplete searches for subjects and associated people across multiple search forms.
  * Preserved existing property coverage while making suggestions more reliable and consistent.
  * Maintained current filtering and language-handling behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->