### PR TITLE
fix(frontend): include creator role qualifier in bibid auto-generated label

### DIFF
--- a/frontend/components/item/Create.vue
+++ b/frontend/components/item/Create.vue
@@ -656,15 +656,17 @@ function generateLabelFromClaims () {
     case 'bibid': {
       const surname = getClaimValue('P247')
       const author = getClaimValue('P21')
-      const creator = getClaimValue('P845') || getClaimValue('P1134')
+      const creator = getClaimValue('P845')
       const title = getClaimValue('P11')
       const date = getBibidDate()
 
-      const name = surname || author || creator
+      const name = surname || author || creator || getClaimValue('P1134')
 
       if (name && title) {
+        const role = name === creator ? getQualifierValue('P845', 'P820') : null
+        const rolePart = role ? ` (${role})` : ''
         const datePart = date ? ` (${date})` : ''
-        generatedLabel = `${name}${datePart}, ${title}`
+        generatedLabel = `${name}${rolePart}${datePart}, ${title}`
       }
       break
     }

--- a/frontend/components/item/Create.vue
+++ b/frontend/components/item/Create.vue
@@ -660,10 +660,11 @@ function generateLabelFromClaims () {
       const title = getClaimValue('P11')
       const date = getBibidDate()
 
+      const usesP845Creator = !surname && !author && Boolean(creator)
       const name = surname || author || creator || getClaimValue('P1134')
 
       if (name && title) {
-        const role = name === creator ? getQualifierValue('P845', 'P820') : null
+        const role = usesP845Creator ? getQualifierValue('P845', 'P820') : null
         const rolePart = role ? ` (${role})` : ''
         const datePart = date ? ` (${date})` : ''
         generatedLabel = `${name}${rolePart}${datePart}, ${title}`


### PR DESCRIPTION
## Summary
- Fixes #387 (último comentario de faulhaber, 2026-08-11): al crear un item BIB con P845 (Creador) + calificativo P820 (Objeto tiene rol), el rol no aparecía en la etiqueta autogenerada.
- `generateLabelFromClaims()` (caso `bibid`) ahora incorpora el rol entre paréntesis justo después del nombre del creador, con el orden solicitado: `Creador (Rol) (Fecha), Título`.
- El resto de las rutas de generación de etiqueta para `bibid` (P247, P21, P1134, sin rol) quedan sin cambios.

## Test plan
- [x] Script standalone que replica la lógica exacta de `getClaimValue`/`getQualifierValue`/`getBibidDate` con datos de claims con forma real de Wikibase, verificando:
  - P845 + calificativo P820 (rol) + P49 (año) + P11 (título) → `Charles B. Faulhaber (Editor literario) (1999), BIB Test Item` (coincide con el ejemplo de faulhaber)
  - P845 sin rol → comportamiento previo sin cambios
  - P247 (apellido) → comportamiento previo sin cambios
  - P1134 (fallback) → comportamiento previo sin cambios
- [x] `yarn lint` sin nuevos errores/warnings en `Create.vue`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved BibID label generation when creator information comes from different sources.
  - Uses the most appropriate available creator details and applies a role qualifier when applicable.
  - Existing date and title formatting remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->