### PR TITLE
fix(frontend): keep item alias tagged with bibliography locale, not UI locale

### DIFF
--- a/frontend/components/item/Create.vue
+++ b/frontend/components/item/Create.vue
@@ -517,6 +517,12 @@ async function create () {
       const cleanedClaims = cleanClaims(claims.value)
       if (props.table === 'manid') addManidEditionFrbrClaim(cleanedClaims)
 
+      // The alias is the PBID (e.g. "BETA texid 0000"), which must always be
+      // tagged under the bibliography's language, not the interface locale —
+      // otherwise a BETA item created with the English/Galician UI would get
+      // its alias stored as "en"/"gl" instead of "es".
+      const aliasLocale = BIBLIOGRAPHY_LOCALE_MAP[props.database] || locale.value
+
       const data = {
         labels: {
           [locale.value]: label.value
@@ -525,7 +531,7 @@ async function create () {
           [locale.value]: description.value || ' '
         },
         aliases: {
-          [locale.value]: aliasValue.value
+          [aliasLocale]: aliasValue.value
         },
         claims: {
           ...cleanedClaims


### PR DESCRIPTION
## Summary
- Follow-up to #451 (from PR #522): as [confirmed by @faulhaber](https://github.com/PhiloBiblon/philobiblon-ui/pull/522#issuecomment-3169847432), English/Galician UI users are allowed to create items for any bibliography (BETA/BITECA/BITAGAP), but the item's alias (the PBID, e.g. "BETA texid 0000") must stay tagged under the bibliography's own language — not the interface locale.
- Example: creating a BETA texid with the English UI selected must store the alias under `es`, not `en`.
- `frontend/components/item/Create.vue`: the `create()` function now derives `aliasLocale` from `BIBLIOGRAPHY_LOCALE_MAP[props.database]` (already used elsewhere in the file for the language-mismatch check) instead of reusing `locale.value`. Labels and descriptions are unaffected — they still use the UI locale.

## Test plan
- [x] `npx eslint frontend/components/item/Create.vue` — no errors
- [x] Manually create an item (e.g. BETA texid) with the English or Galician UI selected and confirm the alias is stored under the bibliography's locale (`es`/`ca`/`pt`) via `wbgetentities` or the item's multilingual edit box, not under `en`/`gl`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Item aliases are now assigned using the bibliography’s configured locale.
  * Spanish, Catalan, and Portuguese bibliographies now receive the correct language-specific aliases, while other databases use the interface language.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->