### PR TITLE
fix(frontend): #240 drop language-specific prefixes from cnum label

### DIFF
--- a/frontend/components/item/Create.vue
+++ b/frontend/components/item/Create.vue
@@ -642,11 +642,7 @@ function generateLabelFromClaims () {
       const work = getClaimValue('P590')
       const partOf = getClaimValue('P8')
       if (work && partOf) {
-        const prefixes = WikibaseService.CNUM_LABEL_PREFIXES[props.database] || {}
-        const prefixedWork = prefixes.work ? `${prefixes.work} ${work}` : work
-        const prefixedPartOf = prefixes.partOf ? `${prefixes.partOf} ${partOf}` : partOf
-        const workTerminated = /[.!?]\s*$/.test(prefixedWork) ? prefixedWork.trimEnd() : `${prefixedWork}.`
-        generatedLabel = `${workTerminated} ${prefixedPartOf}`
+        generatedLabel = `${work}, ${partOf}`
       }
       break
     }

--- a/frontend/service/wikibase.service.js
+++ b/frontend/service/wikibase.service.js
@@ -11,11 +11,6 @@ export class WikibaseService {
   static PROPERTY_FORMATTER_URL = 'P236'
   static PROPERTY_NOTES = 'P817'
   static BIBLIOGRAPHY_MAP = { BETA: 'Q254471', BITECA: 'Q256810', BITAGAP: 'Q256809' }
-  static CNUM_LABEL_PREFIXES = {
-    BETA: { work: 'Testimonio de', partOf: 'Parte de' },
-    BITECA: { work: 'Testimoni de', partOf: 'Part de' },
-    BITAGAP: { work: 'Testimonio de', partOf: 'Parte de' }
-  }
   static ITEM_PHILOBIBLON_PROPERTIES = 'Q394229'
   static COMMONS_WIKIMEDIA_URL_ENDPOINT =
     'https://en.wikipedia.org/w/api.php?action=query&titles=File:$file&prop=imageinfo&iiprop=url&format=json&origin=*'


### PR DESCRIPTION
## Summary
- Removes the "Testimonio de"/"Testimoni de" and "Parte de"/"Part de" prefixes that were added to the `cnum` (ANA / textual witness) auto-generated label in #540
- The label now simply joins P590 (work context) and P8 (part of) as `${work}, ${partOf}`, matching the reporter's 2026-08-08 follow-up comment on #240 which explicitly retracts the earlier prefix rule
- Removes the now-unused `WikibaseService.CNUM_LABEL_PREFIXES` constant

Closes #240

## Test plan
- [x] `yarn lint` passes on the changed files
- [x] Manually create a new cnum item on staging with P590/P8 filled in and confirm the generated label is `<work>, <part of>` with no prefix

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * CNUM labels now display work and part-of values directly in the format “work, part-of.”
  * Removed database-specific prefixes and punctuation normalization for more consistent label formatting.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->