### PR TITLE
fix(frontend): duplicate label/cnum description under "en" on create

### DIFF
--- a/frontend/components/item/Create.vue
+++ b/frontend/components/item/Create.vue
@@ -109,7 +109,7 @@ const props = defineProps({
 })
 
 const { $notification, $wikibase } = useNuxtApp()
-const { t, locale } = useI18n()
+const { t, locale, loadLocaleMessages } = useI18n()
 const router = useRouter()
 const route = useRoute()
 const localePath = useLocalePath()
@@ -280,7 +280,7 @@ async function loadInitialClaims () {
     const res = await $wikibase.getTableLastItem(props.database, props.table)
     if (res?.length && res[0]) {
       await getDefaultClaims(res[0].item_number)
-      setDefaultDescription()
+      await setDefaultDescription()
       initialClaimsLoaded.value = true
     }
   } catch (error) {
@@ -288,8 +288,15 @@ async function loadInitialClaims () {
   }
 }
 
-function setDefaultDescription () {
+// @nuxtjs/i18n lazy-loads each locale's message bundle on demand: only the
+// active UI locale (plus the "en" fallback) is guaranteed loaded. Requesting
+// t(key, {}, { locale }) for the bibliography locale before it's loaded
+// silently falls back to "en" text instead of throwing, so a BETA cnum item
+// created with the English UI got English text stored under the "es" key.
+// Force-load the target bundle first (#562).
+async function setDefaultDescription () {
   if (props.table === 'cnum' && !description.value) {
+    await loadLocaleMessages(entityLocale.value)
     description.value = t('item.cnum_description', {}, { locale: entityLocale.value })
   }
 }
@@ -523,13 +530,22 @@ async function create () {
       const cleanedClaims = cleanClaims(claims.value)
       if (props.table === 'manid') addManidEditionFrbrClaim(cleanedClaims)
 
+      const labels = { [entityLocale.value]: label.value }
+      const descriptions = { [entityLocale.value]: description.value || ' ' }
+
+      // Wikibase's default working language is English: without an "en" label
+      // (and, for cnum, description), BETA/BITECA/BITAGAP items are hard to
+      // find/read outside their own bibliography locale (#562).
+      if (entityLocale.value !== 'en') {
+        labels.en = label.value
+        if (props.table === 'cnum') {
+          descriptions.en = t('item.cnum_description', {}, { locale: 'en' })
+        }
+      }
+
       const data = {
-        labels: {
-          [entityLocale.value]: label.value
-        },
-        descriptions: {
-          [entityLocale.value]: description.value || ' '
-        },
+        labels,
+        descriptions,
         aliases: {
           [entityLocale.value]: aliasValue.value
         },

--- a/frontend/components/item/Create.vue
+++ b/frontend/components/item/Create.vue
@@ -295,10 +295,10 @@ async function loadInitialClaims () {
 // created with the English UI got English text stored under the "es" key.
 // Force-load the target bundle first (#562).
 async function setDefaultDescription () {
-  if (props.table === 'cnum' && !description.value) {
-    await loadLocaleMessages(entityLocale.value)
-    description.value = t('item.cnum_description', {}, { locale: entityLocale.value })
-  }
+  if (props.table !== 'cnum' || description.value) return
+  await loadLocaleMessages(entityLocale.value)
+  if (description.value) return
+  description.value = t('item.cnum_description', {}, { locale: entityLocale.value })
 }
 
 function getEntityLabel (entity) {


### PR DESCRIPTION
## Summary
- Closes #562. PBUI-FG's default working language is English, so BETA/BITECA/BITAGAP items created via the wiki-driven label/description flow (#559/#560) had no `en` label/description — only the bibliography's own language (`es`/`ca`/`pt`). `create()` now also writes an `en` label (same value as the bibliography label) and, for `cnum`, an `en` description ("textual witness").
- Also fixes a related bug found while testing this against a running dev server: `@nuxtjs/i18n` lazy-loads each locale's message bundle, so the `cnum` default-description generation (added in #560) silently fell back to English text when the bibliography locale wasn't already loaded, storing English text under the `es`/`ca`/`pt` key. Fixed by forcing `loadLocaleMessages(entityLocale.value)` before generating the default description.

## Test plan
- [x] `yarn lint` (no new warnings/errors)
- [x] Manually exercised the create form in a running dev server (via a scripted fake-login bypassing OAuth, since this is a local, credential-gated flow) for a BETA `cnum` item: confirmed the auto-generated description resolves to "testimonio textual" (not falling back to English) with the UI locale set to English.
- [ ] Would appreciate a real end-to-end check on staging: create a `cnum` item in each bibliography and confirm both `Lxx`/`Len` and `Dxx`/`Den` are set correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)