### PR TITLE
fix(frontend): add MS:/Ed. prefix and collection to MAN auto-label

### DIFF
--- a/frontend/components/item/Create.vue
+++ b/frontend/components/item/Create.vue
@@ -679,8 +679,10 @@ function generateLabelFromClaims () {
       const holding = getClaimValue('P329')
       if (holding) {
         const prefix = getManidPrefix()
+        const collection = getClaimValue('P1054') || getQualifierValue('P329', 'P1054')
         const position = getClaimValue('P10') || getQualifierValue('P329', 'P10')
-        generatedLabel = position ? `${prefix}${holding}, ${position}` : `${prefix}${holding}`
+        const holdingPart = collection ? `${holding} (${collection})` : holding
+        generatedLabel = position ? `${prefix}${holdingPart}, ${position}` : `${prefix}${holdingPart}`
       }
       break
     }

--- a/frontend/components/item/value/type/Entity.vue
+++ b/frontend/components/item/value/type/Entity.vue
@@ -126,12 +126,8 @@ function buildFullQuery (sparqlQuery) {
 function getDefaultValue (currentValue, defaultValue) {
   if (currentValue) {
     return currentValue
-  } else if (defaultValue) {
-    emit('new-value', defaultValue)
-    return defaultValue
-  } else {
-    return null
   }
+  return defaultValue || null
 }
 
 function setOptionsAutocomplete () {
@@ -163,6 +159,12 @@ function setOptionsAutocomplete () {
           options.value.push(foundOption)
         }
         selectedOption.value = foundOption || null
+        // currentId came from defaultValue (no existing item value): propagate the
+        // resolved {id, label} option, not the raw QID, so consumers reading
+        // claim.value.datavalue.value.id (e.g. manid's MS:/Ed.: label prefix) see it.
+        if (!props.valueToView.item && foundOption) {
+          emit('new-value', foundOption)
+        }
       })
   } else {
     options.value = [{

--- a/frontend/components/item/value/type/Entity.vue
+++ b/frontend/components/item/value/type/Entity.vue
@@ -159,11 +159,15 @@ function setOptionsAutocomplete () {
           options.value.push(foundOption)
         }
         selectedOption.value = foundOption || null
-        // currentId came from defaultValue (no existing item value): propagate the
-        // resolved {id, label} option, not the raw QID, so consumers reading
+        // currentId came from defaultValue (no existing item value): propagate an
+        // {id, label} object, not the raw QID, so consumers reading
         // claim.value.datavalue.value.id (e.g. manid's MS:/Ed.: label prefix) see it.
-        if (!props.valueToView.item && foundOption) {
-          emit('new-value', foundOption)
+        // Fall back to a bare { id } even if the SPARQL-fetched options don't
+        // include it yet (e.g. transient endpoint lag, see #393): the claim must
+        // still carry a non-null, id-shaped value so required-field validation
+        // and submission aren't blocked by a slow autocomplete load.
+        if (!props.valueToView.item && currentId) {
+          emit('new-value', foundOption || { id: currentId })
         }
       })
   } else {


### PR DESCRIPTION
## Summary
- Fixes the MAN (`manid`) auto-generated label so it includes the "MS: "/"Ed.: " prefix (per P2) and the P1054 (Colección) qualifier in parentheses, per the last comment on #393: `MS: P329Value (P1054Value), P10Value`.
- Root cause of the missing "MS: " prefix: `Entity.vue` applies the P2 default value (Manuscrito/Q15, configured in `Ui_ControlledVocabulary` for all bibliographies) by emitting the raw QID string instead of the `{id, label}` object a manual selection produces. `getManidPrefix()` reads `.id` off that value, which silently failed for the default-applied case. A manually picked "Publicación impresa" (Q20) went through the normal selection path and worked correctly, which is why only the MS: prefix was broken.

## Test plan
- [x] `yarn eslint` clean on both changed files
- [x] Verified the label-generation logic in isolation against the issue's example (`MS: Madrid: Nacional (BNE) (Colección X), MSS/1234`)
- [x] Verified in the running app (localhost dev server) that creating a new MAN now shows the MS: prefix and the collection in parentheses

Closes #393 (the remaining item from the last comment)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Enhancements**
  - Manid labels now include the relevant collection, displayed after the holding and before any position information.
  - Entity autocomplete now preserves default or current selections more reliably, showing the available label when present and falling back to the identifier when necessary.
  - Default values no longer trigger unnecessary new-value events during initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->