### PR TITLE
fix(frontend): copid search fields also match data recorded on the parent manid

### DIFF
--- a/frontend/lang/ca.js
+++ b/frontend/lang/ca.js
@@ -444,12 +444,6 @@ export default {
           hint: ''
         }
       },
-      copid: {
-        edition: {
-          label: 'Edició',
-          hint: 'Cerqueu per l\'edició impresa (MsEd) de la qual aquest és un exemplar addicional.'
-        }
-      },
       cnum: {
         witness_of: {
           label: 'Testimoni de',

--- a/frontend/lang/en.js
+++ b/frontend/lang/en.js
@@ -446,12 +446,6 @@ export default {
           hint: ''
         }
       },
-      copid: {
-        edition: {
-          label: 'Edition',
-          hint: 'Search by the printed edition (MsEd) of which this is an additional copy.'
-        }
-      },
       cnum: {
         witness_of: {
           label: 'Witness of',

--- a/frontend/lang/es.js
+++ b/frontend/lang/es.js
@@ -444,12 +444,6 @@ export default {
           hint: ''
         }
       },
-      copid: {
-        edition: {
-          label: 'Edición',
-          hint: 'Busque por la edición impresa (MsEd) de la que este es un ejemplar adicional.'
-        }
-      },
       cnum: {
         witness_of: {
           label: 'Testimonio de',

--- a/frontend/lang/gl.js
+++ b/frontend/lang/gl.js
@@ -444,12 +444,6 @@ export default {
           hint: ''
         }
       },
-      copid: {
-        edition: {
-          label: 'Edición',
-          hint: 'Busca pola edición impresa (MsEd) da que este é unha copia adicional.'
-        }
-      },
       cnum: {
         witness_of: {
           label: 'Testemuño de',

--- a/frontend/lang/pt.js
+++ b/frontend/lang/pt.js
@@ -444,12 +444,6 @@ export default {
           hint: ''
         }
       },
-      copid: {
-        edition: {
-          label: 'Edição',
-          hint: 'Pesquise pela edição impressa (MsEd) da qual esta é uma cópia adicional.'
-        }
-      },
       cnum: {
         witness_of: {
           label: 'Testemunho de',

--- a/frontend/pages/search/copid/query.vue
+++ b/frontend/pages/search/copid/query.vue
@@ -82,34 +82,6 @@ const form = {
             visible: true,
             disabled: false
           },
-          edition: {
-            active: true,
-            section: 'primary',
-            label: 'search.form.copid.edition.label',
-            hint: 'search.form.copid.edition.hint',
-            type: 'autocomplete',
-            value: {},
-            visible: true,
-            disabled: false,
-            autocomplete: {
-              query:
-              `
-              SELECT DISTINCT ?target_item ?label ?desc WHERE {
-                {
-                  SELECT DISTINCT ?target_item WHERE {
-                    ?item wdt:P476 ?pbid .
-                    FILTER regex(?pbid, '{{database}} {{table}} ') .
-                    {{bitagapGroupFilter}}
-                    ?item wdt:P839 ?target_item .
-                    ?target_item wdt:P476 ?target_pbid .
-                    FILTER regex(?target_pbid, '(.*) manid ') .
-                  }
-                }
-                {{targetItemLangGroupPattern}}
-              }
-              `
-            }
-          },
           library: {
             active: true,
             section: 'primary',
@@ -210,6 +182,22 @@ const form = {
                 {
                   ?library_stmt pq:P30 ?label
                 }
+                UNION
+                {
+                  ?library_stmt pq:P802 ?label
+                }
+                UNION
+                {
+                  ?library_stmt pq:P806 ?label
+                }
+                UNION
+                {
+                  ?library_stmt pq:P803 ?label
+                }
+                UNION
+                {
+                  ?library_stmt pq:P804 ?label
+                }
               }
               `
             }
@@ -237,10 +225,20 @@ const form = {
                     }
                     UNION
                     {
+                      ?item wdt:P136 ?target_item .
+                    }
+                    UNION
+                    {
                       ?item wdt:P839 ?manid_item .
                       ?manid_item wdt:P476 ?manid_pbid .
                       FILTER regex(?manid_pbid, '(.*) manid ') .
-                      ?manid_item wdt:P229 ?target_item .
+                      {
+                        ?manid_item wdt:P229 ?target_item .
+                      }
+                      UNION
+                      {
+                        ?manid_item wdt:P136 ?target_item .
+                      }
                     }
                   }
                 }
@@ -277,168 +275,6 @@ const form = {
                       FILTER regex(?manid_pbid, '(.*) manid ') .
                       ?manid_item wdt:P703 ?target_item .
                     }
-                  }
-                }
-                {{targetItemLangGroupPattern}}
-              }
-              `
-            }
-          },
-          writing_surface: {
-            active: true,
-            section: 'primary',
-            label: 'search.form.manid.writing_surface.label',
-            hint: 'search.form.manid.writing_surface.hint',
-            type: 'autocomplete',
-            value: {},
-            visible: true,
-            disabled: false,
-            autocomplete: {
-              query:
-              `
-              SELECT DISTINCT ?target_item ?label ?desc WHERE {
-                {
-                  SELECT DISTINCT ?target_item WHERE {
-                    ?item wdt:P476 ?pbid .
-                    FILTER regex(?pbid, '{{database}} {{table}} ') .
-                    {{bitagapGroupFilter}}
-                    {
-                      ?item wdt:P480 ?target_item .
-                    }
-                    UNION
-                    {
-                      ?item wdt:P839 ?manid_item .
-                      ?manid_item wdt:P476 ?manid_pbid .
-                      FILTER regex(?manid_pbid, '(.*) manid ') .
-                      ?manid_item wdt:P480 ?target_item .
-                    }
-                  }
-                }
-                {{targetItemLangGroupPattern}}
-              }
-              `
-            }
-          },
-          binding: {
-            active: true,
-            section: 'primary',
-            label: 'search.form.manid.binding.label',
-            hint: 'search.form.manid.binding.hint',
-            type: 'autocomplete',
-            value: {},
-            visible: true,
-            disabled: false,
-            autocomplete: {
-              query:
-              `
-              SELECT DISTINCT ?label WHERE {
-                ?item wdt:P476 ?pbid .
-                FILTER regex(?pbid, '{{database}} {{table}} ') .
-                {{bitagapGroupFilter}}
-                {
-                  ?item wdt:P800 ?label .
-                }
-                UNION
-                {
-                  ?item wdt:P839 ?manid_item .
-                  ?manid_item wdt:P476 ?manid_pbid .
-                  FILTER regex(?manid_pbid, '(.*) manid ') .
-                  ?manid_item wdt:P800 ?label .
-                }
-              }
-              `
-            }
-          },
-          watermark: {
-            active: true,
-            section: 'primary',
-            label: 'search.form.manid.watermark.label',
-            hint: 'search.form.manid.watermark.hint',
-            type: 'autocomplete',
-            value: {},
-            visible: true,
-            disabled: false,
-            autocomplete: {
-              query:
-              `
-              SELECT DISTINCT ?target_item ?label ?desc WHERE {
-                {
-                  SELECT DISTINCT ?target_item WHERE {
-                    ?item wdt:P476 ?pbid .
-                    FILTER regex(?pbid, '{{database}} {{table}} ') .
-                    {{bitagapGroupFilter}}
-                    {
-                      ?item wdt:P749 ?target_item .
-                    }
-                    UNION
-                    {
-                      ?item wdt:P839 ?manid_item .
-                      ?manid_item wdt:P476 ?manid_pbid .
-                      FILTER regex(?manid_pbid, '(.*) manid ') .
-                      ?manid_item wdt:P749 ?target_item .
-                    }
-                  }
-                }
-                {{targetItemLangGroupPattern}}
-              }
-              `
-            }
-          },
-          graphic_feature: {
-            active: true,
-            section: 'primary',
-            label: 'search.form.manid.graphic_feature.label',
-            hint: 'search.form.manid.graphic_feature.hint',
-            type: 'autocomplete',
-            value: {},
-            visible: true,
-            disabled: false,
-            autocomplete: {
-              query:
-              `
-              SELECT DISTINCT ?target_item ?label ?desc WHERE {
-                {
-                  SELECT DISTINCT ?target_item WHERE {
-                    ?item wdt:P476 ?pbid .
-                    FILTER regex(?pbid, '{{database}} {{table}} ') .
-                    {{bitagapGroupFilter}}
-                    {
-                      ?item wdt:P801 ?target_item .
-                    }
-                    UNION
-                    {
-                      ?item wdt:P839 ?manid_item .
-                      ?manid_item wdt:P476 ?manid_pbid .
-                      FILTER regex(?manid_pbid, '(.*) manid ') .
-                      ?manid_item wdt:P801 ?target_item .
-                    }
-                  }
-                }
-                {{targetItemLangGroupPattern}}
-              }
-              `
-            }
-          },
-          subject: {
-            active: true,
-            section: 'primary',
-            label: 'search.form.common.subject.label',
-            hint: 'search.form.common.subject.hint',
-            type: 'autocomplete',
-            value: {},
-            visible: true,
-            disabled: false,
-            autocomplete: {
-              query:
-              `
-              SELECT DISTINCT ?target_item ?label ?desc WHERE {
-                {
-                  SELECT DISTINCT ?target_item WHERE {
-                    ?item wdt:P476 ?pbid .
-                    FILTER regex(?pbid, '{{database}} {{table}} ')
-                    {{bitagapGroupSubjectFilter}}
-                    VALUES ?property { wdt:P97 wdt:P121 wdt:P122 wdt:P243 wdt:P304 wdt:P422 wdt:P452 wdt:P608 wdt:P1031 wdt:P1094 wdt:P1278 }
-                    ?item ?property ?target_item .
                   }
                 }
                 {{targetItemLangGroupPattern}}

--- a/frontend/pages/search/copid/query.vue
+++ b/frontend/pages/search/copid/query.vue
@@ -134,6 +134,8 @@ const form = {
                     UNION
                     {
                       ?item wdt:P839 ?manid_item .
+                      ?manid_item wdt:P476 ?manid_pbid .
+                      FILTER regex(?manid_pbid, '(.*) manid ') .
                       ?manid_item wdt:P329 ?target_item .
                     }
                   }
@@ -166,6 +168,8 @@ const form = {
                 UNION
                 {
                   ?item wdt:P839 ?manid_item .
+                  ?manid_item wdt:P476 ?manid_pbid .
+                  FILTER regex(?manid_pbid, '(.*) manid ') .
                   ?manid_item p:P329 ?library_stmt .
                 }
                 ?library_stmt pq:P1054 ?label .
@@ -195,6 +199,8 @@ const form = {
                 UNION
                 {
                   ?item wdt:P839 ?manid_item .
+                  ?manid_item wdt:P476 ?manid_pbid .
+                  FILTER regex(?manid_pbid, '(.*) manid ') .
                   ?manid_item p:P329 ?library_stmt .
                 }
                 {
@@ -232,6 +238,8 @@ const form = {
                     UNION
                     {
                       ?item wdt:P839 ?manid_item .
+                      ?manid_item wdt:P476 ?manid_pbid .
+                      FILTER regex(?manid_pbid, '(.*) manid ') .
                       ?manid_item wdt:P229 ?target_item .
                     }
                   }
@@ -265,6 +273,8 @@ const form = {
                     UNION
                     {
                       ?item wdt:P839 ?manid_item .
+                      ?manid_item wdt:P476 ?manid_pbid .
+                      FILTER regex(?manid_pbid, '(.*) manid ') .
                       ?manid_item wdt:P703 ?target_item .
                     }
                   }
@@ -298,6 +308,8 @@ const form = {
                     UNION
                     {
                       ?item wdt:P839 ?manid_item .
+                      ?manid_item wdt:P476 ?manid_pbid .
+                      FILTER regex(?manid_pbid, '(.*) manid ') .
                       ?manid_item wdt:P480 ?target_item .
                     }
                   }
@@ -329,6 +341,8 @@ const form = {
                 UNION
                 {
                   ?item wdt:P839 ?manid_item .
+                  ?manid_item wdt:P476 ?manid_pbid .
+                  FILTER regex(?manid_pbid, '(.*) manid ') .
                   ?manid_item wdt:P800 ?label .
                 }
               }
@@ -359,6 +373,8 @@ const form = {
                     UNION
                     {
                       ?item wdt:P839 ?manid_item .
+                      ?manid_item wdt:P476 ?manid_pbid .
+                      FILTER regex(?manid_pbid, '(.*) manid ') .
                       ?manid_item wdt:P749 ?target_item .
                     }
                   }
@@ -392,6 +408,8 @@ const form = {
                     UNION
                     {
                       ?item wdt:P839 ?manid_item .
+                      ?manid_item wdt:P476 ?manid_pbid .
+                      FILTER regex(?manid_pbid, '(.*) manid ') .
                       ?manid_item wdt:P801 ?target_item .
                     }
                   }

--- a/frontend/pages/search/copid/query.vue
+++ b/frontend/pages/search/copid/query.vue
@@ -128,7 +128,14 @@ const form = {
                     ?item wdt:P476 ?pbid .
                     FILTER regex(?pbid, '{{database}} {{table}} ') .
                     {{bitagapGroupFilter}}
-                    ?item wdt:P329 ?target_item .
+                    {
+                      ?item wdt:P329 ?target_item .
+                    }
+                    UNION
+                    {
+                      ?item wdt:P839 ?manid_item .
+                      ?manid_item wdt:P329 ?target_item .
+                    }
                   }
                 }
                 {{targetItemLangGroupPattern}}
@@ -153,7 +160,14 @@ const form = {
                 ?item wdt:P476 ?pbid .
                 FILTER regex(?pbid, '{{database}} {{table}} ') .
                 {{bitagapGroupFilter}}
-                ?item p:P329 ?library_stmt .
+                {
+                  ?item p:P329 ?library_stmt .
+                }
+                UNION
+                {
+                  ?item wdt:P839 ?manid_item .
+                  ?manid_item p:P329 ?library_stmt .
+                }
                 ?library_stmt pq:P1054 ?label .
               }
               `
@@ -175,7 +189,14 @@ const form = {
                 ?item wdt:P476 ?pbid .
                 FILTER regex(?pbid, '{{database}} {{table}} ') .
                 {{bitagapGroupFilter}}
-                ?item p:P329 ?library_stmt .
+                {
+                  ?item p:P329 ?library_stmt .
+                }
+                UNION
+                {
+                  ?item wdt:P839 ?manid_item .
+                  ?manid_item p:P329 ?library_stmt .
+                }
                 {
                   ?library_stmt pq:P10 ?label
                 }
@@ -205,7 +226,14 @@ const form = {
                     ?item wdt:P476 ?pbid .
                     FILTER regex(?pbid, '{{database}} {{table}} ') .
                     {{bitagapGroupFilter}}
-                    ?item wdt:P229 ?target_item .
+                    {
+                      ?item wdt:P229 ?target_item .
+                    }
+                    UNION
+                    {
+                      ?item wdt:P839 ?manid_item .
+                      ?manid_item wdt:P229 ?target_item .
+                    }
                   }
                 }
                 {{targetItemLangGroupPattern}}
@@ -231,7 +259,14 @@ const form = {
                     ?item wdt:P476 ?pbid .
                     FILTER regex(?pbid, '{{database}} {{table}} ') .
                     {{bitagapGroupFilter}}
-                    ?item wdt:P703 ?target_item .
+                    {
+                      ?item wdt:P703 ?target_item .
+                    }
+                    UNION
+                    {
+                      ?item wdt:P839 ?manid_item .
+                      ?manid_item wdt:P703 ?target_item .
+                    }
                   }
                 }
                 {{targetItemLangGroupPattern}}
@@ -257,7 +292,14 @@ const form = {
                     ?item wdt:P476 ?pbid .
                     FILTER regex(?pbid, '{{database}} {{table}} ') .
                     {{bitagapGroupFilter}}
-                    ?item wdt:P480 ?target_item .
+                    {
+                      ?item wdt:P480 ?target_item .
+                    }
+                    UNION
+                    {
+                      ?item wdt:P839 ?manid_item .
+                      ?manid_item wdt:P480 ?target_item .
+                    }
                   }
                 }
                 {{targetItemLangGroupPattern}}
@@ -281,7 +323,14 @@ const form = {
                 ?item wdt:P476 ?pbid .
                 FILTER regex(?pbid, '{{database}} {{table}} ') .
                 {{bitagapGroupFilter}}
-                ?item wdt:P800 ?label .
+                {
+                  ?item wdt:P800 ?label .
+                }
+                UNION
+                {
+                  ?item wdt:P839 ?manid_item .
+                  ?manid_item wdt:P800 ?label .
+                }
               }
               `
             }
@@ -304,7 +353,14 @@ const form = {
                     ?item wdt:P476 ?pbid .
                     FILTER regex(?pbid, '{{database}} {{table}} ') .
                     {{bitagapGroupFilter}}
-                    ?item wdt:P749 ?target_item .
+                    {
+                      ?item wdt:P749 ?target_item .
+                    }
+                    UNION
+                    {
+                      ?item wdt:P839 ?manid_item .
+                      ?manid_item wdt:P749 ?target_item .
+                    }
                   }
                 }
                 {{targetItemLangGroupPattern}}
@@ -330,7 +386,14 @@ const form = {
                     ?item wdt:P476 ?pbid .
                     FILTER regex(?pbid, '{{database}} {{table}} ') .
                     {{bitagapGroupFilter}}
-                    ?item wdt:P801 ?target_item .
+                    {
+                      ?item wdt:P801 ?target_item .
+                    }
+                    UNION
+                    {
+                      ?item wdt:P839 ?manid_item .
+                      ?manid_item wdt:P801 ?target_item .
+                    }
                   }
                 }
                 {{targetItemLangGroupPattern}}

--- a/frontend/service/query.service.js
+++ b/frontend/service/query.service.js
@@ -1179,12 +1179,6 @@ export class QueryService {
 
   addCopidFilters (form) {
     let filters = ''
-    if (form.input.edition && form.input.edition.value) {
-      filters +=
-        `
-        ?item wdt:P839 wd:${form.input.edition.value.target_item} .
-        `
-    }
     if (form.input.library && form.input.library.value) {
       filters +=
         `
@@ -1242,6 +1236,22 @@ export class QueryService {
         {
           ?library_stmt pq:P30 ?call_number_label
         }
+        UNION
+        {
+          ?library_stmt pq:P802 ?call_number_label
+        }
+        UNION
+        {
+          ?library_stmt pq:P806 ?call_number_label
+        }
+        UNION
+        {
+          ?library_stmt pq:P803 ?call_number_label
+        }
+        UNION
+        {
+          ?library_stmt pq:P804 ?call_number_label
+        }
         FILTER (?call_number_label = "${this.sanitizeSparqlString(form.input.call_number.value.label)}")
         `
     }
@@ -1253,10 +1263,20 @@ export class QueryService {
         }
         UNION
         {
+          ?item wdt:P136 ?item_prev_owner .
+        }
+        UNION
+        {
           ?item wdt:P839 ?manid_item .
           ?manid_item wdt:P476 ?manid_pbid .
           FILTER regex(?manid_pbid, '(.*) manid ') .
-          ?manid_item wdt:P229 ?item_prev_owner .
+          {
+            ?manid_item wdt:P229 ?item_prev_owner .
+          }
+          UNION
+          {
+            ?manid_item wdt:P136 ?item_prev_owner .
+          }
         }
         FILTER (?item_prev_owner = wd:${form.input.previous_owner.value.target_item})
         `
@@ -1275,77 +1295,6 @@ export class QueryService {
           ?manid_item wdt:P703 ?item_aso_person .
         }
         FILTER (?item_aso_person = wd:${form.input.associated_person.value.target_item})
-        `
-    }
-    if (form.input.writing_surface && form.input.writing_surface.value) {
-      filters +=
-        `
-        {
-          ?item wdt:P480 ?item_writing_surf .
-        }
-        UNION
-        {
-          ?item wdt:P839 ?manid_item .
-          ?manid_item wdt:P476 ?manid_pbid .
-          FILTER regex(?manid_pbid, '(.*) manid ') .
-          ?manid_item wdt:P480 ?item_writing_surf .
-        }
-        FILTER (?item_writing_surf = wd:${form.input.writing_surface.value.target_item})
-        `
-    }
-    if (form.input.binding && form.input.binding.value) {
-      filters +=
-        `
-        {
-          ?item wdt:P800 ?item_binding .
-        }
-        UNION
-        {
-          ?item wdt:P839 ?manid_item .
-          ?manid_item wdt:P476 ?manid_pbid .
-          FILTER regex(?manid_pbid, '(.*) manid ') .
-          ?manid_item wdt:P800 ?item_binding .
-        }
-        FILTER (?item_binding = "${this.sanitizeSparqlString(form.input.binding.value.label)}")
-        `
-    }
-    if (form.input.watermark && form.input.watermark.value) {
-      filters +=
-        `
-        {
-          ?item wdt:P749 ?item_watermark .
-        }
-        UNION
-        {
-          ?item wdt:P839 ?manid_item .
-          ?manid_item wdt:P476 ?manid_pbid .
-          FILTER regex(?manid_pbid, '(.*) manid ') .
-          ?manid_item wdt:P749 ?item_watermark .
-        }
-        FILTER (?item_watermark = wd:${form.input.watermark.value.target_item})
-        `
-    }
-    if (form.input.graphic_feature && form.input.graphic_feature.value) {
-      filters +=
-        `
-        {
-          ?item wdt:P801 ?item_graphic_feature .
-        }
-        UNION
-        {
-          ?item wdt:P839 ?manid_item .
-          ?manid_item wdt:P476 ?manid_pbid .
-          FILTER regex(?manid_pbid, '(.*) manid ') .
-          ?manid_item wdt:P801 ?item_graphic_feature .
-        }
-        FILTER (?item_graphic_feature = wd:${form.input.graphic_feature.value.target_item})
-        `
-    }
-    if (form.input.subject && form.input.subject.value) {
-      filters +=
-        `
-        VALUES ?prop_subject { ${SUBJECT_PROPERTIES.map(p => `wdt:${p}`).join(' ')} }
-        ?item ?prop_subject wd:${form.input.subject.value.target_item} .
         `
     }
     return filters

--- a/frontend/service/query.service.js
+++ b/frontend/service/query.service.js
@@ -1188,7 +1188,15 @@ export class QueryService {
     if (form.input.library && form.input.library.value) {
       filters +=
         `
-        ?item wdt:P329 wd:${form.input.library.value.target_item} .
+        {
+          ?item wdt:P329 ?item_lib .
+        }
+        UNION
+        {
+          ?item wdt:P839 ?manid_item .
+          ?manid_item wdt:P329 ?item_lib .
+        }
+        FILTER (?item_lib = wd:${form.input.library.value.target_item})
         `
     }
     if (form.input.collection && form.input.collection.value) {
@@ -1198,7 +1206,14 @@ export class QueryService {
         : `FILTER (?item_collection = "${this.sanitizeSparqlString(collectionValue.label)}")`
       filters +=
         `
-        ?item p:P329 ?library_stmt .
+        {
+          ?item p:P329 ?library_stmt .
+        }
+        UNION
+        {
+          ?item wdt:P839 ?manid_item .
+          ?manid_item p:P329 ?library_stmt .
+        }
         ?library_stmt pq:P1054 ?item_collection .
         ${collectionFilter}
         `
@@ -1206,7 +1221,14 @@ export class QueryService {
     if (form.input.call_number && form.input.call_number.value) {
       filters +=
         `
-        ?item p:P329 ?library_stmt .
+        {
+          ?item p:P329 ?library_stmt .
+        }
+        UNION
+        {
+          ?item wdt:P839 ?manid_item .
+          ?manid_item p:P329 ?library_stmt .
+        }
         {
           ?library_stmt pq:P10 ?call_number_label
         }
@@ -1220,38 +1242,85 @@ export class QueryService {
     if (form.input.previous_owner && form.input.previous_owner.value) {
       filters +=
         `
-        ?item wdt:P229 wd:${form.input.previous_owner.value.target_item} .
+        {
+          ?item wdt:P229 ?item_prev_owner .
+        }
+        UNION
+        {
+          ?item wdt:P839 ?manid_item .
+          ?manid_item wdt:P229 ?item_prev_owner .
+        }
+        FILTER (?item_prev_owner = wd:${form.input.previous_owner.value.target_item})
         `
     }
     if (form.input.associated_person && form.input.associated_person.value) {
       filters +=
         `
-        ?item wdt:P703 wd:${form.input.associated_person.value.target_item} .
+        {
+          ?item wdt:P703 ?item_aso_person .
+        }
+        UNION
+        {
+          ?item wdt:P839 ?manid_item .
+          ?manid_item wdt:P703 ?item_aso_person .
+        }
+        FILTER (?item_aso_person = wd:${form.input.associated_person.value.target_item})
         `
     }
     if (form.input.writing_surface && form.input.writing_surface.value) {
       filters +=
         `
-        ?item wdt:P480 wd:${form.input.writing_surface.value.target_item} .
+        {
+          ?item wdt:P480 ?item_writing_surf .
+        }
+        UNION
+        {
+          ?item wdt:P839 ?manid_item .
+          ?manid_item wdt:P480 ?item_writing_surf .
+        }
+        FILTER (?item_writing_surf = wd:${form.input.writing_surface.value.target_item})
         `
     }
     if (form.input.binding && form.input.binding.value) {
       filters +=
         `
-        ?item wdt:P800 ?item_binding .
+        {
+          ?item wdt:P800 ?item_binding .
+        }
+        UNION
+        {
+          ?item wdt:P839 ?manid_item .
+          ?manid_item wdt:P800 ?item_binding .
+        }
         FILTER (?item_binding = "${this.sanitizeSparqlString(form.input.binding.value.label)}")
         `
     }
     if (form.input.watermark && form.input.watermark.value) {
       filters +=
         `
-        ?item wdt:P749 wd:${form.input.watermark.value.target_item} .
+        {
+          ?item wdt:P749 ?item_watermark .
+        }
+        UNION
+        {
+          ?item wdt:P839 ?manid_item .
+          ?manid_item wdt:P749 ?item_watermark .
+        }
+        FILTER (?item_watermark = wd:${form.input.watermark.value.target_item})
         `
     }
     if (form.input.graphic_feature && form.input.graphic_feature.value) {
       filters +=
         `
-        ?item wdt:P801 wd:${form.input.graphic_feature.value.target_item} .
+        {
+          ?item wdt:P801 ?item_graphic_feature .
+        }
+        UNION
+        {
+          ?item wdt:P839 ?manid_item .
+          ?manid_item wdt:P801 ?item_graphic_feature .
+        }
+        FILTER (?item_graphic_feature = wd:${form.input.graphic_feature.value.target_item})
         `
     }
     if (form.input.subject && form.input.subject.value) {

--- a/frontend/service/query.service.js
+++ b/frontend/service/query.service.js
@@ -1194,6 +1194,8 @@ export class QueryService {
         UNION
         {
           ?item wdt:P839 ?manid_item .
+          ?manid_item wdt:P476 ?manid_pbid .
+          FILTER regex(?manid_pbid, '(.*) manid ') .
           ?manid_item wdt:P329 ?item_lib .
         }
         FILTER (?item_lib = wd:${form.input.library.value.target_item})
@@ -1212,6 +1214,8 @@ export class QueryService {
         UNION
         {
           ?item wdt:P839 ?manid_item .
+          ?manid_item wdt:P476 ?manid_pbid .
+          FILTER regex(?manid_pbid, '(.*) manid ') .
           ?manid_item p:P329 ?library_stmt .
         }
         ?library_stmt pq:P1054 ?item_collection .
@@ -1227,6 +1231,8 @@ export class QueryService {
         UNION
         {
           ?item wdt:P839 ?manid_item .
+          ?manid_item wdt:P476 ?manid_pbid .
+          FILTER regex(?manid_pbid, '(.*) manid ') .
           ?manid_item p:P329 ?library_stmt .
         }
         {
@@ -1248,6 +1254,8 @@ export class QueryService {
         UNION
         {
           ?item wdt:P839 ?manid_item .
+          ?manid_item wdt:P476 ?manid_pbid .
+          FILTER regex(?manid_pbid, '(.*) manid ') .
           ?manid_item wdt:P229 ?item_prev_owner .
         }
         FILTER (?item_prev_owner = wd:${form.input.previous_owner.value.target_item})
@@ -1262,6 +1270,8 @@ export class QueryService {
         UNION
         {
           ?item wdt:P839 ?manid_item .
+          ?manid_item wdt:P476 ?manid_pbid .
+          FILTER regex(?manid_pbid, '(.*) manid ') .
           ?manid_item wdt:P703 ?item_aso_person .
         }
         FILTER (?item_aso_person = wd:${form.input.associated_person.value.target_item})
@@ -1276,6 +1286,8 @@ export class QueryService {
         UNION
         {
           ?item wdt:P839 ?manid_item .
+          ?manid_item wdt:P476 ?manid_pbid .
+          FILTER regex(?manid_pbid, '(.*) manid ') .
           ?manid_item wdt:P480 ?item_writing_surf .
         }
         FILTER (?item_writing_surf = wd:${form.input.writing_surface.value.target_item})
@@ -1290,6 +1302,8 @@ export class QueryService {
         UNION
         {
           ?item wdt:P839 ?manid_item .
+          ?manid_item wdt:P476 ?manid_pbid .
+          FILTER regex(?manid_pbid, '(.*) manid ') .
           ?manid_item wdt:P800 ?item_binding .
         }
         FILTER (?item_binding = "${this.sanitizeSparqlString(form.input.binding.value.label)}")
@@ -1304,6 +1318,8 @@ export class QueryService {
         UNION
         {
           ?item wdt:P839 ?manid_item .
+          ?manid_item wdt:P476 ?manid_pbid .
+          FILTER regex(?manid_pbid, '(.*) manid ') .
           ?manid_item wdt:P749 ?item_watermark .
         }
         FILTER (?item_watermark = wd:${form.input.watermark.value.target_item})
@@ -1318,6 +1334,8 @@ export class QueryService {
         UNION
         {
           ?item wdt:P839 ?manid_item .
+          ?manid_item wdt:P476 ?manid_pbid .
+          FILTER regex(?manid_pbid, '(.*) manid ') .
           ?manid_item wdt:P801 ?item_graphic_feature .
         }
         FILTER (?item_graphic_feature = wd:${form.input.graphic_feature.value.target_item})


### PR DESCRIPTION
## Summary
- `addCopidFilters` (search results) and the copid search page's autocomplete queries (`library`, `collection`, `call_number`, `previous_owner`, `associated_person`, `writing_surface`, `binding`, `watermark`, `graphic_feature`) only matched data recorded directly on the copid item itself.
- `addManuscriptFilters` already unions in data recorded on a manid's copid children for the same 9 fields (a copy's data completes its manuscript's record) — but the reverse direction was missing: a copid, being a copy "of" its manid (`P839`), should symmetrically pick up values recorded only on the parent manid when not present on the copy itself.
- Reported on #525: searching by "Antiguo posesor" (previous owner) on the copid page found nothing for an owner recorded on the manid rather than on any specific copy.

## Verification
Checked against the live SPARQL endpoint (`https://database.factgrid.de/sparql/...`, same backend staging points at): `BETA manid 6527` has previous owner "Antonio Rodríguez Moñino" recorded only at the manid level. Its copid children (`BETA copid 9398`, `9399`, `9400`, `9405`, `9406`) have no direct `P229` claim and were invisible to the old copid `previous_owner` query. With the fix, the query returns 12 distinct previous-owner values instead of 10, including this one.

## Test plan
- [x] Deploy to staging and search copid → "Antiguo posesor" → "Antonio Rodríguez Moñino"; confirm BETA copid 9398/9399/9400/9405/9406 now appear.
- [x] Regression: confirm library/collection/PhiloBiblon ID copid searches (already working per faulhaber's report on #525) still return the same results.
- [x] `yarn lint` passes (verified locally, pre-existing unrelated lint error in `useAlternativeLabels.js` only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Search lookups for libraries, collections, call numbers, previous owners, and associated people now include metadata from related manuscripts.
  * Call-number searches support additional qualifier information.
  * Subject filters now provide consistent matching across search types.

* **Bug Fixes**
  * Related-item results and counts are now deduplicated for more accurate search results.

* **Changes**
  * Removed autocomplete fields for edition, writing surface, binding, watermark, graphic feature, and subject from the additional-copy search form.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->