### PR TITLE
fix: surface real error messages instead of generic "Something went wrong" (#393)

### DIFF
--- a/backend/src/main/java/io/github/philobiblon/backend/error/WikibaseExceptionHandler.java
+++ b/backend/src/main/java/io/github/philobiblon/backend/error/WikibaseExceptionHandler.java
@@ -1,13 +1,19 @@
 package io.github.philobiblon.backend.error;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.context.request.WebRequest;
 
+import java.util.UUID;
+
 @ControllerAdvice
 public class WikibaseExceptionHandler {
+
+    private static final Logger LOG = LoggerFactory.getLogger(WikibaseExceptionHandler.class);
 
     @ExceptionHandler({WikibaseException.class})
     public ResponseEntity<Object> handleWikibaseException(WikibaseException ex, WebRequest request) {
@@ -22,9 +28,17 @@ public class WikibaseExceptionHandler {
     // used to surface as an undiagnosable "undefined: undefined" / generic error client-side.
     // Reusing that shape here, with the real exception message as "info", makes the actual
     // cause visible without needing server log access. See #393.
+    //
+    // This proxy only serves authenticated OAuth-signed edit requests (see ProxyController's
+    // /w/** mapping): every caller is already a logged-in editor, and the exceptions expected
+    // here are infra-level (e.g. IOExceptions reaching the already-public Wikibase endpoint),
+    // not secrets. Still log with a correlation ID server-side, so a support/audit trail
+    // exists independent of what ends up shown client-side.
     @ExceptionHandler({Exception.class})
     public ResponseEntity<Object> handleUnexpected(Exception ex, WebRequest request) {
-        WikibaseError wikibaseError = new WikibaseError("internal-error", ex.getMessage());
+        String correlationId = UUID.randomUUID().toString();
+        LOG.error("Unexpected error [{}] handling {}", correlationId, request.getDescription(false), ex);
+        WikibaseError wikibaseError = new WikibaseError("internal-error", ex.getMessage() + " (ref: " + correlationId + ")");
         return new ResponseEntity<>(wikibaseError, HttpStatus.INTERNAL_SERVER_ERROR);
     }
 }

--- a/backend/src/main/java/io/github/philobiblon/backend/error/WikibaseExceptionHandler.java
+++ b/backend/src/main/java/io/github/philobiblon/backend/error/WikibaseExceptionHandler.java
@@ -10,8 +10,21 @@ import org.springframework.web.context.request.WebRequest;
 public class WikibaseExceptionHandler {
 
     @ExceptionHandler({WikibaseException.class})
-    public ResponseEntity<Object> handleAll(WikibaseException ex, WebRequest request) {
+    public ResponseEntity<Object> handleWikibaseException(WikibaseException ex, WebRequest request) {
         WikibaseError wikibaseError = new WikibaseError(ex.getCode(), ex.getMessage());
+        return new ResponseEntity<>(wikibaseError, HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+
+    // Spring's default error page hides the real exception message from the response body
+    // (returns a bare {"error":"Internal Server Error"} with no detail). The frontend's
+    // wikibase-edit client only understands the {"error":{"code","info"}} shape, so an
+    // unrecognized failure here (e.g. an IOException talking to the real Wikibase instance)
+    // used to surface as an undiagnosable "undefined: undefined" / generic error client-side.
+    // Reusing that shape here, with the real exception message as "info", makes the actual
+    // cause visible without needing server log access. See #393.
+    @ExceptionHandler({Exception.class})
+    public ResponseEntity<Object> handleUnexpected(Exception ex, WebRequest request) {
+        WikibaseError wikibaseError = new WikibaseError("internal-error", ex.getMessage());
         return new ResponseEntity<>(wikibaseError, HttpStatus.INTERNAL_SERVER_ERROR);
     }
 }

--- a/frontend/components/item/Create.vue
+++ b/frontend/components/item/Create.vue
@@ -504,6 +504,7 @@ function addManidEditionFrbrClaim (cleanedClaims) {
 }
 
 async function create () {
+  let entityCreationStarted = false
   try {
     const existingPBID = await $wikibase.getEntityFromPBID(aliasValue.value)
     if (existingPBID !== null) {
@@ -532,6 +533,7 @@ async function create () {
       }
     }
 
+    entityCreationStarted = true
     const response = await $wikibase.getWbEdit().entity.create(data, authStore.requestConfig)
 
     if (!response.success) {
@@ -544,7 +546,7 @@ async function create () {
       query: { justCreated: 'true' }
     }))
   } catch (error) {
-    if (!isSessionExpired(error)) {
+    if (entityCreationStarted && !isSessionExpired(error)) {
       draft.clear()
     }
     notifyError(error)

--- a/frontend/components/item/Create.vue
+++ b/frontend/components/item/Create.vue
@@ -504,49 +504,50 @@ function addManidEditionFrbrClaim (cleanedClaims) {
 }
 
 async function create () {
-  const existingPBID = await $wikibase.getEntityFromPBID(aliasValue.value)
-  if (existingPBID === null) {
-    try {
-      const cleanedClaims = cleanClaims(claims.value)
-      if (props.table === 'manid') addManidEditionFrbrClaim(cleanedClaims)
-
-      const data = {
-        labels: {
-          [locale.value]: label.value
-        },
-        descriptions: {
-          [locale.value]: description.value || ' '
-        },
-        aliases: {
-          [locale.value]: aliasValue.value
-        },
-        claims: {
-          ...cleanedClaims
-        }
-      }
-
-      const response = await $wikibase.getWbEdit().entity.create(data, authStore.requestConfig)
-
-      if (!response.success) {
-        throw response
-      }
-
-      draft.clear()
-      await router.push(localePath({
-        path: '/item/' + response.entity.id,
-        query: { justCreated: 'true' }
+  try {
+    const existingPBID = await $wikibase.getEntityFromPBID(aliasValue.value)
+    if (existingPBID !== null) {
+      $notification.error(t('messages.error.creation.pbid_already_exists', {
+        pbid: aliasValue.value,
+        item: `&nbsp;<a target="_blank" style="color: #ffffff; font-weight: bold;" href="${$wikibase.getQItemUrl(existingPBID)}">${existingPBID}</a>`
       }))
-    } catch (error) {
-      if (!isSessionExpired(error)) {
-        draft.clear()
-      }
-      notifyError(error)
+      return
     }
-  } else {
-    $notification.error(t('messages.error.creation.pbid_already_exists', {
-      pbid: aliasValue.value,
-      item: `&nbsp;<a target="_blank" style="color: #ffffff; font-weight: bold;" href="${$wikibase.getQItemUrl(existingPBID)}">${existingPBID}</a>`
+
+    const cleanedClaims = cleanClaims(claims.value)
+    if (props.table === 'manid') addManidEditionFrbrClaim(cleanedClaims)
+
+    const data = {
+      labels: {
+        [locale.value]: label.value
+      },
+      descriptions: {
+        [locale.value]: description.value || ' '
+      },
+      aliases: {
+        [locale.value]: aliasValue.value
+      },
+      claims: {
+        ...cleanedClaims
+      }
+    }
+
+    const response = await $wikibase.getWbEdit().entity.create(data, authStore.requestConfig)
+
+    if (!response.success) {
+      throw response
+    }
+
+    draft.clear()
+    await router.push(localePath({
+      path: '/item/' + response.entity.id,
+      query: { justCreated: 'true' }
     }))
+  } catch (error) {
+    if (!isSessionExpired(error)) {
+      draft.clear()
+    }
+    notifyError(error)
   }
 }
 

--- a/frontend/composables/useNotifyError.js
+++ b/frontend/composables/useNotifyError.js
@@ -44,7 +44,11 @@ function getFriendlyMessage (error, t) {
   if (isNetworkOrTimeout(error)) {
     return t('messages.error.wikibase_unreachable')
   }
-  return error?.body?.error?.info ?? error?.error?.info ?? t('messages.error.something_went_wrong')
+  // Fall back to the raw error message (e.g. a wikibase-edit client-side validation
+  // error, which has neither a Wikibase API error.code nor a recognizable error.name)
+  // instead of masking it behind the generic message — see #393, where several
+  // unrelated causes all surfaced as an undiagnosable "Something went wrong!".
+  return error?.body?.error?.info ?? error?.error?.info ?? error?.message ?? t('messages.error.something_went_wrong')
 }
 
 function getHint (error) {

--- a/frontend/composables/useNotifyError.js
+++ b/frontend/composables/useNotifyError.js
@@ -44,17 +44,25 @@ function getFriendlyMessage (error, t) {
   if (isNetworkOrTimeout(error)) {
     return t('messages.error.wikibase_unreachable')
   }
-  // Fall back to the raw error message (e.g. a wikibase-edit client-side validation
-  // error, which has neither a Wikibase API error.code nor a recognizable error.name)
-  // instead of masking it behind the generic message — see #393, where several
-  // unrelated causes all surfaced as an undiagnosable "Something went wrong!".
-  return error?.body?.error?.info ?? error?.error?.info ?? error?.message ?? t('messages.error.something_went_wrong')
+  return error?.body?.error?.info ?? error?.error?.info ?? t('messages.error.something_went_wrong')
 }
 
 function getHint (error) {
   const code = error?.body?.error?.code ?? error?.error?.code ?? error?.name
-  if (!code || code === 'Error' || WIKIBASE_ERROR_KEYS[code]) return null
-  return code
+  if (code && code !== 'Error' && !WIKIBASE_ERROR_KEYS[code]) {
+    return code
+  }
+  // No recognizable Wikibase error code and no structured info: fall back to the raw
+  // error message as a hint alongside the translated generic message, instead of
+  // masking it entirely — see #393, where several unrelated causes all surfaced as an
+  // undiagnosable "Something went wrong!". The main message stays translated; only this
+  // technical detail (parenthesized, same as the existing "(TypeError)"-style hints) is
+  // untranslated raw text, since it's arbitrary diagnostic content, not UI copy.
+  const hasStructuredInfo = (error?.body?.error?.info ?? error?.error?.info) != null
+  if (!hasStructuredInfo && error?.message) {
+    return error.message
+  }
+  return null
 }
 
 function buildMessage (error, t) {


### PR DESCRIPTION
## Summary
- `useNotifyError.js` only recognized the Wikibase API's `{error:{code,info}}` shape; any other exception (e.g. a client-side validation error thrown by `wikibase-edit`) collapsed into the generic "Algo salió mal" with no way to diagnose it. Now falls back to `error.message`.
- `Create.vue`'s `create()` left the initial `getEntityFromPBID()` call outside the `try/catch`, so a rejection there became an unhandled promise rejection: clicking Create would silently do nothing. Now the whole flow is wrapped.
- The backend's `WikibaseExceptionHandler` only formatted `WikibaseException`; any other exception (e.g. an `IOException` reaching the real Wikibase instance) fell through to Spring Boot's default error page, which hides the real message (`{"error":"Internal Server Error"}`) — which `wikibase-edit` then misreads as a malformed Wikibase API error, surfacing as `"undefined: undefined"` client-side. Now reuses the `{error:{code,info}}` shape for any exception, with the real message.

This doesn't fix the still-unknown underlying cause of the MAN/P329 creation failure reported in #393 — it makes that cause (and any future one) actually visible instead of masked behind a dead-end generic message.

## Test plan
- [x] `./mvnw compile` passes on the backend change.
- [ ] Reproduce the MAN + P329 creation failure from #393 against staging and confirm a real, actionable error message now appears (backend or frontend) instead of the generic one.
- [ ] Confirm normal item creation (success path) is unaffected.

Closes/relates to #393.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of unexpected server errors with clearer internal-error responses.
  - Prevented duplicate PBID submissions from continuing through entity creation.
  - Preserved draft data when sessions expire during entity creation.
  - Error notifications now display the original error message when no specific guidance is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->