### PR TITLE
fix(backend): drop /api/search's v=2 params condition to fix /w/** body loss

### DIFF
--- a/backend/src/main/java/io/github/philobiblon/backend/controller/SearchController.java
+++ b/backend/src/main/java/io/github/philobiblon/backend/controller/SearchController.java
@@ -9,7 +9,7 @@ import org.springframework.web.bind.annotation.*;
 public interface SearchController {
 
     /** Async contract: never blocks; a cold query answers immediately with indexLoading=true. */
-    @PostMapping(params = "v=2", consumes = "application/x-www-form-urlencoded")
+    @PostMapping(consumes = "application/x-www-form-urlencoded")
     SearchResponse searchV2(@RequestParam String sparqlQuery,
                             @RequestParam String q,
                             @RequestParam(required = false) String searchVars,

--- a/backend/src/test/java/io/github/philobiblon/backend/controller/impl/SearchControllerImplTest.java
+++ b/backend/src/test/java/io/github/philobiblon/backend/controller/impl/SearchControllerImplTest.java
@@ -35,22 +35,12 @@ class SearchControllerImplTest {
     }
 
     @Test
-    void requestWithoutVersionIsRejected() throws Exception {
-        mockMvc.perform(post("/api/search")
-                        .contentType(MediaType.APPLICATION_FORM_URLENCODED)
-                        .param("sparqlQuery", "SELECT ?label WHERE {}")
-                        .param("q", "barcelona"))
-                .andExpect(status().is4xxClientError());
-    }
-
-    @Test
     void v2RequestReturnsEnvelopeWithIndexLoadingFlag() throws Exception {
         when(sparqlCacheService.search(anyString(), anyString(), eq("label,pbid"), eq("bioid.author"), any(), any(), any(), any()))
                 .thenReturn(new SearchResponse(true, List.of()));
 
         mockMvc.perform(post("/api/search")
                         .contentType(MediaType.APPLICATION_FORM_URLENCODED)
-                        .param("v", "2")
                         .param("sparqlQuery", "SELECT ?label WHERE {}")
                         .param("q", "barcelona")
                         .param("searchVars", "label,pbid")
@@ -67,7 +57,6 @@ class SearchControllerImplTest {
 
         mockMvc.perform(post("/api/search")
                         .contentType(MediaType.APPLICATION_FORM_URLENCODED)
-                        .param("v", "2")
                         .param("sparqlQuery", "SELECT ?label ?lang WHERE {}")
                         .param("q", "barcelona")
                         .param("lang", "ca"))
@@ -82,7 +71,6 @@ class SearchControllerImplTest {
 
         mockMvc.perform(post("/api/search")
                         .contentType(MediaType.APPLICATION_FORM_URLENCODED)
-                        .param("v", "2")
                         .param("sparqlQuery", "SELECT ?label ?db WHERE {}")
                         .param("q", "barcelona")
                         .param("group", "BETA"))
@@ -97,7 +85,6 @@ class SearchControllerImplTest {
 
         mockMvc.perform(post("/api/search")
                         .contentType(MediaType.APPLICATION_FORM_URLENCODED)
-                        .param("v", "2")
                         .param("sparqlQuery", "SELECT ?label ?bg WHERE {}")
                         .param("q", "cartas")
                         .param("bitagapGroup", "ORIG"))
@@ -112,7 +99,6 @@ class SearchControllerImplTest {
 
         mockMvc.perform(post("/api/search")
                         .contentType(MediaType.APPLICATION_FORM_URLENCODED)
-                        .param("v", "2")
                         .param("sparqlQuery", "SELECT ?label WHERE {}")
                         .param("q", "barcelona"))
                 .andExpect(status().isOk())

--- a/frontend/service/query.templates.js
+++ b/frontend/service/query.templates.js
@@ -244,7 +244,7 @@ export function filterQuery (query, table, sparqlQueryPrefix) {
 
 /**
  * Global search over the 8 PhiloBiblon tables, served by the backend cache
- * (POST /api/search v=2 with searchVars label,aliases,pbid,item). Fetches every UI
+ * (POST /api/search with searchVars label,aliases,pbid,item). Fetches every UI
  * language at once, one result row per (item, pbid) and label/alias/desc value; the
  * backend pivots and merges them into one cached row per item with per-language
  * columns (first label wins, aliases joined, first desc wins), so no server-side

--- a/frontend/service/wikibase.service.js
+++ b/frontend/service/wikibase.service.js
@@ -45,12 +45,12 @@ export class WikibaseService {
   }
 
   /**
-   * Search a query's results through the backend DB cache (POST /api/search v=2).
+   * Search a query's results through the backend DB cache (POST /api/search).
    * Returns { indexLoading, results: [{ text, value }] }; while indexLoading is true
    * the backend is materializing the query in the background and the caller should retry.
    */
   async cachedSearch (sparqlQuery, q, { searchVars, hint, limit, lang, group, bitagapGroup } = {}) {
-    const params = new URLSearchParams({ v: '2', q, sparqlQuery })
+    const params = new URLSearchParams({ q, sparqlQuery })
     if (searchVars) { params.set('searchVars', searchVars) }
     if (hint) { params.set('hint', hint) }
     if (limit) { params.set('limit', String(limit)) }


### PR DESCRIPTION
## Summary

- Fixes entity create/edit failing with an unhelpful `Error: undefined: undefined` in the browser console (proxied through `ProxyController`'s `/w/**` mapping, which returned a generic Spring 500 with an empty body).
- Root cause: Spring's `RequestMappingHandlerMapping` can't use its fast direct-path lookup for wildcard mappings like `/w/**`, so it falls back to evaluating **every** registered mapping's conditions against the incoming request — including `SearchController.searchV2`'s `params = "v=2"` condition. Evaluating a `params` condition calls `request.getParameterMap()`, which makes the servlet container eagerly parse and drain the POST body for any `application/x-www-form-urlencoded` request. By the time `ProxyControllerImpl` reads `@RequestBody`, the body is gone — `WikibaseOAuthServiceImpl.addParamsFromBody` then NPEs on a null body, which Spring reports as a generic 500 with no error detail.
- Reproduced consistently: locally, against the real `ui-local` staging backend directly, and bisected against the code from ~3 weeks ago (before the `v=2` condition existed) to confirm the interaction, not just the Spring Boot 4 upgrade, is what triggers it.
- `v=2` no longer disambiguates anything: the old unversioned `search()` method was already removed in the SPARQL cache unification (#536), and the frontend always sent `v=2` explicitly — so the condition was only causing this side effect without serving its original purpose.

## Fix

- Backend: drop `params = "v=2"` from `SearchController.searchV2`'s `@PostMapping`. Remove the now-invalid `requestWithoutVersionIsRejected` test and the now-meaningless `.param("v", "2")` calls in the rest of `SearchControllerImplTest`.
- Frontend: stop sending `v: '2'` in `cachedSearch` (`wikibase.service.js`) and drop the stale "v=2" references from the accompanying comments (`wikibase.service.js`, `query.templates.js`), since it's no longer a real contract requirement.

`ProxyController`'s `/w/**` mapping is left untouched.

## Test plan
- [x] `./mvnw test` — 70/70 passing.
- [x] Manual verification (local `mvnw spring-boot:run`, dummy OAuth creds): 5/5 consecutive POSTs to `/w/api.php` return the proper `session-expired` JSON instead of the generic 500/NPE.
- [x] GET requests to `/w/api.php` still work (no regression).
- [x] `POST /api/search` without `v` now reaches `searchV2` instead of 404ing (confirmed it proceeds to query execution).
- [x] `yarn lint` clean on the touched frontend files.
- [ ] Verify on `ui-local`/`ui-dev` staging after deploy that entity create/edit works end-to-end with a real session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)