### PR TITLE
fix(frontend): trim leading/trailing whitespace before saving values

### DIFF
--- a/frontend/service/wikibase.service.js
+++ b/frontend/service/wikibase.service.js
@@ -11,7 +11,10 @@ import { useQueryCacheStore } from '~/stores/queryCache'
 // that as an error to the user, trim silently before every write (issue #556).
 function trimStringsDeep (value) {
   if (typeof value === 'string') {
-    return value.trim()
+    const trimmed = value.trim()
+    // Leave whitespace-only strings untouched: Create.vue relies on a single space as a
+    // placeholder to work around Wikibase rejecting an empty description (see PR #261).
+    return trimmed === '' ? value : trimmed
   }
   if (Array.isArray(value)) {
     return value.map(trimStringsDeep)

--- a/frontend/service/wikibase.service.js
+++ b/frontend/service/wikibase.service.js
@@ -6,6 +6,50 @@ import { useAuthStore } from '~/stores/auth'
 import { useItemCacheStore } from '~/stores/itemCache'
 import { useQueryCacheStore } from '~/stores/queryCache'
 
+// Wikibase rejects string/monolingualtext/url/external-id values with leading or trailing
+// whitespace ("White space found at the beginning/end of the value."). Rather than surfacing
+// that as an error to the user, trim silently before every write (issue #556).
+function trimStringsDeep (value) {
+  if (typeof value === 'string') {
+    return value.trim()
+  }
+  if (Array.isArray(value)) {
+    return value.map(trimStringsDeep)
+  }
+  if (value !== null && typeof value === 'object' && value.constructor === Object) {
+    return Object.fromEntries(Object.entries(value).map(([key, v]) => [key, trimStringsDeep(v)]))
+  }
+  return value
+}
+
+// `oldValue` is left untouched: claim/qualifier update look up the currently stored snak by
+// an exact value match, so trimming it could break that lookup against legacy padded data.
+function trimEditParams (params) {
+  if (params === null || typeof params !== 'object') {
+    return params
+  }
+  const { oldValue, ...rest } = params
+  const trimmed = trimStringsDeep(rest)
+  return 'oldValue' in params ? { ...trimmed, oldValue } : trimmed
+}
+
+function withTrimmedValues (wbEditInstance) {
+  const wrapped = {}
+  for (const [namespace, methods] of Object.entries(wbEditInstance)) {
+    if (methods === null || typeof methods !== 'object') {
+      wrapped[namespace] = methods
+      continue
+    }
+    wrapped[namespace] = {}
+    for (const [name, fn] of Object.entries(methods)) {
+      wrapped[namespace][name] = typeof fn === 'function'
+        ? (params, ...rest) => fn(trimEditParams(params), ...rest)
+        : fn
+    }
+  }
+  return wrapped
+}
+
 export class WikibaseService {
   static PROPERTY_PBID = 'P476'
   static PROPERTY_FORMATTER_URL = 'P236'
@@ -30,9 +74,9 @@ export class WikibaseService {
       instance: config.wikibaseApiUrl,
       sparqlEndpoint: config.sparqlEndpoint
     })
-    this.wbEdit = wbEdit({
+    this.wbEdit = withTrimmedValues(wbEdit({
       instance: config.apiBaseUrl
-    })
+    }))
     this.$query = new QueryService({ config })
     this.$oauth = new OAuthService({ config })
     this.$notification = $notification

--- a/frontend/service/wikibase.service.js
+++ b/frontend/service/wikibase.service.js
@@ -28,6 +28,9 @@ function trimStringsDeep (value) {
 // `oldValue` is left untouched: claim/qualifier update look up the currently stored snak by
 // an exact value match, so trimming it could break that lookup against legacy padded data.
 function trimEditParams (params) {
+  if (Array.isArray(params)) {
+    return params.map(trimEditParams)
+  }
   if (params === null || typeof params !== 'object') {
     return params
   }


### PR DESCRIPTION
## Summary
- Wikibase rejects string/monolingualtext/url/external-id values that start or end with whitespace, and the raw API error ("White space found at the beginning/end of the value.") was surfacing to the user instead of the value being saved.
- Wraps the `wikibase-edit` instance (the single boundary all writes go through — `claim.create/update`, `qualifier.set/update`, `reference.set`, `entity.create`, `label.set`, `description.set`, etc.) to trim string values before they're sent, so leading/trailing whitespace is stripped silently on save instead of blocking it with an error.
- `oldValue` is deliberately left untouched: `claim.update`/`qualifier.update` look up the currently stored snak by exact value match, and trimming it could break that lookup against legacy data that was imported with padded whitespace.

Fixes #556

## Test plan
- [x] `yarn lint` passes on the changed file
- [x] Verified the trim logic in isolation: `newValue`/create payloads get trimmed, `oldValue` is preserved exactly
- [x] Manually save a claim/qualifier/label value with leading/trailing spaces in the UI and confirm it saves without error, with whitespace stripped

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Wikibase edits now automatically remove unnecessary leading and trailing whitespace from text values, including nested data.
  * Whitespace-only values remain unchanged.
  * Existing values used for comparison are preserved exactly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->