### PR TITLE
fix(frontend): fix reference-value regression and align item creation with edit UX

### DIFF
--- a/frontend/components/item/Create.vue
+++ b/frontend/components/item/Create.vue
@@ -256,8 +256,8 @@ function getCreateDisabledReason () {
           continue
         }
         const dateQualifiers = item?.qualifiers?.P106
-        const dateQualifier = Array.isArray(dateQualifiers) ? dateQualifiers[0] : dateQualifiers
-        if (dateQualifier == null || !isCompleteDate(dateQualifier)) {
+        const dateQualifierValues = Array.isArray(dateQualifiers) ? dateQualifiers : [dateQualifiers]
+        if (dateQualifierValues.length === 0 || !dateQualifierValues.every(v => v != null && isCompleteDate(v))) {
           return t('messages.error.inputs.incomplete_date', { propertyLabel })
         }
       }

--- a/frontend/components/item/Create.vue
+++ b/frontend/components/item/Create.vue
@@ -443,33 +443,34 @@ function updateClaims (data) {
 
 function generateClaimsData (data) {
   const result = {}
+  const extractValue = v => v?.datavalue?.value?.id ?? v?.datavalue?.value
+
+  const formatQualifiers = (qualifiers) => Object.fromEntries(
+    (qualifiers || []).map(q => [q.property?.id ?? q.property, extractValue(q)])
+  )
+
+  const formatReferences = (references) => (references || [])
+    .map(r => ({ propertyId: r.property?.id ?? r.property, value: extractValue(r) }))
+    .filter(r => r.propertyId && r.value != null && r.value !== '')
+    .map(r => ({ [r.propertyId]: r.value }))
+
+  const createClaim = (val, qualifiers = {}, references = []) => ({
+    value: extractValue(val),
+    qualifiers,
+    references
+  })
+
   data.forEach((claim) => {
     if (claim.property) {
       const claimKey = claim?.property?.id
 
       result[claimKey] = result[claimKey] || []
-      const extractValue = v => v?.datavalue?.value?.id ?? v?.datavalue?.value
 
-      const createClaim = (val, qualifiers = {}, references = []) => ({
-        value: extractValue(val),
-        qualifiers,
-        references
-      })
-
-      const qualifiers = Object.fromEntries(
-        (claim.qualifiers || []).map(q => [q.property?.id ?? q.property, extractValue(q)])
-      )
-
-      const references = (claim.references || [])
-        .map(r => ({ propertyId: r.property?.id ?? r.property, value: extractValue(r) }))
-        .filter(r => r.propertyId && r.value != null && r.value !== '')
-        .map(r => ({ [r.propertyId]: r.value }))
-
-      result[claimKey].push(createClaim(claim.value, qualifiers, references))
+      result[claimKey].push(createClaim(claim.value, formatQualifiers(claim.qualifiers), formatReferences(claim.references)))
 
       const values = Object.values(claim.claimsValues || {}) || []
       values.forEach((v) => {
-        result[claimKey].push(createClaim(v))
+        result[claimKey].push(createClaim(v, formatQualifiers(v.qualifiers), formatReferences(v.references)))
       })
     }
   })

--- a/frontend/components/item/Create.vue
+++ b/frontend/components/item/Create.vue
@@ -116,6 +116,7 @@ const localePath = useLocalePath()
 const authStore = useAuthStore()
 const { notifyError } = useNotifyError()
 const draft = useItemDraft(props.table)
+const { groupByProperty } = useQualifierGrouping()
 const previousPathCookie = useCookie('previous-path', { path: '/', maxAge: 5 * 60 })
 
 const label = ref('')
@@ -254,7 +255,8 @@ function getCreateDisabledReason () {
         if (item?.value == null || item?.value === '') {
           continue
         }
-        const dateQualifier = item?.qualifiers?.P106
+        const dateQualifiers = item?.qualifiers?.P106
+        const dateQualifier = Array.isArray(dateQualifiers) ? dateQualifiers[0] : dateQualifiers
         if (dateQualifier == null || !isCompleteDate(dateQualifier)) {
           return t('messages.error.inputs.incomplete_date', { propertyLabel })
         }
@@ -445,8 +447,8 @@ function generateClaimsData (data) {
   const result = {}
   const extractValue = v => v?.datavalue?.value?.id ?? v?.datavalue?.value
 
-  const formatQualifiers = (qualifiers) => Object.fromEntries(
-    (qualifiers || []).map(q => [q.property?.id ?? q.property, extractValue(q)])
+  const formatQualifiers = (qualifiers) => groupByProperty(
+    qualifiers, q => q.property?.id ?? q.property, q => extractValue(q)
   )
 
   const formatReferences = (references) => (references || [])
@@ -490,15 +492,14 @@ function cleanClaims (claimsToClean) {
       }
 
       const cleanedQualifiers = {}
-      for (const [qualKey, qualVal] of Object.entries(claim.qualifiers || {})) {
-        if (
-          qualKey &&
-          qualKey !== 'null' &&
-          qualVal != null &&
-          qualVal !== 'null' &&
-          qualVal !== ''
-        ) {
-          cleanedQualifiers[qualKey] = qualVal
+      for (const [qualKey, qualVals] of Object.entries(claim.qualifiers || {})) {
+        if (!qualKey || qualKey === 'null') {
+          continue
+        }
+        const values = (Array.isArray(qualVals) ? qualVals : [qualVals])
+          .filter(v => v != null && v !== 'null' && v !== '')
+        if (values.length) {
+          cleanedQualifiers[qualKey] = values
         }
       }
 

--- a/frontend/components/item/claim/AddValue.vue
+++ b/frontend/components/item/claim/AddValue.vue
@@ -3,14 +3,14 @@
     <v-row
       v-for="(claim, key) in claims"
       :key="key"
-      class="even-row"
+      class="even-row value-divider"
       density="comfortable"
     >
       <v-col class="p-0 pr-3 pt-3">
         <div class="d-flex">
           <item-value-base
             :key="`${claim.value}-${key}`"
-            class="full-width"
+            class="full-width value-wrapper"
             :label="t('common.value')"
             :value="claim"
             type="claim"
@@ -54,6 +54,39 @@
             </v-btn>
           </div>
         </div>
+        <v-container class="claim-values">
+          <div class="subsection-indent">
+            <item-qualifier-create
+              :key="`${key}-qualifiers`"
+              :claim="claim"
+              :for-create="forCreate"
+              :table="table"
+              :initial-qualifiers="claim.qualifiers"
+              @update-qualifiers="updateQualifiers($event, key)"
+            />
+          </div>
+          <div class="subsection-indent">
+            <v-expansion-panels class="mt-2 mb-2 mr-2 pa-2 bg-gray none-z-index">
+              <v-expansion-panel class="bg-gray">
+                <v-expansion-panel-title class="bg-gray header">
+                  <p class="text-subtitle-2 mb-0 reference-header">
+                    {{ referenceHeader(claim) }}
+                  </p>
+                </v-expansion-panel-title>
+                <v-expansion-panel-text class="bg-gray">
+                  <item-reference-create
+                    :key="`${key}-references`"
+                    :claim="claim"
+                    :for-create="forCreate"
+                    :table="table"
+                    :initial-references="claim.references"
+                    @update-references="updateReferences($event, key)"
+                  />
+                </v-expansion-panel-text>
+              </v-expansion-panel>
+            </v-expansion-panels>
+          </div>
+        </v-container>
       </v-col>
     </v-row>
     <v-row class="back pr-5 mt-1 add-value" justify="end">
@@ -78,7 +111,8 @@ const props = defineProps({
   item: { type: Object, default: null },
   value: { type: Object, default: null },
   forCreate: { type: Boolean, default: false },
-  defaultValue: { type: Object, default: null }
+  defaultValue: { type: Object, default: null },
+  table: { type: String, default: null }
 })
 
 const emit = defineEmits(['update-claims-values', 'create-claim'])
@@ -97,7 +131,10 @@ onMounted(() => {
     claims[newKey] = {
       property: props.value.property,
       datatype: props.value.datatype,
-      datavalue: { value: props.defaultValue }
+      datavalue: { value: props.defaultValue },
+      mainsnak: { property: props.value.property },
+      qualifiers: [],
+      references: []
     }
   }
 })
@@ -108,7 +145,10 @@ function addClaim () {
   claims[newKey] = {
     property,
     datatype,
-    datavalue: { value: null, default: false }
+    datavalue: { value: null, default: false },
+    mainsnak: { property },
+    qualifiers: [],
+    references: []
   }
 
   if (props.forCreate) {
@@ -135,17 +175,66 @@ function updateClaimValue (value, key) {
   }
 }
 
+function updateQualifiers (data, key) {
+  claims[key].qualifiers = data.map((qualifier) => {
+    if (!props.forCreate) {
+      const propertyId = qualifier?.property?.id || qualifier?.property
+      return { property: propertyId, value: qualifier?.datavalue?.value?.id ?? qualifier.datavalue?.value }
+    } else {
+      return qualifier
+    }
+  })
+
+  if (props.forCreate) {
+    emit('update-claims-values', claims)
+  }
+}
+
+function updateReferences (data, key) {
+  claims[key].references = data.map((reference) => {
+    if (!props.forCreate) {
+      const propertyId = reference?.property?.id || reference?.property
+      return { property: propertyId, value: reference?.datavalue?.value?.id ?? reference.datavalue?.value }
+    } else {
+      return reference
+    }
+  })
+
+  if (props.forCreate) {
+    emit('update-claims-values', claims)
+  }
+}
+
+function referenceHeader (claim) {
+  const count = claim.references?.length ?? 0
+  return `${count} reference${count === 1 ? '' : 's'}`
+}
+
 async function createClaim (index) {
-  const raw = claims[index]?.datavalue?.value
+  const claim = claims[index]
+  const raw = claim?.datavalue?.value
   const value = raw && typeof raw === 'object' && 'id' in raw ? raw.id ?? null : raw
   if (value == null) {
     return
   }
+
+  const formattedQualifiers = Object.fromEntries(
+    (claim.qualifiers || [])
+      .filter(q => q.property && q.value)
+      .map(({ property: p, value: v }) => [p, { value: v }])
+  )
+
+  const formattedReferences = (claim.references || [])
+    .filter(r => r.property && r.value)
+    .map(({ property: p, value: v }) => ({ [p]: v }))
+
   try {
     const res = await $wikibase.getWbEdit().claim.create({
       value,
       id: props.item.id,
-      property: props.value.property
+      property: props.value.property,
+      qualifiers: Object.keys(formattedQualifiers).length ? formattedQualifiers : undefined,
+      references: formattedReferences.length ? formattedReferences : undefined
     }, authStore.requestConfig)
     if (res.success) {
       $notification.success(t('messages.success.updated'))
@@ -170,5 +259,35 @@ function updateClaims (res) {
 }
 .claim {
   padding: 0;
+}
+.claim-values {
+  padding: 0;
+}
+.value-wrapper {
+  padding: 8px 16px;
+}
+.value-divider {
+  border-top: 1px solid #e0e0e0;
+  padding-top: 10px;
+  margin-top: 10px;
+}
+.subsection-indent {
+  padding-left: 40px;
+}
+.bg-gray {
+  background-color: #ECEFF1;
+}
+.none-z-index {
+  z-index: unset;
+}
+.header {
+  padding: 0;
+  align-items: center;
+}
+.reference-header {
+  font-weight: normal !important;
+}
+:deep(.v-expansion-panel-text__wrapper) {
+  padding: 0 8px 0 8px;
 }
 </style>

--- a/frontend/components/item/claim/AddValue.vue
+++ b/frontend/components/item/claim/AddValue.vue
@@ -120,6 +120,7 @@ const emit = defineEmits(['update-claims-values', 'create-claim'])
 const { $notification, $wikibase } = useNuxtApp()
 const { t } = useI18n()
 const { notifyError } = useNotifyError()
+const { groupByProperty } = useQualifierGrouping()
 const authStore = useAuthStore()
 
 const items = reactive({})
@@ -207,7 +208,7 @@ function updateReferences (data, key) {
 
 function referenceHeader (claim) {
   const count = claim.references?.length ?? 0
-  return `${count} reference${count === 1 ? '' : 's'}`
+  return t('common.reference_count', count)
 }
 
 async function createClaim (index) {
@@ -218,11 +219,7 @@ async function createClaim (index) {
     return
   }
 
-  const formattedQualifiers = Object.fromEntries(
-    (claim.qualifiers || [])
-      .filter(q => q.property && q.value)
-      .map(({ property: p, value: v }) => [p, { value: v }])
-  )
+  const formattedQualifiers = groupByProperty(claim.qualifiers, q => q.property, q => q.value)
 
   const formattedReferences = (claim.references || [])
     .filter(r => r.property && r.value)

--- a/frontend/components/item/claim/Base.vue
+++ b/frontend/components/item/claim/Base.vue
@@ -13,6 +13,7 @@
         :item="item"
         :value="claim?.values[0]?.mainsnak ?? { property: claim.property, datatype: claim.datatype }"
         :default-value="claim.values.length === 0 ? claim.defaultValue : null"
+        :table="table"
         @create-claim="emit('create-claim', $event)"
       />
     </v-container>

--- a/frontend/components/item/claim/Create.vue
+++ b/frontend/components/item/claim/Create.vue
@@ -17,7 +17,6 @@
             :items="properties[key]"
             item-title="label"
             return-object
-            :label="t('common.property')"
             variant="underlined"
             density="compact"
             :filter="acceptAll"
@@ -64,30 +63,48 @@
         </v-btn>
       </v-col>
       <v-container v-if="claim?.property?.id || claim.default" class="claim-values">
-        <item-value-base
-          :key="`${claim.property?.id}-${key}`"
-          :claim="claim"
-          :value="claim.value"
-          type="claim"
-          mode="creation"
-          @new-value="onNewValue($event, claim)"
-        />
-        <item-qualifier-create
-          :key="claim?.property?.id"
-          :claim="claim"
-          :for-create="forCreate"
-          :table="table"
-          :initial-qualifiers="claim.qualifiers"
-          @update-qualifiers="updateQualifiers($event, key)"
-        />
-        <item-reference-create
-          :key="claim?.property?.id"
-          :claim="claim"
-          :for-create="forCreate"
-          :table="table"
-          :initial-references="claim.references"
-          @update-references="updateReferences($event, key)"
-        />
+        <div class="value-wrapper">
+          <item-value-base
+            :key="`${claim.property?.id}-${key}`"
+            :label="t('common.value')"
+            :claim="claim"
+            :value="claim.value"
+            type="claim"
+            mode="creation"
+            @new-value="onNewValue($event, claim)"
+          />
+        </div>
+        <div class="subsection-indent">
+          <item-qualifier-create
+            :key="claim?.property?.id"
+            :claim="claim"
+            :for-create="forCreate"
+            :table="table"
+            :initial-qualifiers="claim.qualifiers"
+            @update-qualifiers="updateQualifiers($event, key)"
+          />
+        </div>
+        <div class="subsection-indent">
+          <v-expansion-panels class="mt-2 mb-2 mr-2 pa-2 bg-gray none-z-index">
+            <v-expansion-panel class="bg-gray">
+              <v-expansion-panel-title class="bg-gray header">
+                <p class="text-subtitle-2 mb-0 reference-header">
+                  {{ referenceHeader(claim) }}
+                </p>
+              </v-expansion-panel-title>
+              <v-expansion-panel-text class="bg-gray">
+                <item-reference-create
+                  :key="claim?.property?.id"
+                  :claim="claim"
+                  :for-create="forCreate"
+                  :table="table"
+                  :initial-references="claim.references"
+                  @update-references="updateReferences($event, key)"
+                />
+              </v-expansion-panel-text>
+            </v-expansion-panel>
+          </v-expansion-panels>
+        </div>
       </v-container>
       <item-claim-add-value
         v-if="forCreate"
@@ -96,6 +113,7 @@
         :item="item"
         :value="claim.value"
         :for-create="forCreate"
+        :table="table"
         @update-claims-values="updateClaimValues($event, key)"
       />
     </v-row>
@@ -302,6 +320,11 @@ function updateClaims (res) {
 function acceptAll () {
   return true
 }
+
+function referenceHeader (claim) {
+  const count = claim.references?.length ?? 0
+  return `${count} reference${count === 1 ? '' : 's'}`
+}
 </script>
 
 <style scoped>
@@ -314,11 +337,23 @@ function acceptAll () {
   padding: 0 16px;
   min-height: 48px;
 }
+.claim-header :deep(.v-field__input),
+.claim-header :deep(.v-label) {
+  font-size: 18px;
+  font-weight: 500;
+}
 .claim-values {
+  padding: 0;
   background-color: rgb(247, 245, 245);
   word-wrap: break-word;
   overflow-wrap: break-word;
   white-space: normal;
+}
+.value-wrapper {
+  padding: 8px 16px;
+}
+.subsection-indent {
+  padding-left: 40px;
 }
 
 :deep(.add-claim-value) {
@@ -336,5 +371,21 @@ function acceptAll () {
 .action-btn {
   width: 28px !important;
   height: 28px !important;
+}
+.bg-gray {
+  background-color: #ECEFF1;
+}
+.none-z-index {
+  z-index: unset;
+}
+.header {
+  padding: 0;
+  align-items: center;
+}
+.reference-header {
+  font-weight: normal !important;
+}
+:deep(.v-expansion-panel-text__wrapper) {
+  padding: 0 8px 0 8px;
 }
 </style>

--- a/frontend/components/item/claim/Create.vue
+++ b/frontend/components/item/claim/Create.vue
@@ -17,6 +17,7 @@
             :items="properties[key]"
             item-title="label"
             return-object
+            :aria-label="t('common.property')"
             variant="underlined"
             density="compact"
             :filter="acceptAll"
@@ -149,6 +150,7 @@ const { $notification, $wikibase } = useNuxtApp()
 const { t, locale } = useI18n()
 const { notifyError } = useNotifyError()
 const { applyAlternativeLabels } = useAlternativeLabels()
+const { groupByProperty } = useQualifierGrouping()
 const authStore = useAuthStore()
 
 const claims = reactive([])
@@ -260,11 +262,7 @@ async function addClaim (index) {
 async function createClaim (index) {
   const { property, value, qualifiers: rawQualifiers, references: rawReferences } = claims[index]
 
-  const formattedQualifiers = Object.fromEntries(
-    (rawQualifiers || [])
-      .filter(q => q.property && q.value)
-      .map(({ property: p, value: v }) => [p, { value: v }])
-  )
+  const formattedQualifiers = groupByProperty(rawQualifiers, q => q.property, q => q.value)
 
   const formattedReferences = (rawReferences || [])
     .filter(r => r.property && r.value)
@@ -323,7 +321,7 @@ function acceptAll () {
 
 function referenceHeader (claim) {
   const count = claim.references?.length ?? 0
-  return `${count} reference${count === 1 ? '' : 's'}`
+  return t('common.reference_count', count)
 }
 </script>
 

--- a/frontend/components/item/reference/Create.vue
+++ b/frontend/components/item/reference/Create.vue
@@ -144,6 +144,7 @@ const properties = reactive([])
 const references = reactive([])
 const propertyValues = reactive([])
 const resolvedValues = reactive([])
+const propertyChangeTokens = reactive([])
 
 const isAllowedAddReference = computed(() => props.claim && props.claim.mainsnak.property !== WikibaseService.PROPERTY_NOTES)
 
@@ -184,9 +185,13 @@ function isConfirmed (reference) {
 
 async function confirmReference (index) {
   const reference = references[index]
-  reference.confirmed = true
   const propertyId = reference.property?.id ?? reference.property
-  resolvedValues[index] = await $wikibase.getWbValue(propertyId, reference.datatype, reference.datavalue.value, locale.value)
+  try {
+    resolvedValues[index] = await $wikibase.getWbValue(propertyId, reference.datatype, reference.datavalue.value, locale.value)
+    reference.confirmed = true
+  } catch (error) {
+    notifyError(error)
+  }
 }
 
 function onNewValue (event, reference) {
@@ -195,10 +200,16 @@ function onNewValue (event, reference) {
 
 async function onChangeProperty (event, index) {
   const reference = references[index]
+  const requestId = (propertyChangeTokens[index] = (propertyChangeTokens[index] || 0) + 1)
   if (event) {
     reference.datatype = event.datatype
     reference.datavalue = { value: null }
     const altLabel = await $wikibase.getEntityLabel(props.table, event.id, locale.value)
+    if (propertyChangeTokens[index] !== requestId) {
+      // A newer property selection has since started; don't let this stale
+      // lookup overwrite it with a mismatched datatype/property pair.
+      return
+    }
     reference.property = { ...event, label: altLabel?.value ?? event.label }
   } else {
     reference.property = null
@@ -220,6 +231,7 @@ function removeReference (index) {
   properties.splice(index, 1)
   propertyValues.splice(index, 1)
   resolvedValues.splice(index, 1)
+  propertyChangeTokens.splice(index, 1)
 }
 
 async function onInput (value, type, index) {

--- a/frontend/components/item/reference/Create.vue
+++ b/frontend/components/item/reference/Create.vue
@@ -54,7 +54,7 @@
         <v-col class="p-0 pr-3">
           <div v-if="reference.property">
             <item-value-base
-              :key="`${key}-${reference.property}`"
+              :key="`${key}-${reference.property?.id ?? reference.property}`"
               :label="t('common.value')"
               :claim="claim"
               :value="reference"
@@ -144,7 +144,6 @@ const properties = reactive([])
 const references = reactive([])
 const propertyValues = reactive([])
 const resolvedValues = reactive([])
-const propertyChangeTokens = reactive([])
 
 const isAllowedAddReference = computed(() => props.claim && props.claim.mainsnak.property !== WikibaseService.PROPERTY_NOTES)
 
@@ -187,7 +186,13 @@ async function confirmReference (index) {
   const reference = references[index]
   const propertyId = reference.property?.id ?? reference.property
   try {
-    resolvedValues[index] = await $wikibase.getWbValue(propertyId, reference.datatype, reference.datavalue.value, locale.value)
+    const resolved = await $wikibase.getWbValue(propertyId, reference.datatype, reference.datavalue.value, locale.value)
+    const currentIndex = references.indexOf(reference)
+    if (currentIndex === -1) {
+      // The reference row was removed while this lookup was in flight.
+      return
+    }
+    resolvedValues[currentIndex] = resolved
     reference.confirmed = true
   } catch (error) {
     notifyError(error)
@@ -200,13 +205,15 @@ function onNewValue (event, reference) {
 
 async function onChangeProperty (event, index) {
   const reference = references[index]
-  const requestId = (propertyChangeTokens[index] = (propertyChangeTokens[index] || 0) + 1)
+  const requestId = (reference._changeToken || 0) + 1
+  reference._changeToken = requestId
   if (event) {
     reference.datatype = event.datatype
     reference.datavalue = { value: null }
     const altLabel = await $wikibase.getEntityLabel(props.table, event.id, locale.value)
-    if (propertyChangeTokens[index] !== requestId) {
-      // A newer property selection has since started; don't let this stale
+    if (reference._changeToken !== requestId || !references.includes(reference)) {
+      // A newer property selection has since started, or the row was
+      // removed while this lookup was in flight; don't let this stale
       // lookup overwrite it with a mismatched datatype/property pair.
       return
     }
@@ -231,7 +238,6 @@ function removeReference (index) {
   properties.splice(index, 1)
   propertyValues.splice(index, 1)
   resolvedValues.splice(index, 1)
-  propertyChangeTokens.splice(index, 1)
 }
 
 async function onInput (value, type, index) {

--- a/frontend/components/item/reference/Create.vue
+++ b/frontend/components/item/reference/Create.vue
@@ -8,71 +8,99 @@
       no-gutters
       density="comfortable"
     >
-      <v-col class="p-0 pr-3">
-        <v-autocomplete
-          v-model="reference.property"
-          :label="t('common.property')"
-          required
-          return-object
-          :items="properties[key]"
-          item-title="label"
-          item-value="id"
-          variant="underlined"
-          density="compact"
-          :filter="acceptAll"
-          @update:model-value="onChangeProperty($event, key)"
-          @update:search="onInput($event, 'property', key)"
-        />
-      </v-col>
-      <v-col class="p-0 pr-3">
-        <div v-if="reference.property">
-          <item-value-base
-            :key="`${key}-${reference.property}`"
-            :label="t('common.value')"
-            :claim="claim"
-            :value="reference"
-            type="reference"
-            mode="creation"
-            @new-value="onNewValue($event, reference)"
+      <template v-if="isConfirmed(reference)">
+        <v-col class="p-0 pr-3">
+          <span>{{ reference.property?.label }}</span>
+        </v-col>
+        <v-col class="p-0 pr-3">
+          <span>{{ resolvedValues[key]?.value ?? reference.datavalue?.value?.label ?? reference.datavalue?.value }}</span>
+        </v-col>
+        <v-col class="p-0 pr-3 d-flex justify-end align-center max-w-100">
+          <v-btn
+            variant="text"
+            icon
+            density="compact"
+            class="action-btn"
+            @click.stop="removeReference(key)"
+          >
+            <v-tooltip location="top">
+              <template #activator="{ props: btnProps }">
+                <v-icon v-bind="btnProps" color="#616161" size="22">
+                  mdi-trash-can
+                </v-icon>
+              </template>
+              <span>{{ t("common.remove") }}</span>
+            </v-tooltip>
+          </v-btn>
+        </v-col>
+      </template>
+      <template v-else>
+        <v-col class="p-0 pr-3">
+          <v-autocomplete
+            v-model="reference.property"
+            :label="t('common.property')"
+            required
+            return-object
+            :items="properties[key]"
+            item-title="label"
+            item-value="id"
+            variant="underlined"
+            density="compact"
+            :filter="acceptAll"
+            @update:model-value="onChangeProperty($event, key)"
+            @update:search="onInput($event, 'property', key)"
           />
-        </div>
-      </v-col>
-      <v-col class="p-0 pr-3 d-flex justify-end align-center max-w-100">
-        <v-btn
-          v-if="allowCreateReference(reference)"
-          variant="text"
-          icon
-          density="compact"
-          class="action-btn"
-          @click.stop="createReference(key)"
-        >
-          <v-tooltip location="top">
-            <template #activator="{ props: btnProps }">
-              <v-icon v-bind="btnProps" color="#616161" size="22">
-                mdi-check
-              </v-icon>
-            </template>
-            <span>{{ t("common.save") }}</span>
-          </v-tooltip>
-        </v-btn>
-        <v-btn
-          v-if="claim"
-          variant="text"
-          icon
-          density="compact"
-          class="action-btn"
-          @click.stop="removeReference(key)"
-        >
-          <v-tooltip location="top">
-            <template #activator="{ props: btnProps }">
-              <v-icon v-bind="btnProps" color="#616161" size="22">
-                mdi-trash-can
-              </v-icon>
-            </template>
-            <span>{{ t("common.remove") }}</span>
-          </v-tooltip>
-        </v-btn>
-      </v-col>
+        </v-col>
+        <v-col class="p-0 pr-3">
+          <div v-if="reference.property">
+            <item-value-base
+              :key="`${key}-${reference.property}`"
+              :label="t('common.value')"
+              :claim="claim"
+              :value="reference"
+              type="reference"
+              mode="creation"
+              @new-value="onNewValue($event, reference)"
+            />
+          </div>
+        </v-col>
+        <v-col class="p-0 pr-3 d-flex justify-end align-center max-w-100">
+          <v-btn
+            v-if="allowCreateReference(reference) || allowConfirmReference(reference)"
+            variant="text"
+            icon
+            density="compact"
+            class="action-btn"
+            @click.stop="allowConfirmReference(reference) ? confirmReference(key) : createReference(key)"
+          >
+            <v-tooltip location="top">
+              <template #activator="{ props: btnProps }">
+                <v-icon v-bind="btnProps" color="#616161" size="22">
+                  mdi-check
+                </v-icon>
+              </template>
+              <span>{{ t("common.save") }}</span>
+            </v-tooltip>
+          </v-btn>
+          <v-btn
+            v-if="claim"
+            variant="text"
+            icon
+            density="compact"
+            class="action-btn"
+            @click.stop="removeReference(key)"
+          >
+            <v-tooltip location="top">
+              <template #activator="{ props: btnProps }">
+                <v-icon v-bind="btnProps" color="#616161" size="22">
+                  mdi-trash-can
+                </v-icon>
+              </template>
+              <span>{{ t("common.remove") }}</span>
+            </v-tooltip>
+          </v-btn>
+        </v-col>
+      </template>
     </v-row>
     <v-row
       v-if="isAllowedAddReference"
@@ -115,6 +143,7 @@ const authStore = useAuthStore()
 const properties = reactive([])
 const references = reactive([])
 const propertyValues = reactive([])
+const resolvedValues = reactive([])
 
 const isAllowedAddReference = computed(() => props.claim && props.claim.mainsnak.property !== WikibaseService.PROPERTY_NOTES)
 
@@ -136,9 +165,28 @@ watch(references, (val) => {
   }
 }, { deep: true })
 
-function allowCreateReference (reference) {
+function hasReferenceValue (reference) {
   const propertyId = reference.property?.id || reference.property
-  return props.claim?.id && !props.forCreate && propertyId && reference.datavalue?.value !== undefined && reference.datavalue?.value !== null
+  return !!propertyId && reference.datavalue?.value !== undefined && reference.datavalue?.value !== null
+}
+
+function allowCreateReference (reference) {
+  return props.claim?.id && !props.forCreate && hasReferenceValue(reference)
+}
+
+function allowConfirmReference (reference) {
+  return props.forCreate && hasReferenceValue(reference)
+}
+
+function isConfirmed (reference) {
+  return props.forCreate && !!reference.confirmed
+}
+
+async function confirmReference (index) {
+  const reference = references[index]
+  reference.confirmed = true
+  const propertyId = reference.property?.id ?? reference.property
+  resolvedValues[index] = await $wikibase.getWbValue(propertyId, reference.datatype, reference.datavalue.value, locale.value)
 }
 
 function onNewValue (event, reference) {
@@ -148,13 +196,15 @@ function onNewValue (event, reference) {
 async function onChangeProperty (event, index) {
   const reference = references[index]
   if (event) {
+    reference.datatype = event.datatype
+    reference.datavalue = { value: null }
     const altLabel = await $wikibase.getEntityLabel(props.table, event.id, locale.value)
     reference.property = { ...event, label: altLabel?.value ?? event.label }
   } else {
     reference.property = null
+    reference.datatype = null
+    reference.datavalue = { value: null }
   }
-  reference.datatype = event?.datatype
-  reference.datavalue = { value: null }
 }
 
 function addReference () {
@@ -169,6 +219,7 @@ function removeReference (index) {
   references.splice(index, 1)
   properties.splice(index, 1)
   propertyValues.splice(index, 1)
+  resolvedValues.splice(index, 1)
 }
 
 async function onInput (value, type, index) {
@@ -239,6 +290,7 @@ function acceptAll () {
 <style scoped>
 .add-reference {
   margin-bottom: 5px;
+  font-size: 12px;
 }
 .create-reference {
   padding: 0;

--- a/frontend/composables/useQualifierGrouping.js
+++ b/frontend/composables/useQualifierGrouping.js
@@ -1,0 +1,23 @@
+// wikibase-edit accepts either a single value or an array of values per
+// qualifier property (see buildPropSnaksFactory/forceArray in wikibase-edit),
+// so grouping into arrays here lets a claim carry more than one qualifier
+// value for the same property instead of the last one silently winning.
+export function useQualifierGrouping () {
+  function groupByProperty (items, getPropertyId, getValue) {
+    const grouped = {}
+    for (const item of items || []) {
+      const propertyId = getPropertyId(item)
+      const value = getValue(item)
+      if (!propertyId || value == null || value === '') {
+        continue
+      }
+      if (!grouped[propertyId]) {
+        grouped[propertyId] = []
+      }
+      grouped[propertyId].push(value)
+    }
+    return grouped
+  }
+
+  return { groupByProperty }
+}

--- a/frontend/lang/ca.js
+++ b/frontend/lang/ca.js
@@ -19,6 +19,7 @@ export default {
     to: 'a',
     add: 'afegir',
     add_reference: 'afegir referència',
+    reference_count: '{count} referència | {count} referències',
     add_value: 'afegir valor',
     add_qualifier: 'afegir qualificador',
     add_claim: 'afegir declaració',

--- a/frontend/lang/en.js
+++ b/frontend/lang/en.js
@@ -19,6 +19,7 @@ export default {
     to: 'To',
     add: 'add',
     add_reference: 'add reference',
+    reference_count: '{count} reference | {count} references',
     add_value: 'add value',
     add_qualifier: 'add qualifier',
     add_claim: 'add statement',

--- a/frontend/lang/es.js
+++ b/frontend/lang/es.js
@@ -19,6 +19,7 @@ export default {
     to: 'a',
     add: 'añadir',
     add_reference: 'añadir referencia',
+    reference_count: '{count} referencia | {count} referencias',
     add_value: 'añadir valor',
     add_qualifier: 'añadir calificador',
     add_claim: 'añadir declaración',

--- a/frontend/lang/gl.js
+++ b/frontend/lang/gl.js
@@ -19,6 +19,7 @@ export default {
     to: 'a',
     add: 'engadir',
     add_reference: 'engadir referencia',
+    reference_count: '{count} referencia | {count} referencias',
     add_value: 'valor engadido',
     add_qualifier: 'engadir cualificativo',
     add_claim: 'engadir declaración',

--- a/frontend/lang/pt.js
+++ b/frontend/lang/pt.js
@@ -20,6 +20,7 @@ export default {
     to: 'para',
     add: 'adicionar',
     add_reference: 'adicionar referência',
+    reference_count: '{count} referência | {count} referências',
     add_value: 'agregar valor',
     add_qualifier: 'adicionar qualificador',
     add_claim: 'adicionar declaração',


### PR DESCRIPTION
## Summary
- Fixes a regression where the value input for a reference stopped rendering after selecting a property: `onChangeProperty` in `reference/Create.vue` assigned `reference.property` (which remounts `item-value-base`) before an async `getEntityLabel` call resolved `datatype`/`datavalue`, so the remount happened with `datatype` still `null` and no widget rendered. Same class of bug already fixed for qualifiers in #535; applied the same fix here.
- Brings item-creation's claim/qualifier/reference UI closer to how an existing item is edited:
  - References during item creation now use the same "N references" accordion as edit mode, and collapse to a read-only row once confirmed instead of staying an open form forever.
  - Additional values added via "+ Add value" now get their own qualifier and reference sections, matching the primary value.
  - Visual hierarchy pass: statement property picker stands out (larger label, no redundant "Property" placeholder), value/qualifier/reference get consistent indentation and spacing, and a thin divider separates multiple values of the same property.

## Test plan
- [ ] `cd frontend && yarn lint`
- [ ] Log in on staging-backed dev server, open an existing item with a reference, confirm the value field now shows when picking a property
- [ ] Create a new item, add a statement with a value, add a qualifier and a reference, confirm the reference collapses once confirmed and the "N references" accordion count updates
- [ ] On item creation, add a second value via "+ Add value", confirm it gets its own qualifier/reference sections and a divider line appears above it
- [ ] Submit item creation end-to-end and confirm qualifiers/references on additional values persist correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rbew5QrMeNf7JMZCw7pekU

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Add qualifiers and references when creating or editing claim values.
  - Review and confirm references before adding them, with resolved values and validation.
  - View reference counts and expandable reference details within claims.
- **Improvements**
  - Preserve multiple qualifier values and references across claim values.
  - Organize claim values, qualifiers, and references into clearer sections.
  - Keep reference details synchronized when properties or values change.
  - Improve date validation and normalize qualifier data consistently.
  - Add localized singular and plural reference-count labels.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->